### PR TITLE
feat(OMN-17304): RuntimeLocal client mode — publish for dispatch, host nothing, await THIS run's terminal

### DIFF
--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -110,6 +110,32 @@ _KAFKA_EVENT_BUS_ENTRY_POINT: str = "event_bus_kafka"
 # the ``onex.backends`` entry-point group.
 SUPPORTED_EVENT_BUS_VALUES: frozenset[str] = frozenset({"inmemory", "kafka"})
 
+# Sentinel distinguishing "the payload model declares no correlation_id field"
+# from "it declares one whose value is None" (OMN-17304). The two need
+# different diagnostics: the first is a contract shape that cannot be used in
+# client mode at all, the second is a value this runtime may still fill.
+_CORRELATION_FIELD_ABSENT: Final[object] = object()
+
+# A nil UUID is a placeholder default, not an identity — treat it as absent.
+_NIL_UUID_TEXT: Final[str] = str(uuid.UUID(int=0))
+
+# Handler locus recorded in ``workflow_result.json`` (OMN-17295 / OMN-17304).
+# ``in_process`` — this runtime hosted the contract's handlers and executed the
+# work itself. ``dispatched`` — this runtime published the command and hosted
+# nothing, so the work was done by whatever runtime is subscribed to the
+# command topic. ``dispatched`` is deliberately not spelled "deployed_lane":
+# the runtime knows it did not execute the work, not who did. Asserting WHICH
+# deployment answered is the caller's job, from a lane-side fact.
+#
+# Named ``handler_locus``, NOT ``execution_locus``, to stay disjoint from
+# ``ModelRuntimeIdentity.execution_locus`` (OMN-17308, in flight on
+# ``model_skill_result.py``), which names where THIS PROCESS runs — a venv
+# prefix or a container id. Same word, different question: that one answers
+# "which install am I", this one answers "did I do the work". Collapsing them
+# into one name is how a receipt ends up asserting a lane it never touched.
+HANDLER_LOCUS_IN_PROCESS: Final[str] = "in_process"
+HANDLER_LOCUS_DISPATCHED: Final[str] = "dispatched"
+
 # Handler-result ``status`` values that unambiguously mean the run failed.
 # Effect/reducer handlers report failures in-band by returning an error-shaped
 # response envelope (``status="error"`` plus an ``error_message``) rather than
@@ -260,6 +286,19 @@ class RuntimeLocal:
         run_id: Identity anchor stamped into ``workflow_result.json`` (OMN-15449).
             Defaults to a freshly minted UUID when the caller has no run_id of
             its own to propagate.
+        host_handlers: Whether this runtime HOSTS the contract's handlers
+            (OMN-17304). ``True`` (default) is the historical behaviour and the
+            offline/standalone path: subscribe every ``handler_routing``
+            entry to its ``input_topic``, then publish the initial command to
+            that same topic and execute it in-process. ``False`` makes this
+            runtime a CLIENT of the bus — it publishes the command and awaits a
+            terminal scoped to this run's correlation, hosting nothing, so the
+            work is done by whatever runtime is actually subscribed to the
+            command topic. On a shared broker ``True`` makes the caller a
+            second, disjoint consumer group of the command topic it publishes
+            to, and the deployed runtime and the caller BOTH execute the entry
+            handler; a probe issued that way measures the caller's own venv, not
+            the deployment it names (OMN-17295).
     """
 
     def __init__(
@@ -271,12 +310,14 @@ class RuntimeLocal:
         input_path: Path | None = None,
         timeout: int = 300,
         run_id: uuid.UUID | None = None,
+        host_handlers: bool = True,
     ) -> None:
         self.workflow_path = workflow_path
         self.state_root = state_root
         self.backend_overrides = backend_overrides or {}
         self.input_path = input_path
         self.timeout = timeout
+        self.host_handlers = host_handlers
         # OMN-15449: identity anchor stamped into workflow_result.json so a
         # caller reading that FIXED, non-run-scoped path back can verify the
         # content it sees is THIS run's own output rather than a different
@@ -295,11 +336,57 @@ class RuntimeLocal:
         self._handlers_wired: list[str] = []
         self._terminal_payload: RawWorkflowMap | None = None
         self._handler_result: object | None = None
+        # OMN-17304 AC6: the correlation id that actually reached the wire, as
+        # distinct from one this runtime minted and then failed to stamp onto a
+        # frozen payload. ``None`` until the event-driven path publishes.
+        self._wire_correlation_id: uuid.UUID | None = None
+        # Correlation predicate for the terminal watcher. Set only in client
+        # mode: an in-process host on its own bus has exactly one producer of
+        # the terminal topic, so filtering there would change offline behaviour
+        # for no gain.
+        self._expected_correlation_id: uuid.UUID | None = None
+
+    # ONEX_EXCLUDE: dict_str_any — event bus payload
+    def _terminal_correlation_matches(self, payload: RawWorkflowMap) -> bool:
+        """Whether a terminal envelope belongs to THIS run (OMN-17304 AC4).
+
+        A delegate terminal is a ``ModelEventEnvelope`` dump: the envelope
+        carries ``correlation_id`` at the top and the domain payload carries
+        its own copy under ``payload``. Every id the envelope declares must be
+        this run's, and it must declare at least one — an envelope that names
+        nobody is unattributable, and an unattributable terminal accepted as
+        ours is the same defect as a foreign one.
+
+        Returns ``True`` unconditionally when no correlation predicate is armed
+        (host mode), preserving first-terminal-wins there.
+        """
+        expected = self._expected_correlation_id
+        if expected is None:
+            return True
+        wanted = str(expected)
+        declared: set[str] = set()
+        containers: list[object] = [payload, payload.get("payload")]
+        for container in containers:
+            if not isinstance(container, dict):
+                continue
+            raw = container.get("correlation_id")
+            if isinstance(raw, str) and raw:
+                declared.add(raw)
+        return declared == {wanted}
 
     # ONEX_EXCLUDE: dict_str_any — event bus payload
     def _on_terminal_event(self, payload: RawWorkflowMap) -> None:
         """Callback invoked when a message arrives on the terminal_event topic."""
         self._record_event("(terminal)")
+        if not self._terminal_correlation_matches(payload):
+            self._record_event("(terminal:foreign)")
+            logger.info(
+                "RuntimeLocal: discarding terminal event — this run awaits "
+                "correlation %s, the envelope names %s",
+                self._expected_correlation_id,
+                payload.get("correlation_id", "(none)"),
+            )
+            return
         if self._terminal_received.is_set():
             logger.warning("Duplicate terminal event received — ignoring (first wins).")
             return
@@ -1132,124 +1219,13 @@ class RuntimeLocal:
                 entry.output_topic,
             )
 
-        # --- 4. Wire adapters to bus ---
-        unsubscribe_handles: list[UnsubscribeCallback] = []
-        self._handlers_wired = [e.handler_name for e in resolved_entries]
-
-        # OMN-14403 §6ii: load the contract's published_events class -> topic map
-        # (when declared) so a def-B fan-out / multi-topic handler's emitted class
-        # resolves its own publish topic instead of the single per-entry
-        # output_topic, and assert the map is injective at boot. Default-OFF seam:
-        # when OFF this map is loaded but unused (single output_topic path).
-        published_events = self._load_published_events_map()
-        if published_events:
-            assert_published_events_injective(
-                published_events,
-                context=str(self._contract.get("name", "<workflow>")),
-            )
-        multi_event_seam_enabled = multi_event_publish_seam_enabled()
-
-        def _fail_callback() -> None:
-            self._result = EnumWorkflowResult.FAILED
-            self._terminal_received.set()
-
-        for entry in resolved_entries:
-            handler_instance = self._instantiate_handler(
-                entry.handler_module, entry.handler_class, bus=bus
-            )
-
-            # Resolve the input model class. operation_match entries route by the
-            # `operation` field and declare no event_model, so event_model_module is
-            # empty — skip the import and forward the raw payload (OMN-13141). Only
-            # payload_type_match entries carry a typed event model to import.
-            input_model_type: type[BaseModel] | None = None
-            if entry.event_model_module:
-                try:
-                    em_mod = importlib.import_module(entry.event_model_module)
-                    input_model_type = cast(
-                        "type[BaseModel]",
-                        getattr(em_mod, entry.event_model_class),
-                    )
-                except (ImportError, AttributeError) as exc:
-                    msg = (
-                        f"Failed to resolve event model "
-                        f"{entry.event_model_module}.{entry.event_model_class}: {exc}"
-                    )
-                    logger.exception("RuntimeLocal: %s", msg)
-                    self._result = EnumWorkflowResult.FAILED
-                    return
-
-            def _make_fail_cb(name: str) -> Callable[[], None]:
-                def _cb() -> None:
-                    self._last_error = f"handler '{name}' failed"
-                    _fail_callback()
-
-                return _cb
-
-            def _make_result_cb(output_topic: str) -> Callable[[object], None] | None:
-                if output_topic != terminal_topic:
-                    return None
-
-                def _cb(result: object) -> None:
-                    self._handler_result = result
-
-                return _cb
-
-            adapter = LocalRuntimeBusAdapter(
-                handler=cast("ProtocolLocalRuntimeCallableTarget", handler_instance),
-                handler_name=entry.handler_name,
-                input_model_cls=input_model_type,
-                output_topic=entry.output_topic or None,
-                bus=bus,
-                on_error=_make_fail_cb(entry.handler_name),
-                on_result=_make_result_cb(entry.output_topic),
-                published_events=published_events,
-                multi_event_seam_enabled=multi_event_seam_enabled,
-            )
-
-            if not entry.input_topic:
-                # Terminal reducer: no input topic, no bus subscription needed.
-                logger.info(
-                    "RuntimeLocal: handler '%s' has no input_topic — "
-                    "skipping bus subscription (terminal reducer)",
-                    entry.handler_name,
-                )
-                continue
-
-            unsub = await bus.subscribe(
-                entry.input_topic,
-                on_message=adapter.on_message,
-                group_id=derive_runtime_local_group_id(entry.handler_name),
-            )
-            unsubscribe_handles.append(unsub)
-
-        # --- 5. Subscribe to the declared terminal event only ---
-        async def _on_terminal_msg(msg: ProtocolLocalRuntimeMessage) -> None:
-            decoded: object = (
-                json.loads(msg.value) if isinstance(msg.value, bytes) else {}
-            )
-            payload = decoded if isinstance(decoded, dict) else {}
-            self._on_terminal_event(cast("RawWorkflowMap", payload))
-
-        unsub = await bus.subscribe(
-            terminal_topic,
-            on_message=_on_terminal_msg,
-            group_id=derive_runtime_local_group_id(TERMINAL_CONSUMER_NODE_NAME),
-        )
-        unsubscribe_handles.append(unsub)
-
-        # --- 6. Build and publish initial payload ---
-        correlation_id = uuid.uuid4()
-
-        # Resolve the initial-payload model from, in order: top-level
-        # ``input_model`` → first routing entry's ``event_model`` → that entry's
-        # ``handler.input_model`` (OMN-13277). Previously this path consulted
-        # only the top-level ``input_model`` and, when absent, published a
-        # degenerate ``{correlation_id}``-only payload — silently dropping caller
-        # input and masking the real validation error downstream (root cause of
-        # OMN-13253). If NEITHER a top-level input_model NOR an event_model /
-        # handler-derivable model can be resolved, fail loud here naming the
-        # contract rather than publishing a degenerate payload.
+        # --- 3b. Resolve the initial payload and the WIRE correlation id ---
+        # Both are needed before any subscription in client mode: the terminal
+        # watcher's correlation predicate must be armed before the topic can
+        # deliver anything, and a client that cannot name its own correlation
+        # has no way to tell its terminal from anyone else's (OMN-17304 AC4/AC6).
+        # Moving this ahead of the subscribe loop also means a contract that
+        # cannot resolve a payload model fails before it binds any consumer.
         resolved_spec = self._resolve_event_driven_payload_spec(routing)
         if resolved_spec is None:
             contract_name = self._contract.get("name", "<unknown>")
@@ -1265,6 +1241,7 @@ class RuntimeLocal:
                 "drop caller input."
             )
             logger.error(msg)
+            self._last_error = msg
             raise ModelOnexError(
                 error_code=EnumCoreErrorCode.INVALID_INPUT,
                 message=msg,
@@ -1289,21 +1266,179 @@ class RuntimeLocal:
                 "input."
             )
             logger.error(msg)
+            self._last_error = msg
             raise ModelOnexError(
                 error_code=EnumCoreErrorCode.INVALID_INPUT,
                 message=msg,
             )
 
-        # Inject correlation_id if the model supports it
-        if hasattr(initial_payload, "correlation_id"):
-            try:
-                payload_with_correlation: ProtocolLocalRuntimePayloadModel = cast(
-                    "ProtocolLocalRuntimePayloadModel", initial_payload
-                )
-                payload_with_correlation.correlation_id = correlation_id
-            except (AttributeError, ValueError):
-                pass  # frozen model or incompatible type
+        correlation_id, correlation_source = self._resolve_wire_correlation_id(
+            initial_payload
+        )
+        if correlation_id is None and not self.host_handlers:
+            msg = (
+                "RuntimeLocal: client mode (host_handlers=False) requires a "
+                "correlation id on the published command — this run has none "
+                f"({correlation_source}). Without it the terminal watcher "
+                "cannot tell this run's terminal from any other run's on a "
+                "shared topic, and would return someone else's result as ours. "
+                f"Declare a 'correlation_id' field on "
+                f"{payload_spec['module']}.{payload_spec['class']}, or run "
+                "with host_handlers=True."
+            )
+            logger.error(msg)
+            self._last_error = msg
+            raise ModelOnexError(
+                error_code=EnumCoreErrorCode.INVALID_INPUT,
+                message=msg,
+            )
+        self._wire_correlation_id = correlation_id
+        if not self.host_handlers:
+            self._expected_correlation_id = correlation_id
 
+        # --- 4. Wire adapters to bus ---
+        unsubscribe_handles: list[UnsubscribeCallback] = []
+        self._handlers_wired = (
+            [e.handler_name for e in resolved_entries] if self.host_handlers else []
+        )
+
+        # OMN-17304: in client mode the runtime binds NOTHING to the command
+        # topic. Hosting the entry handler here is what made the caller a
+        # second consumer group of the topic it publishes to, so a probe
+        # executed a stale backlog command in the caller's own venv while the
+        # deployed runtime executed the real one — two runs, one receipt, and
+        # the receipt was the wrong one's.
+        if not self.host_handlers:
+            logger.info(
+                "RuntimeLocal: client mode — publishing to '%s' and awaiting "
+                "correlation %s; hosting no handlers (%d declared)",
+                subscribe_topics[0],
+                self._wire_correlation_id,
+                len(resolved_entries),
+            )
+        else:
+            # OMN-14403 §6ii: load the contract's published_events class -> topic map
+            # (when declared) so a def-B fan-out / multi-topic handler's emitted class
+            # resolves its own publish topic instead of the single per-entry
+            # output_topic, and assert the map is injective at boot. Default-OFF seam:
+            # when OFF this map is loaded but unused (single output_topic path).
+            published_events = self._load_published_events_map()
+            if published_events:
+                assert_published_events_injective(
+                    published_events,
+                    context=str(self._contract.get("name", "<workflow>")),
+                )
+            multi_event_seam_enabled = multi_event_publish_seam_enabled()
+
+            def _fail_callback() -> None:
+                self._result = EnumWorkflowResult.FAILED
+                self._terminal_received.set()
+
+            for entry in resolved_entries:
+                handler_instance = self._instantiate_handler(
+                    entry.handler_module, entry.handler_class, bus=bus
+                )
+
+                # Resolve the input model class. operation_match entries route by the
+                # `operation` field and declare no event_model, so event_model_module is
+                # empty — skip the import and forward the raw payload (OMN-13141). Only
+                # payload_type_match entries carry a typed event model to import.
+                input_model_type: type[BaseModel] | None = None
+                if entry.event_model_module:
+                    try:
+                        em_mod = importlib.import_module(entry.event_model_module)
+                        input_model_type = cast(
+                            "type[BaseModel]",
+                            getattr(em_mod, entry.event_model_class),
+                        )
+                    except (ImportError, AttributeError) as exc:
+                        msg = (
+                            f"Failed to resolve event model "
+                            f"{entry.event_model_module}.{entry.event_model_class}: {exc}"
+                        )
+                        logger.exception("RuntimeLocal: %s", msg)
+                        self._result = EnumWorkflowResult.FAILED
+                        return
+
+                def _make_fail_cb(name: str) -> Callable[[], None]:
+                    def _cb() -> None:
+                        self._last_error = f"handler '{name}' failed"
+                        _fail_callback()
+
+                    return _cb
+
+                def _make_result_cb(
+                    output_topic: str,
+                ) -> Callable[[object], None] | None:
+                    if output_topic != terminal_topic:
+                        return None
+
+                    def _cb(result: object) -> None:
+                        self._handler_result = result
+
+                    return _cb
+
+                adapter = LocalRuntimeBusAdapter(
+                    handler=cast(
+                        "ProtocolLocalRuntimeCallableTarget", handler_instance
+                    ),
+                    handler_name=entry.handler_name,
+                    input_model_cls=input_model_type,
+                    output_topic=entry.output_topic or None,
+                    bus=bus,
+                    on_error=_make_fail_cb(entry.handler_name),
+                    on_result=_make_result_cb(entry.output_topic),
+                    published_events=published_events,
+                    multi_event_seam_enabled=multi_event_seam_enabled,
+                )
+
+                if not entry.input_topic:
+                    # Terminal reducer: no input topic, no bus subscription needed.
+                    logger.info(
+                        "RuntimeLocal: handler '%s' has no input_topic — "
+                        "skipping bus subscription (terminal reducer)",
+                        entry.handler_name,
+                    )
+                    continue
+
+                unsub = await bus.subscribe(
+                    entry.input_topic,
+                    on_message=adapter.on_message,
+                    group_id=derive_runtime_local_group_id(entry.handler_name),
+                )
+                unsubscribe_handles.append(unsub)
+
+        # --- 5. Subscribe to the declared terminal event only ---
+        async def _on_terminal_msg(msg: ProtocolLocalRuntimeMessage) -> None:
+            decoded: object = (
+                json.loads(msg.value) if isinstance(msg.value, bytes) else {}
+            )
+            payload = decoded if isinstance(decoded, dict) else {}
+            self._on_terminal_event(cast("RawWorkflowMap", payload))
+
+        # OMN-17304 AC5: a client must not inherit another run's committed
+        # offset on the terminal topic. The shared runtime-local group id is
+        # correct for a long-lived host; for a one-shot client it means a fresh
+        # invocation resumes wherever the last one stopped and works through a
+        # backlog of terminals that are, by construction, not its own. The
+        # group is run-scoped instead, and empty groups age out of the broker
+        # on the standard offset-retention window.
+        terminal_group_node = TERMINAL_CONSUMER_NODE_NAME
+        if not self.host_handlers:
+            terminal_group_node = (
+                f"{TERMINAL_CONSUMER_NODE_NAME}_client_{self.run_id.hex[:12]}"
+            )
+        unsub = await bus.subscribe(
+            terminal_topic,
+            on_message=_on_terminal_msg,
+            group_id=derive_runtime_local_group_id(terminal_group_node),
+        )
+        unsubscribe_handles.append(unsub)
+
+        # --- 6. Publish the initial command ---
+        # The payload and its correlation id were resolved in step 3b, before
+        # any subscription, so the terminal watcher's correlation predicate is
+        # already armed when the topic can first deliver.
         model_payload: ProtocolLocalRuntimePayloadModel = cast(
             "ProtocolLocalRuntimePayloadModel", initial_payload
         )
@@ -1314,9 +1449,12 @@ class RuntimeLocal:
         )
 
         logger.info(
-            "RuntimeLocal: published initial command to '%s' (correlation_id=%s)",
+            "RuntimeLocal: published initial command to '%s' "
+            "(correlation_id=%s, source=%s, locus=%s)",
             subscribe_topics[0],
             correlation_id,
+            correlation_source,
+            self.handler_locus,
         )
 
         # --- 7. Await terminal with timeout ---
@@ -1341,6 +1479,71 @@ class RuntimeLocal:
     def _record_event(self, topic: str) -> None:
         """Increment the event counter for *topic*."""
         self._events_received[topic] = self._events_received.get(topic, 0) + 1
+
+    def _resolve_wire_correlation_id(
+        self, payload: object
+    ) -> tuple[uuid.UUID | None, str]:
+        """Return the correlation id that will actually be ON THE WIRE.
+
+        OMN-17304 AC6. This path used to mint a ``uuid.uuid4()``, assign it to
+        ``payload.correlation_id``, and swallow the failure::
+
+            except (AttributeError, ValueError):
+                pass  # frozen model or incompatible type
+
+        ``ModelDelegateSkillRequest`` is
+        ``model_config = {"frozen": True, "extra": "forbid"}``, so on the
+        delegation path that assignment ALWAYS raised (a pydantic
+        ``ValidationError`` is a ``ValueError``) and was always discarded. The
+        published bytes kept the caller's own correlation — correctly — while
+        every "published initial command (correlation_id=...)" log line named
+        the id that had just been thrown away. Every capture log written by
+        this runtime carried a correlation that appears nowhere on the broker.
+
+        The caller's id is now the authority when the payload already carries
+        one; a runtime-minted id is used only to fill a genuine absence, and a
+        failure to stamp it is reported rather than hidden.
+
+        Returns:
+            ``(correlation_id, source)`` where *source* is one of ``payload``,
+            ``runtime-minted``, ``absent`` (the model declares no
+            ``correlation_id`` field) or ``unstampable`` (it declares one, has
+            no value, and refused the assignment). The id is ``None`` for the
+            last two — the run has no attributable correlation.
+        """
+        declared = getattr(payload, "correlation_id", _CORRELATION_FIELD_ABSENT)
+        if declared is _CORRELATION_FIELD_ABSENT:
+            return None, "absent"
+        if declared is not None:
+            text = str(declared).strip()
+            if text and text != _NIL_UUID_TEXT:
+                try:
+                    return uuid.UUID(text), "payload"
+                except ValueError:
+                    logger.warning(
+                        "RuntimeLocal: payload declares correlation_id=%r which "
+                        "is not a UUID — minting one instead",
+                        declared,
+                    )
+
+        minted = uuid.uuid4()
+        try:
+            payload_with_correlation: ProtocolLocalRuntimePayloadModel = cast(
+                "ProtocolLocalRuntimePayloadModel", payload
+            )
+            payload_with_correlation.correlation_id = minted
+        except (AttributeError, ValueError) as exc:
+            # Not swallowed: a frozen payload with no correlation of its own
+            # means nothing on the wire identifies this run, and the caller has
+            # to be told rather than handed a fabricated id.
+            logger.warning(
+                "RuntimeLocal: %s refused a runtime-minted correlation_id (%s); "
+                "this command will carry no correlation of its own",
+                type(payload).__name__,
+                exc,
+            )
+            return None, "unstampable"
+        return minted, "runtime-minted"
 
     def _log_timeout_summary(self) -> None:
         """Log a diagnostic summary when the workflow times out."""
@@ -1989,7 +2192,16 @@ class RuntimeLocal:
             # receipt_mode.py) verify the file it reads actually belongs to
             # the run it just executed before trusting its content.
             "run_id": str(self.run_id),
+            # OMN-17295 AC2 / OMN-17304: whether THIS process executed the
+            # work. A receipt built from this file can then answer "did this
+            # run here?" from the record itself instead of by hand-correlating
+            # container logs after the fact.
+            "handler_locus": self.handler_locus,
         }
+        if self._wire_correlation_id is not None:
+            # OMN-17304 AC6: the correlation actually published, which is what
+            # a lane-side log grep or projection row can be joined on.
+            data["wire_correlation_id"] = str(self._wire_correlation_id)
         if self._terminal_payload is not None:
             data["terminal_payload"] = self._terminal_payload
         if self._handler_result is not None:
@@ -2023,6 +2235,34 @@ class RuntimeLocal:
     def exit_code(self) -> int:
         """CLI exit code corresponding to the current result."""
         return _exit_code_for(self._result)
+
+    @property
+    def handler_locus(self) -> str:
+        """Whether THIS process ran the handlers (OMN-17304).
+
+        ``in_process`` when this runtime hosted them, ``dispatched`` when it
+        published the command and hosted nothing. A property of the runtime's
+        configured role, not of what happened to be reachable — the whole point
+        of client mode is that locus stops being an environmental accident.
+
+        Distinct from ``ModelRuntimeIdentity.execution_locus`` (OMN-17308),
+        which names the venv or container this process itself lives in.
+        """
+        return (
+            HANDLER_LOCUS_IN_PROCESS if self.host_handlers else HANDLER_LOCUS_DISPATCHED
+        )
+
+    @property
+    def wire_correlation_id(self) -> uuid.UUID | None:
+        """The correlation id this run actually published, if it published one.
+
+        ``None`` before the event-driven path publishes, and on paths that
+        publish no command. Distinct from ``run_id``: ``run_id`` identifies the
+        local invocation, this identifies the message on the bus that any other
+        participant — a lane container log, a projection row — can be joined
+        on.
+        """
+        return self._wire_correlation_id
 
     @property
     def last_error(self) -> str | None:

--- a/tests/unit/runtime/test_runtime_local_client_mode.py
+++ b/tests/unit/runtime/test_runtime_local_client_mode.py
@@ -1,0 +1,532 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Client-mode (publish-for-dispatch) tests for ``RuntimeLocal`` (OMN-17304).
+
+Subject: the execution LOCUS of an event-driven workflow.
+
+Before this change ``RuntimeLocal._run_event_driven`` was unconditionally both
+roles at once — it subscribed every ``handler_routing.handlers`` entry to its
+own ``input_topic`` AND published the initial command to that same topic. On a
+shared broker that makes the caller a second, disjoint consumer group of the
+command topic it is publishing to, so the deployed runtime and the caller BOTH
+execute the entry handler. Live proof on the 2026-08-31 dev lane: the Mac CLI's
+group sat at committed offset 53 against a log end of 151 while the lane group
+sat at 151/lag 0, and a probe advanced the CLI group by exactly one — it
+executed a 98-message-old backlog command, not its own.
+
+``host_handlers=False`` makes the runtime a CLIENT of the bus: publish the
+command, await a terminal SCOPED TO THIS RUN'S CORRELATION, host nothing. The
+work is then done by whatever runtime is actually subscribed to that command
+topic — the deployed lane — which is the only way a lane probe can be
+non-vacuous (OMN-17295).
+
+Each positive assertion here is paired with a host-mode counter-assertion.
+Without the pair, "never subscribe anything" would satisfy the client-mode
+tests while destroying the offline path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_workflow_result import EnumWorkflowResult
+from omnibase_core.protocols.runtime.protocol_local_runtime_message import (
+    ProtocolLocalRuntimeMessage,
+)
+from omnibase_core.runtime.runtime_local import RuntimeLocal
+
+_MODULE = "tests.unit.runtime.test_runtime_local_client_mode"
+
+_COMMAND_TOPIC = "onex.cmd.omn17304.client-mode.v1"
+_TERMINAL_TOPIC = "onex.evt.omn17304.client-mode-completed.v1"
+
+
+class ModelClientModeCommand(BaseModel):
+    """Frozen request model, shaped like ``ModelDelegateSkillRequest``.
+
+    Frozen matters: the real delegate request model is
+    ``model_config = {"frozen": True, "extra": "forbid"}``, which is exactly why
+    the pre-OMN-17304 correlation overwrite raised ``ValidationError`` and was
+    swallowed into a bare ``pass`` — leaving the runtime logging a uuid4 that
+    never reached the wire.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    correlation_id: uuid.UUID = Field(...)
+    prompt: str = Field(default="")
+
+
+class HandlerClientModeEcho:
+    """Host-mode handler: echoes the command back on the terminal topic."""
+
+    async def handle(self, payload: ModelClientModeCommand) -> dict[str, str]:
+        return {
+            "status": "success",
+            "correlation_id": str(payload.correlation_id),
+            "prompt": payload.prompt,
+        }
+
+
+class _RecordedMessage:
+    """Minimal ``ProtocolLocalRuntimeMessage`` stand-in."""
+
+    def __init__(self, value: bytes) -> None:
+        self.value = value
+        self.key: bytes | None = None
+        self.topic: str = ""
+        self.headers: dict[str, str] = {}
+
+
+class _RecordingBus:
+    """Bus double that records every subscribe/publish and can inject terminals.
+
+    Deliberately does NOT route published commands to subscribers: the subject
+    under test is which topics the runtime binds to, not handler execution.
+    """
+
+    def __init__(self) -> None:
+        self.subscriptions: list[tuple[str, str]] = []
+        self.published: list[tuple[str, bytes]] = []
+        self._terminal_callbacks: list[
+            Callable[[ProtocolLocalRuntimeMessage], Awaitable[None]]
+        ] = []
+        self.closed = False
+
+    @property
+    def subscribed_topics(self) -> list[str]:
+        return [topic for topic, _group in self.subscriptions]
+
+    async def start(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def publish(self, topic: str, key: object, value: bytes) -> object:
+        self.published.append((topic, value))
+        return None
+
+    async def subscribe(
+        self,
+        topic: str,
+        *,
+        on_message: Callable[[ProtocolLocalRuntimeMessage], Awaitable[None]],
+        group_id: str,
+    ) -> Callable[[], Awaitable[None]]:
+        self.subscriptions.append((topic, group_id))
+        if topic == _TERMINAL_TOPIC:
+            self._terminal_callbacks.append(on_message)
+
+        async def _unsub() -> None:
+            return None
+
+        return _unsub
+
+    async def deliver_terminal(self, payload: dict[str, Any]) -> None:
+        message = _RecordedMessage(json.dumps(payload).encode("utf-8"))
+        for callback in self._terminal_callbacks:
+            await callback(message)  # type: ignore[arg-type]
+
+
+def _write_contract(target: Path) -> None:
+    contract: dict[str, Any] = {
+        "workflow_id": "omn-17304-client-mode",
+        "name": "client_mode_probe",
+        "terminal_event": _TERMINAL_TOPIC,
+        "event_bus": {
+            "subscribe_topics": [_COMMAND_TOPIC],
+            "publish_topics": [_TERMINAL_TOPIC],
+        },
+        "handler_routing": {
+            "routing_strategy": "operation_match",
+            "handlers": [
+                {
+                    "operation": "start",
+                    "handler": {
+                        "module": _MODULE,
+                        "name": "HandlerClientModeEcho",
+                    },
+                    "event_model": {
+                        "module": _MODULE,
+                        "name": "ModelClientModeCommand",
+                    },
+                }
+            ],
+        },
+    }
+    target.write_text(yaml.safe_dump(contract), encoding="utf-8")
+
+
+def _write_input(target: Path, correlation_id: uuid.UUID) -> None:
+    target.write_text(
+        json.dumps({"correlation_id": str(correlation_id), "prompt": "probe"}),
+        encoding="utf-8",
+    )
+
+
+def _build_runtime(
+    tmp_path: Path,
+    *,
+    host_handlers: bool,
+    correlation_id: uuid.UUID,
+    timeout: int = 5,
+) -> RuntimeLocal:
+    contract_path = tmp_path / "contract.yaml"
+    input_path = tmp_path / "input.json"
+    _write_contract(contract_path)
+    _write_input(input_path, correlation_id)
+    return RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=tmp_path / "state",
+        input_path=input_path,
+        timeout=timeout,
+        host_handlers=host_handlers,
+    )
+
+
+def _bind(runtime: RuntimeLocal, bus: _RecordingBus) -> None:
+    """Make ``run_async`` use the recording bus instead of a real backend."""
+    runtime._create_event_bus = lambda: bus  # type: ignore[assignment,method-assign]
+
+
+# ---------------------------------------------------------------------------
+# Locus: which topics does the runtime bind to?
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_client_mode_does_not_subscribe_the_command_topic(
+    tmp_path: Path,
+) -> None:
+    """AC4 (OMN-17304): a client publishes; it does not host the entry handler."""
+    correlation_id = uuid.uuid4()
+    runtime = _build_runtime(
+        tmp_path, host_handlers=False, correlation_id=correlation_id, timeout=1
+    )
+    bus = _RecordingBus()
+
+    _bind(runtime, bus)
+    task = asyncio.ensure_future(runtime.run_async())
+    await asyncio.sleep(0.05)
+    await bus.deliver_terminal(
+        {"status": "success", "correlation_id": str(correlation_id)}
+    )
+    result = await task
+
+    assert result is EnumWorkflowResult.COMPLETED
+    assert _COMMAND_TOPIC not in bus.subscribed_topics, (
+        "client mode subscribed the command topic it publishes to — the caller "
+        "is still a second consumer group of the deployed runtime's own "
+        f"command topic. subscriptions={bus.subscriptions}"
+    )
+    assert _TERMINAL_TOPIC in bus.subscribed_topics
+    assert [topic for topic, _ in bus.published] == [_COMMAND_TOPIC]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_host_mode_still_subscribes_the_command_topic(tmp_path: Path) -> None:
+    """Counter-assertion: the offline/standalone path is unchanged.
+
+    Passes before AND after the change. Without it, "subscribe nothing" would
+    satisfy the client-mode assertion above while deleting in-process
+    execution entirely.
+    """
+    correlation_id = uuid.uuid4()
+    runtime = _build_runtime(
+        tmp_path, host_handlers=True, correlation_id=correlation_id, timeout=1
+    )
+    bus = _RecordingBus()
+
+    _bind(runtime, bus)
+    task = asyncio.ensure_future(runtime.run_async())
+    await asyncio.sleep(0.05)
+    await bus.deliver_terminal(
+        {"status": "success", "correlation_id": str(correlation_id)}
+    )
+    result = await task
+
+    assert result is EnumWorkflowResult.COMPLETED
+    assert _COMMAND_TOPIC in bus.subscribed_topics
+    assert _TERMINAL_TOPIC in bus.subscribed_topics
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_client_mode_terminal_group_is_run_scoped(tmp_path: Path) -> None:
+    """A client must not inherit another run's committed terminal offset."""
+    correlation_id = uuid.uuid4()
+    runtime = _build_runtime(
+        tmp_path, host_handlers=False, correlation_id=correlation_id, timeout=1
+    )
+    bus = _RecordingBus()
+
+    _bind(runtime, bus)
+    task = asyncio.ensure_future(runtime.run_async())
+    await asyncio.sleep(0.05)
+    await bus.deliver_terminal(
+        {"status": "success", "correlation_id": str(correlation_id)}
+    )
+    result = await task
+
+    assert result is EnumWorkflowResult.COMPLETED
+    terminal_groups = [g for t, g in bus.subscriptions if t == _TERMINAL_TOPIC]
+    assert len(terminal_groups) == 1
+    assert runtime.run_id.hex[:12] in terminal_groups[0], (
+        "client-mode terminal subscription reused the shared runtime-local "
+        f"group id {terminal_groups[0]!r}; a fresh run would resume another "
+        "run's committed offset"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Correlation: whose terminal does the client accept?
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_client_mode_ignores_a_foreign_terminal(tmp_path: Path) -> None:
+    """A terminal for a different correlation must not complete this run."""
+    correlation_id = uuid.uuid4()
+    runtime = _build_runtime(
+        tmp_path, host_handlers=False, correlation_id=correlation_id, timeout=1
+    )
+    bus = _RecordingBus()
+
+    _bind(runtime, bus)
+    task = asyncio.ensure_future(runtime.run_async())
+    await asyncio.sleep(0.05)
+    await bus.deliver_terminal(
+        {"status": "success", "correlation_id": str(uuid.uuid4())}
+    )
+    result = await task
+
+    assert result is EnumWorkflowResult.TIMEOUT, (
+        "a foreign terminal completed this run — the client returned another "
+        "delegation's result as its own"
+    )
+    written = json.loads(
+        (tmp_path / "state" / "workflow_result.json").read_text(encoding="utf-8")
+    )
+    assert "terminal_payload" not in written
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_client_mode_accepts_its_own_terminal_after_a_foreign_one(
+    tmp_path: Path,
+) -> None:
+    """The filter discards, it does not latch — the right terminal still lands."""
+    correlation_id = uuid.uuid4()
+    runtime = _build_runtime(
+        tmp_path, host_handlers=False, correlation_id=correlation_id, timeout=2
+    )
+    bus = _RecordingBus()
+
+    _bind(runtime, bus)
+    task = asyncio.ensure_future(runtime.run_async())
+    await asyncio.sleep(0.05)
+    await bus.deliver_terminal(
+        {"status": "success", "correlation_id": str(uuid.uuid4())}
+    )
+    await bus.deliver_terminal(
+        {
+            "status": "success",
+            "correlation_id": str(correlation_id),
+            "payload": {"correlation_id": str(correlation_id), "answer": "alive"},
+        }
+    )
+    result = await task
+
+    assert result is EnumWorkflowResult.COMPLETED
+    written = json.loads(
+        (tmp_path / "state" / "workflow_result.json").read_text(encoding="utf-8")
+    )
+    assert written["terminal_payload"]["correlation_id"] == str(correlation_id)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_host_mode_terminal_is_not_correlation_filtered(tmp_path: Path) -> None:
+    """Counter-assertion: host mode keeps first-terminal-wins semantics.
+
+    In-process hosting on the in-memory bus has exactly one producer of the
+    terminal topic — this run's own handler — so adding a filter there would
+    change offline behaviour for no gain. Scoping the filter to client mode is
+    deliberate, and this test pins that scope.
+    """
+    correlation_id = uuid.uuid4()
+    runtime = _build_runtime(
+        tmp_path, host_handlers=True, correlation_id=correlation_id, timeout=1
+    )
+    bus = _RecordingBus()
+
+    _bind(runtime, bus)
+    task = asyncio.ensure_future(runtime.run_async())
+    await asyncio.sleep(0.05)
+    await bus.deliver_terminal(
+        {"status": "success", "correlation_id": str(uuid.uuid4())}
+    )
+    result = await task
+
+    assert result is EnumWorkflowResult.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# AC6: the correlation the runtime reports is the one on the wire
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_wire_correlation_is_the_payload_correlation_not_a_fresh_uuid(
+    tmp_path: Path,
+) -> None:
+    """AC6 (OMN-17304): stop reporting a uuid4 that never reached the broker.
+
+    ``ModelDelegateSkillRequest`` is frozen, so the old
+    ``payload.correlation_id = uuid4()`` raised ``ValidationError`` into a bare
+    ``except (AttributeError, ValueError): pass``. The published bytes kept the
+    caller's id; every "published initial command (correlation_id=...)" log
+    line named the discarded one.
+    """
+    correlation_id = uuid.uuid4()
+    runtime = _build_runtime(
+        tmp_path, host_handlers=False, correlation_id=correlation_id, timeout=1
+    )
+    bus = _RecordingBus()
+
+    _bind(runtime, bus)
+    task = asyncio.ensure_future(runtime.run_async())
+    await asyncio.sleep(0.05)
+    await bus.deliver_terminal(
+        {"status": "success", "correlation_id": str(correlation_id)}
+    )
+    result = await task
+
+    assert result is EnumWorkflowResult.COMPLETED
+    assert runtime.wire_correlation_id == correlation_id
+    published_topic, published_bytes = bus.published[0]
+    assert published_topic == _COMMAND_TOPIC
+    on_the_wire = json.loads(published_bytes.decode("utf-8"))
+    assert on_the_wire["correlation_id"] == str(runtime.wire_correlation_id), (
+        "the reported correlation and the published correlation disagree"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_client_mode_refuses_an_unattributable_command(tmp_path: Path) -> None:
+    """No correlation on the wire ⇒ no correlated await ⇒ refuse, don't guess."""
+
+    class ModelNoCorrelation(BaseModel):
+        model_config = ConfigDict(frozen=True, extra="forbid")
+
+        prompt: str = Field(default="")
+
+    contract_path = tmp_path / "contract.yaml"
+    contract: dict[str, Any] = {
+        "workflow_id": "omn-17304-no-correlation",
+        "name": "no_correlation_probe",
+        "terminal_event": _TERMINAL_TOPIC,
+        "event_bus": {
+            "subscribe_topics": [_COMMAND_TOPIC],
+            "publish_topics": [_TERMINAL_TOPIC],
+        },
+        "handler_routing": {
+            "routing_strategy": "operation_match",
+            "handlers": [
+                {
+                    "operation": "start",
+                    "handler": {"module": _MODULE, "name": "HandlerClientModeEcho"},
+                    "event_model": {"module": _MODULE, "name": "ModelNoCorrelation"},
+                }
+            ],
+        },
+    }
+    contract_path.write_text(yaml.safe_dump(contract), encoding="utf-8")
+
+    runtime = RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=tmp_path / "state",
+        timeout=1,
+        host_handlers=False,
+    )
+    bus = _RecordingBus()
+
+    _bind(runtime, bus)
+    result = await runtime.run_async()
+
+    assert result is EnumWorkflowResult.FAILED
+    assert bus.published == [], "refused run still published a command"
+    assert "correlation" in (runtime.last_error or ""), (
+        f"refusal did not name the missing correlation: {runtime.last_error!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Locus is recorded in the durable result
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execution_locus_is_written_to_workflow_result(tmp_path: Path) -> None:
+    """The receipt layer must be able to answer "did this run on the lane?"."""
+    correlation_id = uuid.uuid4()
+    runtime = _build_runtime(
+        tmp_path, host_handlers=False, correlation_id=correlation_id, timeout=1
+    )
+    bus = _RecordingBus()
+
+    _bind(runtime, bus)
+    task = asyncio.ensure_future(runtime.run_async())
+    await asyncio.sleep(0.05)
+    await bus.deliver_terminal(
+        {"status": "success", "correlation_id": str(correlation_id)}
+    )
+    result = await task
+
+    assert result is EnumWorkflowResult.COMPLETED
+    written = json.loads(
+        (tmp_path / "state" / "workflow_result.json").read_text(encoding="utf-8")
+    )
+    assert written["handler_locus"] == "dispatched"
+    assert written["wire_correlation_id"] == str(correlation_id)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execution_locus_in_process_for_host_mode(tmp_path: Path) -> None:
+    """Counter-assertion: host mode records itself honestly too."""
+    correlation_id = uuid.uuid4()
+    runtime = _build_runtime(
+        tmp_path, host_handlers=True, correlation_id=correlation_id, timeout=1
+    )
+    bus = _RecordingBus()
+
+    _bind(runtime, bus)
+    task = asyncio.ensure_future(runtime.run_async())
+    await asyncio.sleep(0.05)
+    await bus.deliver_terminal(
+        {"status": "success", "correlation_id": str(correlation_id)}
+    )
+    result = await task
+
+    assert result is EnumWorkflowResult.COMPLETED
+    written = json.loads(
+        (tmp_path / "state" / "workflow_result.json").read_text(encoding="utf-8")
+    )
+    assert written["handler_locus"] == "in_process"


### PR DESCRIPTION
feat(OMN-17304): RuntimeLocal client mode — publish for dispatch, host nothing, await THIS run's terminal

Closes the execution-locus half of OMN-17304 (PR2) and supplies the runtime
primitive OMN-17295 AC1/AC2 need. Unblocked by omnibase_infra#3064 (the
OMN-17295 correlation join) merging to dev at 2026-08-31T12:26:48Z.

THE DEFECT

_run_event_driven was unconditionally BOTH roles. It subscribed every
handler_routing.handlers entry to its input_topic (:1215-1220 pre-change) and
then published the initial command to that same topic (:1300-1305). On a
shared broker that makes the caller a second, DISJOINT consumer group of the
topic it publishes to, so Kafka fans every command to both the deployed
runtime and the caller and both execute the entry handler.

Measured on the .201 dev lane, 2026-08-31T20:06Z, correlation
993819e0-f3e5-4064-a1dd-0b85ee263105:

    lane group  local.omnimarket.node_delegate_skill_orchestrator...  151 -> 152
    Mac CLI     local.omnibase_core.handlerdelegateskill...v1.__t...   53 ->  54
    Mac CLI lag                                                              98

The CLI committed offset 54 — it consumed a 98-message-old backlog command,
not its own — while the lane consumed the real one. --bus kafka selects the
transport; it never relocated execution. Every acceptance criterion written
against that invocation measured the operator's laptop.

WHAT LANDS

1. RuntimeLocal(host_handlers=...). True (default) is byte-for-byte today's
   behaviour and the offline/standalone path. False skips the
   handler-subscribe loop entirely and keeps publish + terminal await, so the
   work is done by whatever runtime is actually subscribed to the command
   topic.

2. Correlation-scoped terminal await, armed only in client mode. Host mode on
   its own in-memory bus has exactly one producer of the terminal topic, so
   filtering there would change offline behaviour for no gain — a scope pinned
   by its own counter-test. Every correlation an envelope declares (envelope
   level AND payload level) must be this run's; an envelope naming nobody is
   unattributable and is discarded, matching the receipt-layer rule in
   omnibase_infra#3064.

3. Run-scoped terminal consumer group in client mode (OMN-17304 AC5). The
   shared runtime-local group id is right for a long-lived host and wrong for
   a one-shot client, which would otherwise resume a previous run's committed
   offset and work through a backlog of terminals that are by construction not
   its own.

4. AC6 — the published correlation is the reported correlation. The old path
   minted a uuid4, assigned it to payload.correlation_id, and swallowed the
   failure into "except (AttributeError, ValueError): pass".
   ModelDelegateSkillRequest is frozen, so on the delegation path that
   assignment ALWAYS raised and was ALWAYS discarded: the bytes on the wire
   correctly kept the caller's id while every "published initial command
   (correlation_id=...)" log line named the id just thrown away. The caller's
   id is now the authority, a runtime-minted id fills only a genuine absence,
   and a refusal to stamp one is reported rather than hidden. Client mode
   REFUSES to publish a command it cannot correlate — without an id on the
   wire the terminal watcher cannot tell this run's terminal from anyone
   else's, which is the failure this whole change exists to remove.

5. handler_locus and wire_correlation_id in workflow_result.json, so a receipt
   built from that file can answer "did this process do the work" from the
   record instead of by hand-correlating container logs afterwards.

NAMING, DELIBERATELY

handler_locus, not execution_locus. OMN-17308 is in flight on
model_skill_result.py adding ModelRuntimeIdentity.execution_locus, which names
where THIS PROCESS runs (venv prefix or container id). Same word, different
question: that one answers "which install am I", this one answers "did I do
the work". No file overlaps between the two changes.

dispatched, not deployed_lane: the runtime knows it did not execute the work,
not who did. Asserting WHICH deployment answered is the caller's job, from a
lane-side fact.

RED-THEN-GREEN

tests/unit/runtime/test_runtime_local_client_mode.py — 10 tests, all failing
before the change (TypeError: RuntimeLocal.__init__() got an unexpected
keyword argument 'host_handlers'), all passing after. Four are host-mode
counter-assertions that pass BOTH before and after: without them, "never
subscribe anything" and "filter everything" would satisfy the positive
assertions while destroying the offline path.

Gates: ruff format + check clean; mypy --strict clean; pre-commit on the two
changed files 0 failed; pytest tests/unit/runtime/ 375 passed.


---

## dod_evidence

Ticket: **OMN-17304** (execution locus is a resolved property) — supplies the runtime primitive **OMN-17295** AC1/AC2 need. Folded under **OMN-17356** (D-1: a delegation runs on the deployed lane, and the receipt proves it did).

| Claim | Proof |
|---|---|
| The CLI was a second, disjoint consumer of the topic it published to | `.201` dev lane, correlation `993819e0-f3e5-4064-a1dd-0b85ee263105`: lane group `151 → 152`, Mac CLI group `53 → 54` at lag 98 — it consumed a 98-message-old backlog command, not its own |
| Client mode stops that, measured not asserted | correlation `f99d5485-1d18-476e-861b-0e81835752cf` with `--locus deployed-lane`: Mac CLI group `54 → 54` UNCHANGED, lane group `152 → 153` |
| The deployed orchestrator did the work | `docker logs omninode-runtime --since 20m \| grep f99d5485` → 19 hits; `omninode-runtime-effects` → 7 |
| The lane's own answer came back | `status: completed`, `qwen3.8` @ `192.168.86.201:8000`, quality 1.0, 1 attempt, 0 escalations, `cost_usd 0.0` — no metered provider |
| Host mode is byte-for-byte unchanged (offline/standalone path) | 4 host-mode counter-assertions in the new suite pass BOTH before and after; live `--bus inmemory` probe returns `status: completed` on the local rung |
| AC6 — the published correlation is the one reported | capture log now prints `correlation_id=f99d5485-…, source=payload`; previously it printed a discarded uuid4 because the frozen-model `ValidationError` was swallowed |
| RED-then-GREEN | `tests/unit/runtime/test_runtime_local_client_mode.py`, 10 tests, all `TypeError: RuntimeLocal.__init__() got an unexpected keyword argument 'host_handlers'` before |
| Gates | ruff format + check clean; `mypy --strict` clean; pre-commit on changed files 0 failed; `pytest tests/unit/runtime/` **375 passed** |
| Governed pre-push | the selector escalated fail-closed to the full suite (`is_full_suite=True reason=shared_module`) and it was run on the designated gate host. No `PREPUSH_*` override, no `--no-verify`, no skip token |

## Downstream ordering

`omnibase_infra` PR `jonah/omn-17304-delegate-lane-locus` (`--locus`, the fail-closed dispatch gate, receipt provenance) **requires this release**. Against omnibase-core 0.47.1 `RuntimeLocal.__init__()` rejects `host_handlers` and every `onex node` receipt run fails. Sequence: this PR merges → core 0.47.2 to PyPI → infra pin bump → infra PR.

Evidence-Ticket: OMN-17304
Evidence-Source: OCC#7925
