### PR TITLE
feat(OMN-17308): runtime-identity stamp — an unstamped receipt becomes unconstructable, and the gate ships wired

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1753,6 +1753,82 @@ jobs:
         run: |
           uv run python -m omnibase_core.validators.backend_secret_discipline src/
 
+  # Runtime-Identity Gate (OMN-17308, epic OMN-17306).
+  #
+  # Enforces that every evidence-producing execution self-identifies. Four
+  # stale-surface incidents in the week of 2026-08-24 shared one defect: a
+  # version string was read as evidence of content, and the process that
+  # produced the evidence never said what it was — a Mac venv pinning
+  # omnimarket 0.4.11 produced a probe read as a .201 lane result
+  # (OMN-16932/OMN-17295); a lane container wore a fresh 0.38.16 label over
+  # week-old vendored content (OMN-17291); a stale PATH binary executed
+  # silently (OMN-17190).
+  #
+  # Two layers ship together, because a detection-only check is one nobody
+  # adopts (CLAUDE.md rule 5):
+  #   1. the TYPE — ModelSkillResult refuses to CONSTRUCT a receipt at
+  #      schema_version >= 1.1.0 without a runtime_identity block, so no
+  #      emitting code path can produce one. Proven by the model suite below.
+  #   2. this GATE — committed receipt JSON is scanned, because an artifact
+  #      may have been written by an older build, hand-edited, or copied in.
+  #
+  # Lives as a job in THIS file rather than in its own workflow for two
+  # reasons: the ci-summary poller only sees jobs from its own run_id
+  # (OMN-14430), and the OMN-14907 PR-workflow ratchet is count-locked — a new
+  # PR-triggered workflow file would have to retire an existing one or take a
+  # waiver. Registered in SPEC_REQUIRED_VALIDATOR_JOBS
+  # (scripts/ci/ci_summary_gate.py) so a red run turns "CI Summary" red.
+  runtime-identity-validator:
+    name: Runtime Identity Validator
+    # OMNI_RUNNER_SELECTOR_V1 - trusted events default to self-hosted omnibase-ci; pull_request defaults to ubuntu-latest
+    runs-on: >-
+      ${{
+        github.event_name != 'pull_request'
+        && fromJSON(vars.OMNI_TRUSTED_CI_RUNS_ON_JSON || '["self-hosted","omnibase-ci"]')
+        || fromJSON(vars.OMNI_PUBLIC_PR_RUNS_ON_JSON || '["ubuntu-latest"]')
+      }}
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run runtime-identity + probe-target validator unit tests
+        run: |
+          uv run pytest \
+            tests/unit/models/dispatch/test_model_skill_result_runtime_identity.py \
+            tests/unit/models/runtime/test_model_runtime_identity.py \
+            tests/unit/validation/test_receipt_runtime_identity_gate.py \
+            tests/unit/validation/test_probe_target_assertion.py \
+            -v
+
+      # Scans every committed JSON in the repo. The validator recognises a
+      # receipt STRUCTURALLY (skill_name + node_name + run_id + status), so a
+      # receipt committed under an unexpected name cannot escape by living
+      # outside a path glob. The PASS line prints how many receipts it
+      # actually saw, so a vacuous scan is visible rather than inferred
+      # (OMN-14531: 16/16 sweeps passed while scanning zero items).
+      - name: Scan committed receipts for a runtime-identity block
+        run: |
+          uv run python -m \
+            omnibase_core.validation.validator_receipt_runtime_identity \
+            --receipts-dir .
+
   # Migrated from validator-banned-compose-vars.yml (OMN-14877, OMN-14430
   # fast-follow). NOTE: this validator had NO pre-commit hook in omnibase_core
   # (audited 2026-07-21) — migrating it here as a required-gating ci.yml job is

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1377,6 +1377,29 @@ repos:
         pass_filenames: true
         stages: [pre-commit]
 
+      # Runtime-Identity Gate (OMN-17308, epic OMN-17306)
+      # Every evidence-producing execution must self-identify. A receipt at
+      # schema_version >= 1.1.0 that carries no runtime_identity block — or
+      # whose block is silent about omnibase_core / omnibase_infra /
+      # omnimarket, or claims source 'vcs' while naming no commit — is
+      # rejected. Receipts stamped below 1.1.0 are grandfathered: they predate
+      # the requirement, and back-filling an identity they never had would
+      # fabricate the exact claim this gate exists to prevent.
+      #
+      # Scoped to ALL staged JSON rather than to a receipt directory: the
+      # validator recognises a receipt structurally (skill_name + node_name +
+      # run_id + status), so a receipt committed under an unexpected name
+      # cannot slip past by living outside a path glob. Non-receipt JSON
+      # returns no findings.
+      - id: check-receipt-runtime-identity
+        name: Runtime Identity Gate (OMN-17308)
+        entry: >-
+          uv run python -m omnibase_core.validation.validator_receipt_runtime_identity
+        language: system
+        types: [json]
+        pass_filenames: true
+        stages: [pre-commit]
+
       # URL Authority Gate (OMN-12818, PR-2 of OMN-12803).
       # Ratchet: NEW fingerprints fail; existing violations are grandfathered.
       # Baseline is burn-down only. Migration debt: OMN-12806 (omnibase_core).

--- a/architecture-handshakes/validator-requirements.yaml
+++ b/architecture-handshakes/validator-requirements.yaml
@@ -701,6 +701,51 @@ required_validators:
     applies_to_repos:
       - omnibase_core
 
+  runtime-identity:
+    description: |
+      Every evidence-producing execution must self-identify. A skill-dispatch
+      receipt at schema_version >= 1.1.0 must carry a runtime_identity block
+      naming, per distribution, the installed version AND the commit, plus the
+      host, the execution locus (venv prefix or container id), the interpreter,
+      and the resolved config source. Receipts below 1.1.0 are GRANDFATHERED —
+      they predate the requirement, and back-filling an identity they never had
+      would fabricate the very claim this gate exists to prevent.
+
+      Two enforcement layers, both required: the TYPE
+      (ModelSkillResult refuses to construct an unstamped current-schema
+      receipt, so no emitting code path can produce one) and this GATE (scans
+      committed receipt JSON, which may have been written by an older build,
+      hand-edited, or copied in). Rules: MISSING_IDENTITY, INCOMPLETE_IDENTITY
+      (a required distribution absent from `packages`), UNRESOLVED_COMMIT
+      (source `vcs` naming no commit — the OMN-17291 shape: a fresh registry
+      label over week-old vendored content), MALFORMED_RECEIPT (fails closed).
+
+      Motivating class (OMN-17306): four stale-surface incidents in the week of
+      2026-08-24 in which a version string was read as evidence of content —
+      a local venv's probe read as a .201 lane result (OMN-16932/OMN-17295), a
+      lane container mislabelled (OMN-17291), a stale PATH binary executing
+      silently (OMN-17190), a clone sync reporting success without moving.
+      OMN-17308.
+    central_source: "omnibase_core.validation.validator_receipt_runtime_identity"
+    pre_commit: required
+    ci_workflow: required
+    required_check_on_main: "CI Summary"
+    silent_skip_allowed: false
+    pre_commit_hook_ids:
+      - "check-receipt-runtime-identity"
+    ci_workflow_keywords:
+      - "validator_receipt_runtime_identity"
+      - "runtime-identity-validator"
+    excludes:
+      # Nothing is excluded: the validator identifies a receipt STRUCTURALLY
+      # (skill_name + node_name + run_id + status), so scoping it to a path
+      # glob would let a receipt committed under an unexpected name pass by
+      # living outside the glob. Non-receipt JSON simply yields no findings.
+      allowed: []
+      forbidden: []
+    applies_to_repos:
+      - omnibase_core
+
 # ---------------------------------------------------------------------------
 # Model B — failing-rollup enforcement (OMN-13574, epic OMN-13573)
 # ---------------------------------------------------------------------------
@@ -787,6 +832,11 @@ model_b_rollup_enforcement:
         # poller) into a ci.yml job. Moved from grandfathered_validators —
         # first instance of the OMN-14430 generalized fix pattern.
         no-hardcoded-topics: ["hardcoded-topic-validator"]
+        # OMN-17308: runtime-identity ships wired, never advisory (CLAUDE.md
+        # rule 5). Runs as a job in ci.yml rather than its own workflow file —
+        # the ci-summary poller only sees jobs from its own run_id (OMN-14430),
+        # and the OMN-14907 PR-workflow ratchet is count-locked.
+        runtime-identity: ["runtime-identity-validator"]
       # Machine-checkable intentional omissions. These validators are
       # ci_workflow: required and apply to omnibase_core, but are currently
       # grandfathered in validator-requirements-baseline.yaml as

--- a/docs/evidence/runtime-identity/grandfathered-receipt.golden.json
+++ b/docs/evidence/runtime-identity/grandfathered-receipt.golden.json
@@ -1,0 +1,14 @@
+{
+  "skill_name": "delegate",
+  "node_name": "node_delegate_skill_orchestrator",
+  "status": "success",
+  "correlation_id": "b9cd305c-8f31-497a-b404-b75b45b98341",
+  "run_id": "1c76154a-2b3c-4d5e-8f90-1a2b3c4d5e6f",
+  "exit_code": 0,
+  "duration_ms": 5120,
+  "result": {"answer": "alive"},
+  "result_model": "omnimarket.models.delegation.ModelDelegateSkillResponse",
+  "metrics": {},
+  "artifact_refs": [],
+  "schema_version": {"major": 1, "minor": 0, "patch": 0, "prerelease": null, "build": null}
+}

--- a/docs/evidence/runtime-identity/stamped-lane-receipt.golden.json
+++ b/docs/evidence/runtime-identity/stamped-lane-receipt.golden.json
@@ -1,0 +1,43 @@
+{
+  "skill_name": "delegate",
+  "node_name": "node_delegate_skill_orchestrator",
+  "status": "success",
+  "correlation_id": "3f8a1c22-0d64-4a1b-9f0e-6c1d2b3a4e5f",
+  "run_id": "7b2e9d10-5c3a-4f8e-bc21-0a9f8e7d6c5b",
+  "exit_code": 0,
+  "duration_ms": 1840,
+  "result": {"answer": "alive"},
+  "result_model": "omnimarket.models.delegation.ModelDelegateSkillResponse",
+  "metrics": {"capture_log_bytes": 4096.0},
+  "artifact_refs": [],
+  "runtime_identity": {
+    "host": "omninode-runtime",
+    "locus_kind": "container",
+    "execution_locus": "9f2c1b0e4a55c7d81e3f0a6b2d4c8e10a5b7c9d1e3f5a7b9c1d3e5f7a9b1c3d5",
+    "interpreter": "/app/.venv/bin/python3.12",
+    "packages": {
+      "omnibase_core": {
+        "name": "omnibase_core",
+        "version": "0.47.1",
+        "commit": null,
+        "source": "registry"
+      },
+      "omnibase_infra": {
+        "name": "omnibase_infra",
+        "version": "0.38.16",
+        "commit": "b8783317f69a1c2d3e4f5a6b7c8d9e0f1a2b3c4d",
+        "source": "vcs"
+      },
+      "omnimarket": {
+        "name": "omnimarket",
+        "version": "0.4.11",
+        "commit": "2f123b4c01ea5d6e7f8a9b0c1d2e3f4a5b6c7d8e",
+        "source": "vcs"
+      }
+    },
+    "config_source": "/app/.venv/lib/python3.12/site-packages/omnimarket/nodes/node_delegate_skill_orchestrator/contract.yaml",
+    "stamped_at": "2026-08-31T08:10:54Z",
+    "schema_version": {"major": 1, "minor": 0, "patch": 0, "prerelease": null, "build": null}
+  },
+  "schema_version": {"major": 1, "minor": 1, "patch": 0, "prerelease": null, "build": null}
+}

--- a/docs/evidence/runtime-identity/stamped-lane-receipt.golden.json
+++ b/docs/evidence/runtime-identity/stamped-lane-receipt.golden.json
@@ -13,7 +13,7 @@
   "runtime_identity": {
     "host": "omninode-runtime",
     "locus_kind": "container",
-    "execution_locus": "9f2c1b0e4a55c7d81e3f0a6b2d4c8e10a5b7c9d1e3f5a7b9c1d3e5f7a9b1c3d5",
+    "execution_locus": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
     "interpreter": "/app/.venv/bin/python3.12",
     "packages": {
       "omnibase_core": {
@@ -25,13 +25,13 @@
       "omnibase_infra": {
         "name": "omnibase_infra",
         "version": "0.38.16",
-        "commit": "b8783317f69a1c2d3e4f5a6b7c8d9e0f1a2b3c4d",
+        "commit": "b878331700000000000000000000000000000000",
         "source": "vcs"
       },
       "omnimarket": {
         "name": "omnimarket",
         "version": "0.4.11",
-        "commit": "2f123b4c01ea5d6e7f8a9b0c1d2e3f4a5b6c7d8e",
+        "commit": "2f123b4c00000000000000000000000000000000",
         "source": "vcs"
       }
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -441,6 +441,7 @@ ignore = [
 "src/omnibase_core/validation/validator_patterns.py" = ["T201"]
 "src/omnibase_core/validation/validator_types.py" = ["T201"]
 "src/omnibase_core/validation/validator_receipt_honesty.py" = ["T201"]  # CLI output for honesty gate scan results (OMN-12791)
+"src/omnibase_core/validation/validator_receipt_runtime_identity.py" = ["T201"]  # CLI output for the runtime-identity gate scan results (OMN-17308)
 "src/omnibase_core/validation/cross_repo/cli.py" = ["T201"]
 "src/omnibase_core/validation/scripts/cross_platform_timeout.py" = ["T201"]
 "src/omnibase_core/validation/scripts/timeout_utils.py" = ["T201"]

--- a/scripts/ci/ci_summary_gate.py
+++ b/scripts/ci/ci_summary_gate.py
@@ -168,6 +168,7 @@ SPEC_REQUIRED_VALIDATOR_JOBS: tuple[str, ...] = (
     "SPDX Headers",  # spdx-headers
     "Duplicate Registry Ids",  # duplicate-registry-ids (OMN-14401)
     "Hardcoded Topic Validator",  # hardcoded-topic-validator (OMN-14430)
+    "Runtime Identity Validator",  # runtime-identity-validator (OMN-17308)
 )
 
 # Conclusions that count as "provably passed".

--- a/src/omnibase_core/enums/enum_execution_locus_kind.py
+++ b/src/omnibase_core/enums/enum_execution_locus_kind.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Execution-locus-kind enum (OMN-17308).
+
+*Where* a process ran, at the granularity that decides whether its output is a
+statement about an operator's laptop or about a deployed lane. The OMN-17295
+invalid probe turned entirely on this distinction: ``--bus kafka`` selects the
+transport, it does not relocate execution, so an orchestrator resolved out of
+``omnibase_infra/.venv`` produced a receipt that read as a lane result.
+"""
+
+from enum import StrEnum, unique
+
+
+@unique
+class EnumExecutionLocusKind(StrEnum):
+    """The kind of place a stamped process was executing in."""
+
+    VENV = "venv"
+    """A Python virtual environment on a host. The locus value is the venv
+    prefix — the surface that distinguishes the CLI venv from the daemon venv
+    from a worktree venv (OMN-17190)."""
+
+    CONTAINER = "container"
+    """A container. The locus value is the container id, which binds the
+    receipt to a specific running image rather than to an image tag."""
+
+    SYSTEM = "system"
+    """A system interpreter with no virtual environment and no container — the
+    OMN-17284 shape, where stale builds sit in brew site-packages and their
+    console scripts are on PATH."""
+
+
+__all__: list[str] = ["EnumExecutionLocusKind"]

--- a/src/omnibase_core/enums/enum_package_source_kind.py
+++ b/src/omnibase_core/enums/enum_package_source_kind.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Package-source-kind enum (OMN-17308).
+
+Where an installed distribution's code actually came from. This is the field
+that separates "I know which commit ran" from "I only know a version string",
+and it exists because the second was repeatedly mistaken for the first: a Mac
+venv pinning ``omnimarket 0.4.11`` produced a probe read as a statement about
+the ``.201`` lane (OMN-16932/OMN-17295), and a lane container wore a fresh
+``0.38.16`` registry label over week-old vendored content (OMN-17291).
+
+The distinction is load-bearing rather than descriptive. :attr:`REGISTRY` is an
+honest admission that no commit is recoverable; :attr:`UNKNOWN` is an honest
+admission that even the source could not be determined. Neither may be silently
+rendered as :attr:`VCS`, and a :attr:`VCS` entry that cannot name a commit is a
+gate violation, not a pass.
+"""
+
+from enum import StrEnum, unique
+
+
+@unique
+class EnumPackageSourceKind(StrEnum):
+    """How an installed distribution was sourced."""
+
+    VCS = "vcs"
+    """Installed from a git URL; PEP 610 ``direct_url.json`` records a
+    ``vcs_info.commit_id``, so the exact content is nameable."""
+
+    LOCAL_PATH = "local_path"
+    """Installed from a local directory (``file://``, editable or workspace
+    staging). The commit, when known, comes from a build-time provenance
+    manifest rather than from the install metadata itself."""
+
+    REGISTRY = "registry"
+    """Installed from a package index (PyPI). Carries a version and NO commit —
+    the OMN-14064 case. A registry install can never be commit-identified."""
+
+    ABSENT = "absent"
+    """The distribution is not installed in this interpreter at all. Recorded
+    explicitly because "omnimarket is missing" is itself an identity fact and
+    the exact regression OMN-14060/OMN-14531 kept re-discovering."""
+
+    UNKNOWN = "unknown"
+    """The distribution is installed but its source could not be determined
+    (unreadable or malformed install metadata). Fails closed downstream."""
+
+    SHADOWED = "shadowed"
+    """The distribution's install metadata describes one tree, but the
+    interpreter imports the module from a DIFFERENT one — a ``PYTHONPATH``
+    entry, a ``.pth`` file, or a `sys.path` prepend winning over site-packages.
+
+    The version and commit recorded by ``importlib.metadata`` then describe
+    code that will not execute, which is the OMN-17306 lie in its purest form:
+    every field is individually true and the block as a whole is false. This is
+    the OMN-17190 stale-binary case one layer in — there the wrong ``onex``
+    resolved on ``PATH``; here the right entry point imports the wrong library.
+
+    Reproduced live 2026-08-31 while verifying OMN-17310: a stamp collected
+    under ``PYTHONPATH=<core-worktree>/src`` reported
+    ``omnibase_core=0.47.1@registry`` while executing 0.47.2 worktree source.
+    Carries no commit — metadata's commit names the tree that LOST."""
+
+
+__all__: list[str] = ["EnumPackageSourceKind"]

--- a/src/omnibase_core/enums/enum_probe_target_disagreement.py
+++ b/src/omnibase_core/enums/enum_probe_target_disagreement.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Probe-target disagreement enum (OMN-17312).
+
+Why a stamped runtime identity failed to satisfy a target's declared identity.
+
+:attr:`UNKNOWN` is deliberately a *disagreement*, not a third neutral state.
+In all four of the 2026-08-2x stale-surface incidents the honest answer was "I
+cannot tell", and every surface rendered it as "fine". A probe that cannot
+answer whether it ran against its declared target has not proven anything, so
+it fails on the same terms as one that provably ran somewhere else.
+"""
+
+from enum import StrEnum, unique
+
+
+@unique
+class EnumProbeTargetDisagreement(StrEnum):
+    """The kind of disagreement between a stamp and a declaration."""
+
+    MISMATCH = "mismatch"
+    """Both sides named the field and the values differ. The probe provably ran
+    somewhere other than its declared target."""
+
+    UNKNOWN = "unknown"
+    """The declaration names the field and the stamp cannot answer it. Fails
+    closed — indistinguishable in consequence from MISMATCH, distinct only in
+    the message so the operator knows which repair applies."""
+
+    EMPTY_DECLARATION = "empty_declaration"
+    """The declaration asserted nothing, so an assertion against it would
+    compare zero fields. A vacuous check that reports PASS is the OMN-14531
+    failure class; this makes it a refusal."""
+
+
+__all__: list[str] = ["EnumProbeTargetDisagreement"]

--- a/src/omnibase_core/enums/enum_runtime_identity_rule.py
+++ b/src/omnibase_core/enums/enum_runtime_identity_rule.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Runtime-identity gate rule enum (OMN-17308).
+
+The closed set of ways a receipt can fail the runtime-identity gate
+(``omnibase_core.validation.validator_receipt_runtime_identity``). Kept in
+``enums/`` rather than beside the validator so the validator module holds no
+classes and needs no one-class-per-file allowlist entry.
+"""
+
+from enum import StrEnum, unique
+
+
+@unique
+class EnumRuntimeIdentityRule(StrEnum):
+    """Why a receipt failed the runtime-identity gate."""
+
+    MISSING_IDENTITY = "missing_identity"
+    """The receipt is at or above the requiring schema version and carries no
+    ``runtime_identity`` block at all."""
+
+    INCOMPLETE_IDENTITY = "incomplete_identity"
+    """A required package is absent from ``runtime_identity.packages``. A stamp
+    that omits a package is silent about it, which is the state this gate
+    exists to make impossible."""
+
+    UNRESOLVED_COMMIT = "unresolved_commit"
+    """A package declares ``source: vcs`` but names no commit. Claiming a git
+    origin while being unable to identify the content is the OMN-17291 shape —
+    a fresh label over stale content."""
+
+    SHADOWED_IMPORT = "shadowed_import"
+    """A package declares ``source: shadowed`` — its install metadata describes
+    one tree while the interpreter imported another. The receipt's own stamp
+    says the code that ran is not the code the versions name, so the receipt
+    cannot be read as evidence about the named build."""
+
+    MALFORMED_RECEIPT = "malformed_receipt"
+    """The file could not be parsed as a receipt at all. Fails closed: an
+    unreadable receipt is never treated as an absent one."""
+
+
+__all__: list[str] = ["EnumRuntimeIdentityRule"]

--- a/src/omnibase_core/models/dispatch/model_skill_result.py
+++ b/src/omnibase_core/models/dispatch/model_skill_result.py
@@ -108,13 +108,13 @@ class ModelSkillResult(BaseModel, Generic[T]):
         >>> identity = ModelRuntimeIdentity(
         ...     host="omninode-runtime",
         ...     locus_kind=EnumExecutionLocusKind.CONTAINER,
-        ...     execution_locus="c0ffee123456",
+        ...     execution_locus="c0ffee123456",  # pragma: allowlist secret
         ...     interpreter="/app/.venv/bin/python",
         ...     packages={
         ...         "omnimarket": ModelPackageIdentity(
         ...             name="omnimarket",
         ...             version="0.4.13",
-        ...             commit="2f123b4c01ea" + "0" * 28,
+        ...             commit="2f123b4c01ea" + "0" * 28,  # pragma: allowlist secret
         ...             source=EnumPackageSourceKind.VCS,
         ...         )
         ...     },

--- a/src/omnibase_core/models/dispatch/model_skill_result.py
+++ b/src/omnibase_core/models/dispatch/model_skill_result.py
@@ -85,8 +85,41 @@ class ModelSkillResult(BaseModel, Generic[T]):
     is the result; intermediate context is captured behind ``artifact_refs``
     instead of flooding the dispatching agent.
 
+    Every receipt built at the current schema version carries a
+    ``runtime_identity`` naming the process that produced it. Collect one with
+    ``omnibase_infra.runtime_identity.collect_runtime_identity()``; it is built
+    by hand here only to keep the example self-contained.
+
     Example:
+        >>> from datetime import datetime, timezone
         >>> from uuid import uuid4
+        >>> from omnibase_core.enums.enum_execution_locus_kind import (
+        ...     EnumExecutionLocusKind,
+        ... )
+        >>> from omnibase_core.enums.enum_package_source_kind import (
+        ...     EnumPackageSourceKind,
+        ... )
+        >>> from omnibase_core.models.runtime.model_package_identity import (
+        ...     ModelPackageIdentity,
+        ... )
+        >>> from omnibase_core.models.runtime.model_runtime_identity import (
+        ...     ModelRuntimeIdentity,
+        ... )
+        >>> identity = ModelRuntimeIdentity(
+        ...     host="omninode-runtime",
+        ...     locus_kind=EnumExecutionLocusKind.CONTAINER,
+        ...     execution_locus="c0ffee123456",
+        ...     interpreter="/app/.venv/bin/python",
+        ...     packages={
+        ...         "omnimarket": ModelPackageIdentity(
+        ...             name="omnimarket",
+        ...             version="0.4.13",
+        ...             commit="2f123b4c01ea" + "0" * 28,
+        ...             source=EnumPackageSourceKind.VCS,
+        ...         )
+        ...     },
+        ...     stamped_at=datetime(2026, 8, 31, 10, 7, 45, tzinfo=timezone.utc),
+        ... )
         >>> envelope = ModelSkillResult[dict[str, str]](
         ...     skill_name="delegate",
         ...     node_name="node_delegate_skill_orchestrator",
@@ -97,8 +130,31 @@ class ModelSkillResult(BaseModel, Generic[T]):
         ...     duration_ms=1250,
         ...     result={"answer": "42"},
         ...     result_model="builtins.dict",
+        ...     runtime_identity=identity,
         ... )
         >>> envelope.status.is_success_like
+        True
+        >>> envelope.runtime_identity.host
+        'omninode-runtime'
+
+    A receipt may omit ``runtime_identity`` only by explicitly declaring a
+    pre-1.1.0 ``schema_version`` — the grandfathering path, which states
+    honestly that the receipt predates the requirement:
+
+        >>> from omnibase_core.models.primitives.model_semver import ModelSemVer
+        >>> legacy = ModelSkillResult[dict[str, str]](
+        ...     skill_name="delegate",
+        ...     node_name="node_delegate_skill_orchestrator",
+        ...     status=EnumSkillResultStatus.SUCCESS,
+        ...     correlation_id=uuid4(),
+        ...     run_id=uuid4(),
+        ...     exit_code=0,
+        ...     duration_ms=1250,
+        ...     result={"answer": "42"},
+        ...     result_model="builtins.dict",
+        ...     schema_version=ModelSemVer(major=1, minor=0, patch=0),
+        ... )
+        >>> legacy.runtime_identity is None
         True
     """
 

--- a/src/omnibase_core/models/dispatch/model_skill_result.py
+++ b/src/omnibase_core/models/dispatch/model_skill_result.py
@@ -34,19 +34,41 @@ import re
 from typing import Generic, TypeVar
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from omnibase_core.enums.enum_skill_result_status import EnumSkillResultStatus
 from omnibase_core.models.artifacts.model_artifact_ref import ModelArtifactRef
 from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.models.runtime.model_runtime_identity import ModelRuntimeIdentity
 
-__all__ = ["SKILL_RESULT_SCHEMA_VERSION", "ModelSkillResult"]
+__all__ = [
+    "RUNTIME_IDENTITY_REQUIRED_FROM",
+    "SKILL_RESULT_SCHEMA_VERSION",
+    "ModelSkillResult",
+]
 
 T = TypeVar("T")
 
 # Current schema version for skill dispatch receipts. The hook backstop
 # (Layer C) sniffs this field to pass receipt-mode output through untouched.
-SKILL_RESULT_SCHEMA_VERSION = ModelSemVer(major=1, minor=0, patch=0)
+#
+# 1.0.0 -> 1.1.0 (OMN-17308): ``runtime_identity`` became mandatory. The bump
+# is what makes the requirement bite, because ``schema_version`` defaults to
+# this constant: every receipt built from now on is a 1.1.0 receipt, and a
+# 1.1.0 receipt without an identity fails construction.
+SKILL_RESULT_SCHEMA_VERSION = ModelSemVer(major=1, minor=1, patch=0)
+
+# The version at which ``runtime_identity`` became required. Receipts stamped
+# below it are GRANDFATHERED -- they predate the requirement and are valid
+# without an identity block.
+#
+# Grandfathering is by schema version rather than by date, path, or an
+# allowlist, for one reason: it keeps the historical record honest. Back-filling
+# an identity onto a 2026-08 receipt would manufacture a claim about a process
+# nobody observed -- the exact fiction epic OMN-17306 exists to stop. "This
+# receipt predates the requirement" is a true statement the receipt can make
+# about itself, and the version field is how it makes it.
+RUNTIME_IDENTITY_REQUIRED_FROM = ModelSemVer(major=1, minor=1, patch=0)
 
 # Fully qualified dotted path: at least one dot, each segment a valid
 # Python identifier (e.g. "omnimarket.models.ModelDelegateSkillResponse").
@@ -145,10 +167,47 @@ class ModelSkillResult(BaseModel, Generic[T]):
             "and hash-verified via the artifact store."
         ),
     )
+    runtime_identity: ModelRuntimeIdentity | None = Field(
+        default=None,
+        description=(
+            "Self-identification of the process that produced this receipt: "
+            "per-package version AND commit, host, execution locus (venv path "
+            "or container id), interpreter, and resolved config source. "
+            "REQUIRED at schema_version >= 1.1.0; None only on grandfathered "
+            "pre-1.1.0 receipts. Without it a receipt printed by a stale local "
+            "venv is byte-indistinguishable from one printed by a deployed "
+            "lane -- the OMN-16932/OMN-17295 defect."
+        ),
+    )
     schema_version: ModelSemVer = Field(
         default_factory=lambda: SKILL_RESULT_SCHEMA_VERSION,
         description="Receipt schema version for format evolution.",
     )
+
+    @model_validator(mode="after")
+    def _require_runtime_identity(self) -> ModelSkillResult[T]:
+        """Refuse a current-schema receipt that does not say what produced it.
+
+        This is the enforcement, not a detection: an unstamped receipt at or
+        above :data:`RUNTIME_IDENTITY_REQUIRED_FROM` cannot be CONSTRUCTED, so
+        there is no code path that emits one and no artifact that carries one.
+        A later scanner could only have reported the problem after the
+        misleading evidence had already been read.
+        """
+        if self.runtime_identity is not None:
+            return self
+        if self.schema_version >= RUNTIME_IDENTITY_REQUIRED_FROM:
+            msg = (
+                "runtime_identity is required at schema_version "
+                f"{self.schema_version} (>= {RUNTIME_IDENTITY_REQUIRED_FROM}). "
+                "A receipt that does not identify the process that produced it "
+                "is a claim, not evidence: collect one with "
+                "omnibase_infra.runtime_identity.collect_runtime_identity(). "
+                "Only receipts stamped below "
+                f"{RUNTIME_IDENTITY_REQUIRED_FROM} are grandfathered."
+            )
+            raise ValueError(msg)
+        return self
 
     @field_validator("result_model")
     @classmethod

--- a/src/omnibase_core/models/runtime/__init__.py
+++ b/src/omnibase_core/models/runtime/__init__.py
@@ -3,6 +3,9 @@
 
 """Runtime models for ONEX node execution."""
 
+from omnibase_core.models.runtime.model_declared_target_identity import (
+    ModelDeclaredTargetIdentity,
+)
 from omnibase_core.models.runtime.model_demand_source_ref import ModelDemandSourceRef
 from omnibase_core.models.runtime.model_descriptor_circuit_breaker import (
     ModelDescriptorCircuitBreaker,
@@ -27,8 +30,12 @@ from omnibase_core.models.runtime.model_liveness_registry_entry import (
     ModelLivenessRegistryEntry,
 )
 from omnibase_core.models.runtime.model_output_join_spec import ModelOutputJoinSpec
+from omnibase_core.models.runtime.model_package_identity import ModelPackageIdentity
 from omnibase_core.models.runtime.model_primary_dlq_disposition_receipt import (
     ModelPrimaryDlqDispositionReceipt,
+)
+from omnibase_core.models.runtime.model_probe_target_verdict import (
+    ModelProbeTargetVerdict,
 )
 from omnibase_core.models.runtime.model_quarantine_disposition_receipt import (
     ModelQuarantineDispositionReceipt,
@@ -46,6 +53,10 @@ from omnibase_core.models.runtime.model_runtime_aliveness_probe_receipt import (
     ModelRuntimeAlivenessProbeReceipt,
 )
 from omnibase_core.models.runtime.model_runtime_directive import ModelRuntimeDirective
+from omnibase_core.models.runtime.model_runtime_identity import (
+    RUNTIME_IDENTITY_SCHEMA_VERSION,
+    ModelRuntimeIdentity,
+)
 from omnibase_core.models.runtime.model_runtime_skill_error import (
     ModelRuntimeSkillError,
 )
@@ -109,6 +120,12 @@ __all__ = [
     # Dual-sink terminal durability (OMN-15666)
     "ModelPrimaryDlqDispositionReceipt",
     "ModelTerminalDispositionRequest",
+    # Runtime-identity stamp + probe-target assertion (OMN-17308 / OMN-17312)
+    "RUNTIME_IDENTITY_SCHEMA_VERSION",
+    "ModelPackageIdentity",
+    "ModelRuntimeIdentity",
+    "ModelDeclaredTargetIdentity",
+    "ModelProbeTargetVerdict",
     # Directive payload types (re-exported for convenience)
     "ModelDirectivePayload",
     "ModelDirectivePayloadBase",

--- a/src/omnibase_core/models/runtime/model_declared_target_identity.py
+++ b/src/omnibase_core/models/runtime/model_declared_target_identity.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""A target's own declaration of what it is (OMN-17312).
+
+The other half of the probe-target assertion. A probe that names a target
+("this proves the ``.201`` dev lane") is asserting a relationship between the
+process that ran and a place; this model is the *place's* statement about
+itself, against which that assertion is checked.
+
+## Declared, not intended
+
+Every field here must come from a surface the target emits about itself — the
+deployed ``build-provenance.json``, an installed ``direct_url.json`` read back
+out of the running container, a lane manifest. ``declared_by`` records which
+surface, and is required.
+
+A caller-supplied "I meant the dev lane" is not a declaration; it is the intent
+that was already wrong in OMN-17295, where the operator correctly prepared the
+lane, correctly believed the probe addressed it, and was correctly told the
+probe succeeded — while the orchestrator ran on the laptop.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.enums.enum_execution_locus_kind import EnumExecutionLocusKind
+
+__all__ = ["ModelDeclaredTargetIdentity"]
+
+_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ModelDeclaredTargetIdentity(BaseModel):
+    """What a probe target declares itself to be."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    target_name: str = Field(
+        ...,
+        min_length=1,
+        description="Human-readable name of the target, for the failure "
+        "message only. Never compared.",
+    )
+    declared_by: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "The surface this declaration was read from (e.g. the deployed "
+            "build-provenance.json path, or a container-id readback command). "
+            "Required: a declaration with no provenance is the caller's "
+            "intent wearing a declaration's shape."
+        ),
+    )
+    host: str | None = Field(
+        default=None,
+        description="Hostname the target runs on, when declared.",
+    )
+    locus_kind: EnumExecutionLocusKind | None = Field(
+        default=None,
+        description="Whether the target is a container, a venv, or a system "
+        "interpreter, when declared.",
+    )
+    execution_locus: str | None = Field(
+        default=None,
+        description="The target's container id or venv prefix, when declared.",
+    )
+    packages: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Expected full 40-character commit per distribution name. This is "
+            "the field that catches OMN-17291: a lane whose declared "
+            "omnimarket commit is origin/dev's tip, asserted against a stamp "
+            "naming an 11-commits-behind SHA."
+        ),
+    )
+
+    @field_validator("packages")
+    @classmethod
+    def _validate_commits(cls, value: dict[str, str]) -> dict[str, str]:
+        normalized: dict[str, str] = {}
+        for name, commit in value.items():
+            candidate = commit.strip().lower()
+            if not _COMMIT_RE.match(candidate):
+                msg = (
+                    f"declared commit for {name!r} must be a full "
+                    "40-character lowercase hex git SHA (an abbreviation "
+                    f"cannot be compared for identity), got: {commit!r}"
+                )
+                raise ValueError(msg)
+            normalized[name] = candidate
+        return normalized
+
+    def is_empty(self) -> bool:
+        """True when this declaration asserts nothing comparable.
+
+        ``target_name`` and ``declared_by`` are metadata, not claims, so a
+        declaration carrying only those two compares zero fields. The
+        assertion helper refuses such a declaration rather than returning a
+        pass that proves nothing (OMN-14531's vacuous-check class).
+        """
+        return (
+            self.host is None
+            and self.locus_kind is None
+            and self.execution_locus is None
+            and not self.packages
+        )

--- a/src/omnibase_core/models/runtime/model_package_identity.py
+++ b/src/omnibase_core/models/runtime/model_package_identity.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Per-distribution identity for the runtime-identity stamp (OMN-17308).
+
+One entry of :class:`~omnibase_core.models.runtime.model_runtime_identity.ModelRuntimeIdentity`
+``packages``: what a single installed distribution actually is, at content
+granularity rather than at label granularity.
+
+Why both fields. ``version`` comes from ``importlib.metadata`` and is a label
+the packaging system prints; ``commit`` names the content. The two are
+routinely inconsistent, and every incident in the OMN-17306 class turned on
+reading the first as though it were the second — most starkly OMN-17291, where
+a lane advertised registry ``0.38.16`` while its vendored ``omnimarket`` sat 11
+commits behind ``origin/dev`` at ``05e3882f9``.
+
+This model is pure data. Collecting it needs ``importlib.metadata``, PEP 610
+``direct_url.json`` and (inside a container) the RT-1 build-provenance
+manifest, none of which belongs in core — that lives in omnibase_infra
+(OMN-17310).
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from omnibase_core.enums.enum_package_source_kind import EnumPackageSourceKind
+
+__all__ = ["ModelPackageIdentity"]
+
+_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ModelPackageIdentity(BaseModel):
+    """What one installed distribution is, by label AND by content."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        description="Distribution name as importlib.metadata knows it.",
+    )
+    version: str | None = Field(
+        default=None,
+        description=(
+            "Installed version string, or None when the distribution is "
+            "ABSENT. A version alone is a label, never proof of content."
+        ),
+    )
+    commit: str | None = Field(
+        default=None,
+        description=(
+            "Full 40-character git commit the distribution was built from, "
+            "when it is recoverable (PEP 610 vcs_info, or a build-time "
+            "provenance manifest for a workspace install). None is an honest "
+            "'not recoverable', never a placeholder."
+        ),
+    )
+    source: EnumPackageSourceKind = Field(
+        ...,
+        description="How the distribution was sourced. Decides whether a "
+        "missing commit is expected (REGISTRY) or a violation (VCS).",
+    )
+    import_path: str | None = Field(
+        default=None,
+        description=(
+            "Directory the interpreter actually imports this package's "
+            "top-level module from, when it differs from the location the "
+            "install metadata claims. None means the two agree, or the "
+            "package is ABSENT. Required whenever source is SHADOWED: the "
+            "whole content of that verdict is 'the code that runs is over "
+            "there', so a SHADOWED entry that cannot say where is an "
+            "unsupported claim."
+        ),
+    )
+
+    @field_validator("commit")
+    @classmethod
+    def _validate_commit(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        if not _COMMIT_RE.match(normalized):
+            msg = (
+                "commit must be a full 40-character lowercase hex git SHA "
+                f"(abbreviations are not identity), got: {value!r}"
+            )
+            raise ValueError(msg)
+        return normalized
+
+    @model_validator(mode="after")
+    def _absent_carries_nothing(self) -> ModelPackageIdentity:
+        """An ABSENT distribution cannot carry a version or a commit.
+
+        Recorded as a hard rule rather than a convention because "absent" was
+        repeatedly indistinguishable from "stale" in the OMN-14060 →
+        OMN-14531 recurrence: the guard's fail-open path treated a missing
+        install and an unreadable one identically.
+        """
+        if self.source is EnumPackageSourceKind.ABSENT and (
+            self.version is not None or self.commit is not None
+        ):
+            msg = (
+                f"package {self.name!r} is ABSENT but carries "
+                f"version={self.version!r} commit={self.commit!r}; an absent "
+                "distribution has neither"
+            )
+            raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def _shadowed_names_the_winner(self) -> ModelPackageIdentity:
+        """A SHADOWED entry must say where the code that actually runs lives.
+
+        SHADOWED means "the metadata describes a tree the interpreter did not
+        import". An entry that asserts that and cannot name the winning path
+        states the problem without giving anyone the means to check it, which
+        is the vacuous-verdict failure class of OMN-14531. It must also carry
+        no commit: the metadata's commit identifies the tree that lost, so
+        reporting it here would attribute a SHA to code that never ran --
+        exactly the substitution this whole model exists to prevent.
+        """
+        if self.source is not EnumPackageSourceKind.SHADOWED:
+            return self
+        if self.import_path is None:
+            msg = (
+                f"package {self.name!r} is SHADOWED but names no import_path; "
+                "a shadowing claim that cannot say which tree won is "
+                "unverifiable"
+            )
+            raise ValueError(msg)
+        if self.commit is not None:
+            msg = (
+                f"package {self.name!r} is SHADOWED but carries "
+                f"commit={self.commit!r}; that commit identifies the tree the "
+                "interpreter did NOT import"
+            )
+            raise ValueError(msg)
+        return self

--- a/src/omnibase_core/models/runtime/model_probe_target_verdict.py
+++ b/src/omnibase_core/models/runtime/model_probe_target_verdict.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Result of a satisfied probe-target assertion (OMN-17312)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ModelProbeTargetVerdict"]
+
+
+class ModelProbeTargetVerdict(BaseModel):
+    """A stamp that satisfied a target's declaration, and what was compared."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    target_name: str = Field(
+        ...,
+        min_length=1,
+        description="The target the stamp was asserted against.",
+    )
+    declared_by: str = Field(
+        ...,
+        min_length=1,
+        description="The surface the declaration was read from.",
+    )
+    compared_fields: list[str] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Every field actually compared, e.g. ['host', "
+            "'package:omnimarket']. Non-empty by construction so 'asserted' "
+            "can never quietly mean 'compared nothing' — the OMN-14531 "
+            "failure class, where 16/16 sweeps passed while scanning zero "
+            "items."
+        ),
+    )

--- a/src/omnibase_core/models/runtime/model_runtime_identity.py
+++ b/src/omnibase_core/models/runtime/model_runtime_identity.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Runtime-identity stamp (OMN-17308, epic OMN-17306).
+
+The block every evidence-producing execution attaches to its own output so the
+output is a statement about a knowable process rather than an unattributed
+claim.
+
+## Why this exists
+
+Four stale-surface incidents in the week of 2026-08-24, one defect class:
+
+* **OMN-16932 / OMN-17295** — a probe issued as ``onex delegate ... --bus
+  kafka`` was read as a statement about the ``.201`` dev lane. ``--bus``
+  selects the transport; it does not relocate execution. The orchestrator
+  resolved out of the local ``omnibase_infra/.venv`` (``omnimarket 0.4.11`` at
+  ``66b7131a3``, pre-fix), and the lane's own logs had zero hits for the
+  correlation id. The receipt was byte-indistinguishable from a real lane
+  receipt.
+* **OMN-17291** — a lane container advertised registry ``0.38.16`` over
+  ``omnimarket`` content 11 commits behind ``origin/dev``.
+* **OMN-17190** — a stale ``onex`` binary on PATH executed silently in place of
+  the one under test.
+* **OMN-17291 (defect 1)** — a clone sync reported success without moving
+  (``core.bare=true`` makes ``fetch`` exit 0 while ``checkout`` exits 128).
+
+Each was caught by a human comparing install metadata against ``origin/dev`` by
+hand. The stamp makes that comparison possible from the artifact alone.
+
+## Shape
+
+Deliberately small and cheap: a handful of ``importlib.metadata`` lookups and
+one ``gethostname()``, collected once per process. It answers exactly four
+questions — *what code*, *on what host*, *out of what venv or container*,
+*against what config* — and nothing else. It is not telemetry and not a
+dependency inventory.
+
+## Placement
+
+Pure data in core because :class:`~omnibase_core.models.dispatch.model_skill_result.ModelSkillResult`
+carries it and lives in core (repo layering: compat → core → spi → infra, so a
+field of a core model may not live in infra). Collection is I/O and lives in
+``omnibase_infra`` (OMN-17310).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.enums.enum_execution_locus_kind import EnumExecutionLocusKind
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.models.runtime.model_package_identity import ModelPackageIdentity
+
+__all__ = ["RUNTIME_IDENTITY_SCHEMA_VERSION", "ModelRuntimeIdentity"]
+
+# Schema version of the identity block itself, independent of the receipt
+# envelope's own version.
+RUNTIME_IDENTITY_SCHEMA_VERSION = ModelSemVer(major=1, minor=0, patch=0)
+
+
+class ModelRuntimeIdentity(BaseModel):
+    """Self-identification of the process that produced an artifact."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    host: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Hostname of the machine the process ran on. The coarsest answer "
+            "to 'was this my laptop or the lane', and the one that would have "
+            "settled OMN-17295 on sight."
+        ),
+    )
+    locus_kind: EnumExecutionLocusKind = Field(
+        ...,
+        description="Whether the process ran in a venv, a container, or a "
+        "bare system interpreter.",
+    )
+    execution_locus: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "The locus itself: the venv prefix, or the container id. A venv "
+            "path distinguishes the CLI venv from the daemon venv from a "
+            "worktree venv (OMN-17190); a container id binds the receipt to a "
+            "running container rather than to a mutable image tag."
+        ),
+    )
+    interpreter: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Absolute path of the interpreter that executed (sys.executable). "
+            "Makes the OMN-17190 stale-PATH-binary case visible in the "
+            "artifact instead of requiring a `which` at the terminal."
+        ),
+    )
+    packages: dict[str, ModelPackageIdentity] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Per-distribution identity, keyed by distribution name. Includes "
+            "distributions that are ABSENT, because absence is an identity "
+            "fact. An empty map is refused: a stamp that names no code is not "
+            "a stamp."
+        ),
+    )
+    config_source: str | None = Field(
+        default=None,
+        description=(
+            "Resolved config/contract source this execution ran against (e.g. "
+            "the packaged contract path). None when the execution resolved no "
+            "contract. Never a secret value — a location only."
+        ),
+    )
+    stamped_at: datetime = Field(
+        ...,
+        description=(
+            "When the stamp was collected. Caller-supplied rather than "
+            "defaulted so a replayed or copied stamp cannot silently "
+            "re-date itself."
+        ),
+    )
+    schema_version: ModelSemVer = Field(
+        default_factory=lambda: RUNTIME_IDENTITY_SCHEMA_VERSION,
+        description="Identity-block schema version, for format evolution.",
+    )
+
+    @field_validator("packages")
+    @classmethod
+    def _keys_match_names(
+        cls, value: dict[str, ModelPackageIdentity]
+    ) -> dict[str, ModelPackageIdentity]:
+        """Refuse a map whose key disagrees with the entry's own name.
+
+        A key/name split is how a stamp starts describing one package under
+        another's label — the same substitution the whole epic exists to
+        prevent, in miniature.
+        """
+        mismatched = sorted(key for key, entry in value.items() if key != entry.name)
+        if mismatched:
+            msg = (
+                "packages keys must equal each entry's own name; mismatched "
+                f"keys: {mismatched}"
+            )
+            raise ValueError(msg)
+        return value
+
+    def package(self, name: str) -> ModelPackageIdentity | None:
+        """Return the identity for ``name``, or ``None`` when unstamped.
+
+        ``None`` here means "this stamp is silent about that package" — which
+        is distinct from an entry whose ``source`` is ABSENT ("that package is
+        not installed"). Callers that conflate the two reintroduce the
+        fail-open path this model exists to close.
+        """
+        return self.packages.get(name)

--- a/src/omnibase_core/models/validation/model_runtime_identity_violation.py
+++ b/src/omnibase_core/models/validation/model_runtime_identity_violation.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""One runtime-identity gate finding (OMN-17308)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_runtime_identity_rule import EnumRuntimeIdentityRule
+
+__all__ = ["ModelRuntimeIdentityViolation"]
+
+
+class ModelRuntimeIdentityViolation(BaseModel):
+    """A receipt that failed the runtime-identity gate, and why."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    path: str = Field(
+        ...,
+        min_length=1,
+        description="Path of the offending receipt file.",
+    )
+    rule: EnumRuntimeIdentityRule = Field(
+        ...,
+        description="Which gate rule the receipt violated.",
+    )
+    detail: str = Field(
+        ...,
+        min_length=1,
+        description="What is missing or wrong, named specifically enough to "
+        "repair without opening the file.",
+    )

--- a/src/omnibase_core/validation/validator_probe_target.py
+++ b/src/omnibase_core/validation/validator_probe_target.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Probe-target assertion (OMN-17312, epic OMN-17306).
+
+Answers one question mechanically: *did the process that produced this stamp
+run against the target this probe claims to be about?*
+
+## The manual step this replaces
+
+On 2026-08-31 a **valid** in-lane probe was performed by hand — read the
+deployed container's ``direct_url.json``, compare the vendored ``omnimarket``
+commit against ``origin/dev``, confirm the code under test was actually
+present, and only then read the result as a statement about the lane. Two hours
+earlier an **invalid** probe skipped that step (OMN-16932 record, correlation
+``b9cd305c-8f31-497a-b404-b75b45b98341``): it published over the lane's broker,
+so it looked addressed to ``.201``, while the orchestrator resolved out of the
+operator's local venv on pre-fix ``omnimarket 0.4.11``. The lane's own logs had
+zero hits for that correlation. Both probes printed a confident result; only
+one of them was about the lane.
+
+The difference between the two was entirely a human comparison. This module is
+that comparison.
+
+## Fails closed on UNKNOWN, not only on MISMATCH
+
+The load-bearing property. In every incident of the OMN-17306 class the honest
+answer was "I cannot tell" and every surface rendered it as "fine":
+``core.bare=true`` made ``fetch`` exit 0 while ``checkout`` exited 128
+(OMN-17291); ``DEPLOY_REF`` unset printed a warning into a 4000-line log and
+built anyway; the drift guard's ``None`` short-circuit treated "not installed"
+as "nothing to check" (OMN-14060 → OMN-14531).
+
+So a declared field the stamp cannot answer is a REFUSAL, on the same terms as
+a provable mismatch. The two are distinguished only in the message, because
+they call for different repairs -- restamp versus re-target -- never in the
+verdict.
+
+An empty declaration is likewise a refusal: an assertion that compares zero
+fields and returns PASS is the vacuous-check failure class OMN-14531 found
+across 16/16 sweeps.
+
+Pure comparison, no I/O: reading the declaration off a lane and the stamp off a
+receipt is the caller's job (``onex identity assert-target`` in omnibase_infra).
+"""
+
+from __future__ import annotations
+
+from omnibase_core.enums.enum_probe_target_disagreement import (
+    EnumProbeTargetDisagreement,
+)
+from omnibase_core.models.runtime.model_declared_target_identity import (
+    ModelDeclaredTargetIdentity,
+)
+from omnibase_core.models.runtime.model_probe_target_verdict import (
+    ModelProbeTargetVerdict,
+)
+from omnibase_core.models.runtime.model_runtime_identity import ModelRuntimeIdentity
+
+__all__ = [
+    "ProbeTargetMismatchError",
+    "assert_probe_target",
+]
+
+
+class ProbeTargetMismatchError(RuntimeError):
+    """A stamp did not satisfy a target's declared identity.
+
+    Carries the disagreement kind so a caller can distinguish "ran elsewhere"
+    from "cannot tell" without parsing the message, while treating both as the
+    same refusal.
+    """
+
+    def __init__(
+        self,
+        *,
+        kind: EnumProbeTargetDisagreement,
+        target_name: str,
+        detail: str,
+    ) -> None:
+        self.kind = kind
+        self.target_name = target_name
+        self.detail = detail
+        super().__init__(
+            f"probe-target assertion FAILED ({kind.value}) for target "
+            f"{target_name!r}: {detail}"
+        )
+
+
+def assert_probe_target(
+    *,
+    stamped: ModelRuntimeIdentity,
+    declared: ModelDeclaredTargetIdentity,
+) -> ModelProbeTargetVerdict:
+    """Assert ``stamped`` satisfies ``declared``, or raise.
+
+    Returns a verdict naming every field actually compared, so a caller can
+    prove the assertion was not vacuous. Raises
+    :class:`ProbeTargetMismatchError` on the first disagreement, checked
+    cheapest-first (host, then locus, then per-package commits) so the message
+    names the coarsest thing that is wrong -- "you were on the wrong host" is
+    more useful than "omnimarket's commit differs" when both are true.
+
+    Args:
+        stamped: What the executing process said it was.
+        declared: What the target says it is, read from the target's own
+            surface. Never the caller's intent.
+
+    Raises:
+        ProbeTargetMismatchError: the declaration asserts nothing
+            (EMPTY_DECLARATION), the stamp cannot answer a declared field
+            (UNKNOWN), or the values differ (MISMATCH).
+    """
+    if declared.is_empty():
+        raise ProbeTargetMismatchError(
+            kind=EnumProbeTargetDisagreement.EMPTY_DECLARATION,
+            target_name=declared.target_name,
+            detail=(
+                f"the declaration read from {declared.declared_by!r} asserts "
+                "no comparable field (no host, no locus, no package commits), "
+                "so asserting against it would compare nothing and pass "
+                "unconditionally"
+            ),
+        )
+
+    compared: list[str] = []
+
+    if declared.host is not None:
+        compared.append("host")
+        if stamped.host != declared.host:
+            raise ProbeTargetMismatchError(
+                kind=EnumProbeTargetDisagreement.MISMATCH,
+                target_name=declared.target_name,
+                detail=(
+                    f"host: stamped {stamped.host!r} != declared "
+                    f"{declared.host!r} (declared by {declared.declared_by!r}) "
+                    "-- this execution ran on a different machine than the "
+                    "target it claims to prove"
+                ),
+            )
+
+    if declared.locus_kind is not None:
+        compared.append("locus_kind")
+        if stamped.locus_kind is not declared.locus_kind:
+            raise ProbeTargetMismatchError(
+                kind=EnumProbeTargetDisagreement.MISMATCH,
+                target_name=declared.target_name,
+                detail=(
+                    f"locus_kind: stamped {stamped.locus_kind.value!r} != "
+                    f"declared {declared.locus_kind.value!r} -- selecting a "
+                    "shared transport does not relocate execution (OMN-17295)"
+                ),
+            )
+
+    if declared.execution_locus is not None:
+        compared.append("execution_locus")
+        if stamped.execution_locus != declared.execution_locus:
+            raise ProbeTargetMismatchError(
+                kind=EnumProbeTargetDisagreement.MISMATCH,
+                target_name=declared.target_name,
+                detail=(
+                    f"execution_locus: stamped {stamped.execution_locus!r} != "
+                    f"declared {declared.execution_locus!r}"
+                ),
+            )
+
+    for name in sorted(declared.packages):
+        expected = declared.packages[name]
+        compared.append(f"package:{name}")
+        entry = stamped.package(name)
+        if entry is None:
+            raise ProbeTargetMismatchError(
+                kind=EnumProbeTargetDisagreement.UNKNOWN,
+                target_name=declared.target_name,
+                detail=(
+                    f"package {name!r}: the target declares commit "
+                    f"{expected} but the stamp is silent about this package, "
+                    "so whether the code under test was present cannot be "
+                    "determined -- restamp with this package included"
+                ),
+            )
+        if entry.commit is None:
+            raise ProbeTargetMismatchError(
+                kind=EnumProbeTargetDisagreement.UNKNOWN,
+                target_name=declared.target_name,
+                detail=(
+                    f"package {name!r}: the target declares commit "
+                    f"{expected} but the stamp names no commit "
+                    f"(source={entry.source.value}, version="
+                    f"{entry.version!r}) -- a version string is not evidence "
+                    "of content"
+                ),
+            )
+        if entry.commit != expected:
+            raise ProbeTargetMismatchError(
+                kind=EnumProbeTargetDisagreement.MISMATCH,
+                target_name=declared.target_name,
+                detail=(
+                    f"package {name!r}: stamped {entry.commit} != declared "
+                    f"{expected} -- the executing code is not the code the "
+                    "target declares it is running"
+                ),
+            )
+
+    return ModelProbeTargetVerdict(
+        target_name=declared.target_name,
+        declared_by=declared.declared_by,
+        compared_fields=compared,
+    )

--- a/src/omnibase_core/validation/validator_receipt_runtime_identity.py
+++ b/src/omnibase_core/validation/validator_receipt_runtime_identity.py
@@ -372,9 +372,24 @@ def main(argv: list[str] | None = None) -> int:
         candidates = [p for p in sorted(root.rglob("*.json")) if _is_scannable(p)]
         target = str(root)
     else:
-        # NoReturn: argparse exits 2. Kept as the only "no target" path so a
-        # mis-wired hook fails loudly instead of scanning nothing and passing.
-        parser.error("pass receipt files, or --receipts-dir")
+        # The only "no target" path, so a mis-wired hook fails loudly instead
+        # of scanning nothing and reporting success — a gate that passes
+        # because it was handed nothing is the vacuous-PASS failure class this
+        # validator exists to close (OMN-14531).
+        #
+        # Spelled as an explicit usage-print + return rather than argparse's
+        # parser.error(): error() terminates only by convention, which left
+        # `candidates` and `target` provably-unbound to static analysis (CodeQL
+        # py/uninitialized-local-variable, 3 alerts on PR #1634). A validator
+        # whose own no-target path can raise UnboundLocalError fails in the
+        # least legible way available to it — the operator sees a traceback
+        # instead of the refusal the gate meant to give.
+        parser.print_usage(sys.stderr)
+        print(
+            "ERROR: pass receipt files, or --receipts-dir",
+            file=sys.stderr,
+        )
+        return 2
 
     violations = scan_receipt_files(candidates, required_packages=required)
     receipts = count_receipts(candidates)

--- a/src/omnibase_core/validation/validator_receipt_runtime_identity.py
+++ b/src/omnibase_core/validation/validator_receipt_runtime_identity.py
@@ -1,0 +1,401 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Runtime-identity gate for committed receipts (OMN-17308, epic OMN-17306).
+
+The second of two enforcement layers. The first is the type itself:
+:class:`~omnibase_core.models.dispatch.model_skill_result.ModelSkillResult`
+refuses to CONSTRUCT a receipt at schema >= 1.1.0 without a
+``runtime_identity`` block, so no emitting code path can produce one. This
+module covers the artifacts -- receipt JSON that has been committed to a repo
+as evidence, which may have been written by an older build, hand-edited, or
+copied in from elsewhere.
+
+## Rules
+
+* ``MISSING_IDENTITY`` -- at/above the requiring schema version with no block.
+* ``INCOMPLETE_IDENTITY`` -- a required distribution is absent from
+  ``packages``. Silence about a package is not the same as recording it as
+  ABSENT; the first is a gap, the second is a fact.
+* ``UNRESOLVED_COMMIT`` -- an entry claims ``source: vcs`` and names no commit.
+  Declaring a git origin while being unable to identify the content is the
+  OMN-17291 shape: a fresh ``0.38.16`` label over ``omnimarket`` content 11
+  commits behind ``origin/dev``.
+* ``MALFORMED_RECEIPT`` -- unparseable. Fails closed; an unreadable receipt is
+  never treated as an absent one, because "the checker could not read it" was
+  itself a pass condition in several of the surfaces this epic replaces.
+
+## Grandfathering
+
+A receipt whose ``schema_version`` is below
+:data:`~omnibase_core.models.dispatch.model_skill_result.RUNTIME_IDENTITY_REQUIRED_FROM`
+predates the requirement and PASSES. History is never rewritten: back-filling
+an identity onto an old receipt would fabricate a claim about a process nobody
+observed. Grandfathering is by version rather than by an allowlist so it
+expires on its own as old receipts age out, with no file to prune.
+
+CLI::
+
+    python -m omnibase_core.validation.validator_receipt_runtime_identity \\
+        --receipts-dir docs/evidence/receipts
+    python -m omnibase_core.validation.validator_receipt_runtime_identity a.json b.json
+
+Exit 0 clean, exit 1 on any violation. Wired as a pre-commit hook
+(``check-receipt-runtime-identity``) and as the ``receipt-runtime-identity``
+CI job in the same PR that introduced it -- an advisory-only check is one
+nobody adopts (operating rule 5).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+from omnibase_core.enums.enum_package_source_kind import EnumPackageSourceKind
+from omnibase_core.enums.enum_runtime_identity_rule import EnumRuntimeIdentityRule
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.dispatch.model_skill_result import (
+    RUNTIME_IDENTITY_REQUIRED_FROM,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.models.validation.model_runtime_identity_violation import (
+    ModelRuntimeIdentityViolation,
+)
+from omnibase_core.types.type_json import JsonType
+
+__all__ = [
+    "DEFAULT_REQUIRED_PACKAGES",
+    "count_receipts",
+    "main",
+    "scan_receipt_file",
+    "scan_receipt_files",
+    "scan_receipts_directory",
+]
+
+# The distributions a receipt must be able to speak about. These three decide
+# whether a receipt describes a local venv or a deployed lane: omnimarket owns
+# the node/handler set, omnibase_infra the runtime and CLI, omnibase_core the
+# models and dispatch. A stamp silent about any of them cannot settle the
+# question the whole epic exists to settle.
+DEFAULT_REQUIRED_PACKAGES: tuple[str, ...] = (
+    "omnibase_core",
+    "omnibase_infra",
+    "omnimarket",
+)
+
+# Receipts are identified structurally rather than by filename: a receipt is a
+# JSON object carrying these keys. Keeps the gate from silently skipping a
+# receipt someone named differently -- an unscanned file passing is exactly the
+# vacuous-gate shape OMN-14531 catalogued.
+_RECEIPT_MARKER_KEYS = frozenset({"skill_name", "node_name", "run_id", "status"})
+
+
+def _looks_like_receipt(payload: object) -> bool:
+    return isinstance(payload, dict) and _RECEIPT_MARKER_KEYS.issubset(payload)
+
+
+def _parse_schema_version(raw: object) -> ModelSemVer | None:
+    """Parse a receipt's ``schema_version``, tolerating both wire shapes.
+
+    Pydantic serialises ``ModelSemVer`` as an object; hand-written fixtures and
+    older tooling use the ``"1.0.0"`` string form. Returning ``None`` for
+    anything else makes an unparseable version fail closed at the call site
+    rather than defaulting to a grandfathered reading.
+    """
+    if isinstance(raw, str):
+        try:
+            return ModelSemVer.parse(raw)
+        except (ModelOnexError, ValueError, TypeError):
+            return None
+    if isinstance(raw, dict):
+        try:
+            return ModelSemVer.model_validate(raw)
+        except (ModelOnexError, ValueError, TypeError):
+            return None
+    return None
+
+
+def _packages_of(identity: dict[str, JsonType]) -> dict[str, JsonType]:
+    packages = identity.get("packages")
+    return packages if isinstance(packages, dict) else {}
+
+
+def _check_identity(
+    *,
+    path: Path,
+    identity: dict[str, JsonType],
+    required_packages: Sequence[str],
+) -> list[ModelRuntimeIdentityViolation]:
+    violations: list[ModelRuntimeIdentityViolation] = []
+    packages = _packages_of(identity)
+
+    missing = [name for name in required_packages if name not in packages]
+    if missing:
+        violations.append(
+            ModelRuntimeIdentityViolation(
+                path=str(path),
+                rule=EnumRuntimeIdentityRule.INCOMPLETE_IDENTITY,
+                detail=(
+                    "runtime_identity.packages is silent about "
+                    f"{', '.join(sorted(missing))}. Record the distribution "
+                    "explicitly -- source 'absent' is a fact, omission is a "
+                    "gap."
+                ),
+            )
+        )
+
+    for name in sorted(packages):
+        entry = packages[name]
+        if not isinstance(entry, dict):
+            violations.append(
+                ModelRuntimeIdentityViolation(
+                    path=str(path),
+                    rule=EnumRuntimeIdentityRule.MALFORMED_RECEIPT,
+                    detail=(f"runtime_identity.packages[{name!r}] is not an object"),
+                )
+            )
+            continue
+        if entry.get("source") == EnumPackageSourceKind.SHADOWED.value:
+            violations.append(
+                ModelRuntimeIdentityViolation(
+                    path=str(path),
+                    rule=EnumRuntimeIdentityRule.SHADOWED_IMPORT,
+                    detail=(
+                        f"package {name!r} declares source 'shadowed': install "
+                        f"metadata says version={entry.get('version')!r} but "
+                        "the interpreter imported the module from "
+                        f"{entry.get('import_path')!r}. Every version in this "
+                        "receipt names a tree that did not run."
+                    ),
+                )
+            )
+            continue
+        if entry.get("source") != EnumPackageSourceKind.VCS.value:
+            continue
+        if not entry.get("commit"):
+            violations.append(
+                ModelRuntimeIdentityViolation(
+                    path=str(path),
+                    rule=EnumRuntimeIdentityRule.UNRESOLVED_COMMIT,
+                    detail=(
+                        f"package {name!r} declares source 'vcs' but names no "
+                        f"commit (version={entry.get('version')!r}). A version "
+                        "string is a label, not evidence of content."
+                    ),
+                )
+            )
+    return violations
+
+
+def scan_receipt_file(
+    path: Path,
+    *,
+    required_packages: Sequence[str] = DEFAULT_REQUIRED_PACKAGES,
+) -> list[ModelRuntimeIdentityViolation]:
+    """Scan one JSON file; return every violation it carries.
+
+    A file that is not a receipt at all returns no violations -- the gate is
+    scoped to receipts, and a pre-commit hook is handed whatever JSON happens
+    to be staged.
+    """
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [
+            ModelRuntimeIdentityViolation(
+                path=str(path),
+                rule=EnumRuntimeIdentityRule.MALFORMED_RECEIPT,
+                detail=f"could not be read as JSON: {type(exc).__name__}: {exc}",
+            )
+        ]
+
+    if not _looks_like_receipt(payload):
+        return []
+
+    version = _parse_schema_version(payload.get("schema_version"))
+    if version is None:
+        return [
+            ModelRuntimeIdentityViolation(
+                path=str(path),
+                rule=EnumRuntimeIdentityRule.MALFORMED_RECEIPT,
+                detail=(
+                    "schema_version is missing or unparseable, so whether "
+                    "this receipt is grandfathered cannot be decided. An "
+                    "undecidable receipt fails closed."
+                ),
+            )
+        ]
+
+    if version < RUNTIME_IDENTITY_REQUIRED_FROM:
+        # Grandfathered: predates the requirement, and saying so is honest.
+        return []
+
+    identity = payload.get("runtime_identity")
+    if identity is None:
+        return [
+            ModelRuntimeIdentityViolation(
+                path=str(path),
+                rule=EnumRuntimeIdentityRule.MISSING_IDENTITY,
+                detail=(
+                    f"schema_version {version} is at or above "
+                    f"{RUNTIME_IDENTITY_REQUIRED_FROM} and carries no "
+                    "runtime_identity block, so nothing binds this evidence "
+                    "to the process that produced it."
+                ),
+            )
+        ]
+    if not isinstance(identity, dict):
+        return [
+            ModelRuntimeIdentityViolation(
+                path=str(path),
+                rule=EnumRuntimeIdentityRule.MALFORMED_RECEIPT,
+                detail="runtime_identity is present but is not an object",
+            )
+        ]
+
+    return _check_identity(
+        path=path, identity=identity, required_packages=required_packages
+    )
+
+
+def count_receipts(paths: Iterable[Path]) -> int:
+    """Return how many of ``paths`` are actually receipts.
+
+    Reported alongside every PASS so a reader can tell a clean scan from a
+    vacuous one. OMN-14531 found 16/16 sweeps passing while scanning zero
+    items; a gate that cannot say how much it looked at is indistinguishable
+    from one that looked at nothing.
+    """
+    total = 0
+    for path in paths:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if _looks_like_receipt(payload):
+            total += 1
+    return total
+
+
+def scan_receipt_files(
+    paths: Iterable[Path],
+    *,
+    required_packages: Sequence[str] = DEFAULT_REQUIRED_PACKAGES,
+) -> list[ModelRuntimeIdentityViolation]:
+    """Scan explicit files (the pre-commit ``pass_filenames`` path)."""
+    violations: list[ModelRuntimeIdentityViolation] = []
+    for path in paths:
+        violations.extend(scan_receipt_file(path, required_packages=required_packages))
+    return violations
+
+
+# Directory names never walked by a directory scan. ``.venv`` and
+# ``node_modules`` hold vendored JSON by the thousand and no committed
+# evidence; walking them would make the gate slow enough to be disabled, which
+# is the way a gate actually dies.
+_SKIPPED_DIR_NAMES = frozenset({"node_modules", "__pycache__"})
+
+
+def _is_scannable(path: Path) -> bool:
+    return not any(
+        part in _SKIPPED_DIR_NAMES or part.startswith(".") for part in path.parent.parts
+    )
+
+
+def scan_receipts_directory(
+    root: Path,
+    *,
+    required_packages: Sequence[str] = DEFAULT_REQUIRED_PACKAGES,
+) -> list[ModelRuntimeIdentityViolation]:
+    """Scan every committed-looking ``*.json`` under ``root`` (the CI path).
+
+    Hidden directories (``.venv``, ``.git``, ``.mypy_cache``) and vendored
+    trees are skipped; nothing committed as evidence lives in them.
+    """
+    candidates = sorted(p for p in root.rglob("*.json") if _is_scannable(p))
+    return scan_receipt_files(candidates, required_packages=required_packages)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: exit non-zero on any runtime-identity violation.
+
+    Exit codes:
+        0 -- clean (including "every receipt found was grandfathered")
+        1 -- one or more violations, each printed with rule + detail
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Runtime-identity gate (OMN-17308): fail receipts at schema "
+            f">= {RUNTIME_IDENTITY_REQUIRED_FROM} that do not identify the "
+            "process that produced them."
+        )
+    )
+    parser.add_argument(
+        "--receipts-dir",
+        default=None,
+        help="Directory tree to scan for *.json receipts.",
+    )
+    parser.add_argument(
+        "--require-package",
+        action="append",
+        default=None,
+        metavar="DIST",
+        help=(
+            "Distribution a stamp must speak about. Repeatable. Default: "
+            f"{', '.join(DEFAULT_REQUIRED_PACKAGES)}."
+        ),
+    )
+    parser.add_argument(
+        "receipt_paths",
+        nargs="*",
+        help="Explicit receipt files to scan (pre-commit passes these).",
+    )
+    args = parser.parse_args(argv)
+
+    required: Sequence[str] = args.require_package or DEFAULT_REQUIRED_PACKAGES
+
+    explicit = [Path(p) for p in args.receipt_paths]
+    if explicit:
+        candidates = explicit
+        target = f"{len(explicit)} explicit file(s)"
+    elif args.receipts_dir is not None:
+        root = Path(args.receipts_dir)
+        if not root.exists():
+            print(
+                f"ERROR: --receipts-dir does not exist: {root}",
+                file=sys.stderr,
+            )
+            return 1
+        candidates = [p for p in sorted(root.rglob("*.json")) if _is_scannable(p)]
+        target = str(root)
+    else:
+        # NoReturn: argparse exits 2. Kept as the only "no target" path so a
+        # mis-wired hook fails loudly instead of scanning nothing and passing.
+        parser.error("pass receipt files, or --receipts-dir")
+
+    violations = scan_receipt_files(candidates, required_packages=required)
+    receipts = count_receipts(candidates)
+
+    if not violations:
+        print(
+            f"RUNTIME IDENTITY GATE PASSED: 0 violations across "
+            f"{receipts} receipt(s) in {len(candidates)} JSON file(s) "
+            f"under {target}"
+        )
+        return 0
+
+    print(
+        f"RUNTIME IDENTITY GATE FAILED: {len(violations)} violation(s) in {target}:\n"
+    )
+    for violation in violations:
+        print(f"  [{violation.rule.value}] {violation.path}")
+        print(f"    {violation.detail}")
+        print()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/models/dispatch/test_model_skill_result.py
+++ b/tests/unit/models/dispatch/test_model_skill_result.py
@@ -6,11 +6,14 @@
 from __future__ import annotations
 
 import hashlib
+from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 import pytest
 from pydantic import BaseModel, ConfigDict, ValidationError
 
+from omnibase_core.enums.enum_execution_locus_kind import EnumExecutionLocusKind
+from omnibase_core.enums.enum_package_source_kind import EnumPackageSourceKind
 from omnibase_core.enums.enum_skill_result_status import EnumSkillResultStatus
 from omnibase_core.models.artifacts.model_artifact_ref import ModelArtifactRef
 from omnibase_core.models.dispatch.model_skill_result import (
@@ -18,6 +21,8 @@ from omnibase_core.models.dispatch.model_skill_result import (
     ModelSkillResult,
 )
 from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.models.runtime.model_package_identity import ModelPackageIdentity
+from omnibase_core.models.runtime.model_runtime_identity import ModelRuntimeIdentity
 
 
 class StubDelegateResponse(BaseModel):
@@ -37,8 +42,32 @@ def _artifact_ref(seed: bytes = b"capture-log") -> ModelArtifactRef:
     return ModelArtifactRef(ref=f"sha256:{hashlib.sha256(seed).hexdigest()}")
 
 
+def _runtime_identity() -> ModelRuntimeIdentity:
+    """A minimal valid stamp (OMN-17308).
+
+    Required on every current-schema receipt: since 1.1.0 a receipt that does
+    not identify the process that produced it cannot be constructed.
+    """
+    return ModelRuntimeIdentity(
+        host="test-host",
+        locus_kind=EnumExecutionLocusKind.VENV,
+        execution_locus="/venvs/onex",
+        interpreter="/venvs/onex/bin/python3.13",
+        packages={
+            "omnibase_core": ModelPackageIdentity(
+                name="omnibase_core",
+                version="0.47.1",
+                commit=None,
+                source=EnumPackageSourceKind.REGISTRY,
+            ),
+        },
+        stamped_at=datetime(2026, 8, 31, tzinfo=UTC),
+    )
+
+
 def _envelope_kwargs() -> dict[str, object]:
     return {
+        "runtime_identity": _runtime_identity(),
         "skill_name": "delegate",
         "node_name": "node_delegate_skill_orchestrator",
         "status": EnumSkillResultStatus.SUCCESS,

--- a/tests/unit/models/dispatch/test_model_skill_result_runtime_identity.py
+++ b/tests/unit/models/dispatch/test_model_skill_result_runtime_identity.py
@@ -135,3 +135,36 @@ class TestGrandfathering:
         )
         assert restored == receipt
         assert restored.runtime_identity == _identity()
+
+
+class TestDocumentedExampleStaysExecutable:
+    """The module's own docstring must not teach a pattern that raises.
+
+    The 1.0.0 -> 1.1.0 bump silently invalidated the class docstring's example,
+    which constructed a receipt with no ``runtime_identity``. Nothing collected
+    doctests, so the documented example became un-runnable while still reading
+    as authoritative — a docs-shaped instance of exactly the drift epic
+    OMN-17306 exists to close (a surface asserting something the code no longer
+    does). This test executes the docstring so the example is verified rather
+    than assumed.
+    """
+
+    def test_module_doctests_execute_clean(self) -> None:
+        import doctest
+
+        from omnibase_core.models.dispatch import model_skill_result
+
+        results = doctest.testmod(
+            model_skill_result,
+            verbose=False,
+            optionflags=doctest.ELLIPSIS,
+        )
+        assert results.failed == 0, (
+            f"{results.failed} of {results.attempted} doctest example(s) in "
+            "model_skill_result failed — the documented construction pattern "
+            "no longer matches the model's own validation rules."
+        )
+        assert results.attempted > 0, (
+            "no doctest examples were executed; this guard would pass "
+            "vacuously (OMN-14531 failure class)"
+        )

--- a/tests/unit/models/dispatch/test_model_skill_result_runtime_identity.py
+++ b/tests/unit/models/dispatch/test_model_skill_result_runtime_identity.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelSkillResult must carry a runtime-identity stamp (OMN-17308).
+
+RED-first suite for epic OMN-17306. Every assertion here fails before the
+``runtime_identity`` field exists, because a receipt with no self-identification
+is currently a perfectly valid receipt — which is precisely how the OMN-16932
+probe produced a laptop-local result that read as a ``.201`` lane result.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from omnibase_core.enums.enum_execution_locus_kind import EnumExecutionLocusKind
+from omnibase_core.enums.enum_package_source_kind import EnumPackageSourceKind
+from omnibase_core.enums.enum_skill_result_status import EnumSkillResultStatus
+from omnibase_core.models.dispatch.model_skill_result import (
+    SKILL_RESULT_SCHEMA_VERSION,
+    ModelSkillResult,
+)
+from omnibase_core.models.primitives.model_semver import ModelSemVer
+from omnibase_core.models.runtime.model_package_identity import ModelPackageIdentity
+from omnibase_core.models.runtime.model_runtime_identity import ModelRuntimeIdentity
+
+
+class StubResult(BaseModel):
+    """Concrete result model standing in for a skill's typed result."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    answer: str
+
+
+def _identity() -> ModelRuntimeIdentity:
+    return ModelRuntimeIdentity(
+        host="probe-host",
+        locus_kind=EnumExecutionLocusKind.VENV,
+        execution_locus="/opt/venvs/onex",
+        interpreter="/opt/venvs/onex/bin/python3.12",
+        packages={
+            "omnimarket": ModelPackageIdentity(
+                name="omnimarket",
+                version="0.4.11",
+                commit="66b7131a3508000000000000000000000000abcd",
+                source=EnumPackageSourceKind.VCS,
+            ),
+        },
+        stamped_at=datetime(2026, 8, 31, 8, 10, 54, tzinfo=UTC),
+    )
+
+
+def _kwargs(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "skill_name": "delegate",
+        "node_name": "node_delegate_skill_orchestrator",
+        "status": EnumSkillResultStatus.SUCCESS,
+        "correlation_id": uuid4(),
+        "run_id": uuid4(),
+        "exit_code": 0,
+        "duration_ms": 1250,
+        "result": StubResult(answer="alive"),
+        "result_model": (
+            "tests.unit.models.dispatch."
+            "test_model_skill_result_runtime_identity.StubResult"
+        ),
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.unit
+class TestRuntimeIdentityRequiredAtCurrentSchema:
+    """A current-schema receipt cannot be built without self-identification."""
+
+    def test_current_schema_receipt_without_identity_is_refused(self) -> None:
+        """The core enforcement: unstamped receipts are UNCONSTRUCTABLE.
+
+        Not "detected later" — refused at construction, so no code path can
+        emit one and no artifact can carry one.
+        """
+        with pytest.raises(ValidationError) as excinfo:
+            ModelSkillResult[StubResult](**_kwargs())  # type: ignore[arg-type]
+        assert "runtime_identity" in str(excinfo.value)
+
+    def test_current_schema_receipt_with_identity_is_accepted(self) -> None:
+        receipt = ModelSkillResult[StubResult](
+            **_kwargs(runtime_identity=_identity())  # type: ignore[arg-type]
+        )
+        assert receipt.runtime_identity is not None
+        assert receipt.runtime_identity.host == "probe-host"
+
+    def test_schema_version_advanced_to_the_requiring_version(self) -> None:
+        """The bump is what makes the default construction path fail closed."""
+        assert ModelSemVer(major=1, minor=1, patch=0) <= SKILL_RESULT_SCHEMA_VERSION
+
+
+@pytest.mark.unit
+class TestGrandfathering:
+    """History is grandfathered by schema version, never rewritten."""
+
+    def test_pre_requirement_receipt_still_validates(self) -> None:
+        """A receipt stamped 1.0.0 predates the requirement and stays valid.
+
+        Rewriting old receipts to add an identity they never had would
+        manufacture the exact fiction this epic exists to stop. The honest
+        record is "this receipt predates the requirement", and the schema
+        version is what says so.
+        """
+        receipt = ModelSkillResult[StubResult](
+            **_kwargs(schema_version=ModelSemVer(major=1, minor=0, patch=0))  # type: ignore[arg-type]
+        )
+        assert receipt.runtime_identity is None
+
+    def test_grandfathered_receipt_round_trips_from_json(self) -> None:
+        receipt = ModelSkillResult[StubResult](
+            **_kwargs(schema_version=ModelSemVer(major=1, minor=0, patch=0))  # type: ignore[arg-type]
+        )
+        restored = ModelSkillResult[StubResult].model_validate_json(
+            receipt.model_dump_json()
+        )
+        assert restored == receipt
+
+    def test_stamped_receipt_round_trips_from_json(self) -> None:
+        receipt = ModelSkillResult[StubResult](
+            **_kwargs(runtime_identity=_identity())  # type: ignore[arg-type]
+        )
+        restored = ModelSkillResult[StubResult].model_validate_json(
+            receipt.model_dump_json()
+        )
+        assert restored == receipt
+        assert restored.runtime_identity == _identity()

--- a/tests/unit/models/runtime/test_model_runtime_identity.py
+++ b/tests/unit/models/runtime/test_model_runtime_identity.py
@@ -15,14 +15,14 @@ from omnibase_core.enums.enum_package_source_kind import EnumPackageSourceKind
 from omnibase_core.models.runtime.model_package_identity import ModelPackageIdentity
 from omnibase_core.models.runtime.model_runtime_identity import ModelRuntimeIdentity
 
-_SHA = "66b7131a3508" + "0" * 28
+_SHA = "66b7131a3508" + "0" * 28  # pragma: allowlist secret
 
 
 def _identity(**overrides: object) -> ModelRuntimeIdentity:
     base: dict[str, object] = {
         "host": "runtime-host",
         "locus_kind": EnumExecutionLocusKind.CONTAINER,
-        "execution_locus": "9f2c1b0e4a55",
+        "execution_locus": "9f2c1b0e4a55",  # pragma: allowlist secret
         "interpreter": "/app/.venv/bin/python3.12",
         "packages": {
             "omnimarket": ModelPackageIdentity(

--- a/tests/unit/models/runtime/test_model_runtime_identity.py
+++ b/tests/unit/models/runtime/test_model_runtime_identity.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""ModelRuntimeIdentity / ModelPackageIdentity invariants (OMN-17308)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_execution_locus_kind import EnumExecutionLocusKind
+from omnibase_core.enums.enum_package_source_kind import EnumPackageSourceKind
+from omnibase_core.models.runtime.model_package_identity import ModelPackageIdentity
+from omnibase_core.models.runtime.model_runtime_identity import ModelRuntimeIdentity
+
+_SHA = "66b7131a3508" + "0" * 28
+
+
+def _identity(**overrides: object) -> ModelRuntimeIdentity:
+    base: dict[str, object] = {
+        "host": "runtime-host",
+        "locus_kind": EnumExecutionLocusKind.CONTAINER,
+        "execution_locus": "9f2c1b0e4a55",
+        "interpreter": "/app/.venv/bin/python3.12",
+        "packages": {
+            "omnimarket": ModelPackageIdentity(
+                name="omnimarket",
+                version="0.4.11",
+                commit=_SHA,
+                source=EnumPackageSourceKind.VCS,
+            )
+        },
+        "stamped_at": datetime(2026, 8, 31, tzinfo=UTC),
+    }
+    base.update(overrides)
+    return ModelRuntimeIdentity(**base)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestPackageIdentity:
+    def test_commit_is_normalised_to_lowercase(self) -> None:
+        entry = ModelPackageIdentity(
+            name="omnimarket",
+            version="0.4.11",
+            commit=_SHA.upper(),
+            source=EnumPackageSourceKind.VCS,
+        )
+        assert entry.commit == _SHA
+
+    def test_abbreviated_commit_is_refused(self) -> None:
+        """An abbreviation is not identity — it cannot be compared for equality."""
+        with pytest.raises(ValidationError, match="40-character"):
+            ModelPackageIdentity(
+                name="omnimarket",
+                version="0.4.11",
+                commit="66b7131",
+                source=EnumPackageSourceKind.VCS,
+            )
+
+    def test_registry_install_may_carry_no_commit(self) -> None:
+        entry = ModelPackageIdentity(
+            name="omnibase_core",
+            version="0.47.1",
+            commit=None,
+            source=EnumPackageSourceKind.REGISTRY,
+        )
+        assert entry.commit is None
+
+    def test_absent_package_cannot_carry_a_version(self) -> None:
+        """'Absent' and 'stale' were indistinguishable in OMN-14060 → OMN-14531."""
+        with pytest.raises(ValidationError, match="ABSENT"):
+            ModelPackageIdentity(
+                name="omnimarket",
+                version="0.4.11",
+                commit=None,
+                source=EnumPackageSourceKind.ABSENT,
+            )
+
+
+@pytest.mark.unit
+class TestRuntimeIdentity:
+    def test_packages_key_must_match_entry_name(self) -> None:
+        with pytest.raises(ValidationError, match="mismatched"):
+            _identity(
+                packages={
+                    "omnibase_core": ModelPackageIdentity(
+                        name="omnimarket",
+                        version="0.4.11",
+                        commit=_SHA,
+                        source=EnumPackageSourceKind.VCS,
+                    )
+                }
+            )
+
+    def test_empty_package_map_is_refused(self) -> None:
+        """A stamp that names no code is not a stamp."""
+        with pytest.raises(ValidationError):
+            _identity(packages={})
+
+    def test_package_lookup_distinguishes_silence_from_absence(self) -> None:
+        identity = _identity()
+        assert identity.package("omnimarket") is not None
+        assert identity.package("omnibase_infra") is None
+
+    def test_frozen(self) -> None:
+        identity = _identity()
+        with pytest.raises(ValidationError):
+            identity.host = "other"  # type: ignore[misc]
+
+    def test_json_round_trip(self) -> None:
+        identity = _identity()
+        assert (
+            ModelRuntimeIdentity.model_validate_json(identity.model_dump_json())
+            == identity
+        )
+
+
+class TestShadowedImport:
+    """A SHADOWED entry must name the tree that actually ran (OMN-17308).
+
+    Reproduced live 2026-08-31 while verifying OMN-17310: a stamp collected
+    under ``PYTHONPATH=<core-worktree>/src`` reported
+    ``omnibase_core=0.47.1@registry`` while executing 0.47.2 worktree source.
+    Every field was individually true and the block as a whole was false.
+    """
+
+    def test_shadowed_without_import_path_is_refused(self) -> None:
+        """A shadowing claim that cannot say which tree won is unverifiable."""
+        with pytest.raises(ValidationError, match="names no import_path"):
+            ModelPackageIdentity(
+                name="omnibase_core",
+                version="0.47.1",
+                commit=None,
+                source=EnumPackageSourceKind.SHADOWED,
+            )
+
+    def test_shadowed_carrying_a_commit_is_refused(self) -> None:
+        """That commit identifies the tree the interpreter did NOT import."""
+        with pytest.raises(ValidationError, match="did NOT import"):
+            ModelPackageIdentity(
+                name="omnibase_core",
+                version="0.47.1",
+                commit=_SHA,
+                source=EnumPackageSourceKind.SHADOWED,
+                import_path="/w/core/src",
+            )
+
+    def test_shadowed_naming_the_winner_is_accepted(self) -> None:
+        entry = ModelPackageIdentity(
+            name="omnibase_core",
+            version="0.47.1",
+            commit=None,
+            source=EnumPackageSourceKind.SHADOWED,
+            import_path="/w/core/src/omnibase_core",
+        )
+        assert entry.import_path == "/w/core/src/omnibase_core"
+        assert entry.commit is None
+
+    def test_import_path_defaults_to_none_when_metadata_and_import_agree(
+        self,
+    ) -> None:
+        entry = ModelPackageIdentity(
+            name="omnibase_core",
+            version="0.47.1",
+            commit=_SHA,
+            source=EnumPackageSourceKind.VCS,
+        )
+        assert entry.import_path is None

--- a/tests/unit/validation/test_probe_target_assertion.py
+++ b/tests/unit/validation/test_probe_target_assertion.py
@@ -32,9 +32,9 @@ from omnibase_core.validation.validator_probe_target import (
 )
 
 # The pre-fix omnimarket the local venv was pinned to (OMN-17295).
-_LOCAL_MARKET_COMMIT = "66b7131a3508" + "0" * 28
+_LOCAL_MARKET_COMMIT = "66b7131a3508" + "0" * 28  # pragma: allowlist secret
 # origin/dev's tip, which the dev lane was correctly vendored at.
-_LANE_MARKET_COMMIT = "2f123b4c01ea" + "0" * 28
+_LANE_MARKET_COMMIT = "2f123b4c01ea" + "0" * 28  # pragma: allowlist secret
 
 
 def _local_venv_stamp(
@@ -67,7 +67,7 @@ def _lane_stamp() -> ModelRuntimeIdentity:
     return ModelRuntimeIdentity(
         host="omninode-runtime",
         locus_kind=EnumExecutionLocusKind.CONTAINER,
-        execution_locus="9f2c1b0e4a55",
+        execution_locus="9f2c1b0e4a55",  # pragma: allowlist secret
         interpreter="/app/.venv/bin/python3.12",
         packages={
             "omnimarket": ModelPackageIdentity(
@@ -87,7 +87,7 @@ def _lane_declaration(**overrides: object) -> ModelDeclaredTargetIdentity:
         "declared_by": "docker exec omninode-runtime cat /app/build-provenance.json",
         "host": "omninode-runtime",
         "locus_kind": EnumExecutionLocusKind.CONTAINER,
-        "execution_locus": "9f2c1b0e4a55",
+        "execution_locus": "9f2c1b0e4a55",  # pragma: allowlist secret
         "packages": {"omnimarket": _LANE_MARKET_COMMIT},
     }
     base.update(overrides)
@@ -116,7 +116,7 @@ class TestRefusals:
                 "omnimarket": ModelPackageIdentity(
                     name="omnimarket",
                     version="0.4.11",
-                    commit="05e3882f9e2a" + "0" * 28,
+                    commit="05e3882f9e2a" + "0" * 28,  # pragma: allowlist secret
                     source=EnumPackageSourceKind.VCS,
                 ),
             },

--- a/tests/unit/validation/test_probe_target_assertion.py
+++ b/tests/unit/validation/test_probe_target_assertion.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Probe-target assertion (OMN-17312).
+
+The falsifier suite for epic OMN-17306's third leg. The headline case replays
+the real 2026-08-31T08:10:54Z probe (correlation
+``b9cd305c-8f31-497a-b404-b75b45b98341``): published over the ``.201`` broker,
+read as a dev-lane result, executed entirely inside the operator's local venv
+on pre-fix ``omnimarket``. It printed a confident answer and proved nothing.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from omnibase_core.enums.enum_execution_locus_kind import EnumExecutionLocusKind
+from omnibase_core.enums.enum_package_source_kind import EnumPackageSourceKind
+from omnibase_core.enums.enum_probe_target_disagreement import (
+    EnumProbeTargetDisagreement,
+)
+from omnibase_core.models.runtime.model_declared_target_identity import (
+    ModelDeclaredTargetIdentity,
+)
+from omnibase_core.models.runtime.model_package_identity import ModelPackageIdentity
+from omnibase_core.models.runtime.model_runtime_identity import ModelRuntimeIdentity
+from omnibase_core.validation.validator_probe_target import (
+    ProbeTargetMismatchError,
+    assert_probe_target,
+)
+
+# The pre-fix omnimarket the local venv was pinned to (OMN-17295).
+_LOCAL_MARKET_COMMIT = "66b7131a3508" + "0" * 28
+# origin/dev's tip, which the dev lane was correctly vendored at.
+_LANE_MARKET_COMMIT = "2f123b4c01ea" + "0" * 28
+
+
+def _local_venv_stamp(
+    *, market_commit: str | None = _LOCAL_MARKET_COMMIT
+) -> ModelRuntimeIdentity:
+    return ModelRuntimeIdentity(
+        host="operator-macbook",
+        locus_kind=EnumExecutionLocusKind.VENV,
+        # The laptop-shaped venv prefix IS the datum under test: this fixture
+        # reproduces the OMN-17295 stamp the assertion must reject.
+        execution_locus="/Users/example/omni_home/omnibase_infra/.venv",  # local-path-ok
+        interpreter="/Users/example/omni_home/omnibase_infra/.venv/bin/python3.12",  # local-path-ok
+        packages={
+            "omnimarket": ModelPackageIdentity(
+                name="omnimarket",
+                version="0.4.11",
+                commit=market_commit,
+                source=(
+                    EnumPackageSourceKind.VCS
+                    if market_commit
+                    else EnumPackageSourceKind.REGISTRY
+                ),
+            ),
+        },
+        stamped_at=datetime(2026, 8, 31, 8, 10, 54, tzinfo=UTC),
+    )
+
+
+def _lane_stamp() -> ModelRuntimeIdentity:
+    return ModelRuntimeIdentity(
+        host="omninode-runtime",
+        locus_kind=EnumExecutionLocusKind.CONTAINER,
+        execution_locus="9f2c1b0e4a55",
+        interpreter="/app/.venv/bin/python3.12",
+        packages={
+            "omnimarket": ModelPackageIdentity(
+                name="omnimarket",
+                version="0.4.11",
+                commit=_LANE_MARKET_COMMIT,
+                source=EnumPackageSourceKind.VCS,
+            ),
+        },
+        stamped_at=datetime(2026, 8, 31, 8, 10, 54, tzinfo=UTC),
+    )
+
+
+def _lane_declaration(**overrides: object) -> ModelDeclaredTargetIdentity:
+    base: dict[str, object] = {
+        "target_name": "dev lane (.201, omnibase-infra)",
+        "declared_by": "docker exec omninode-runtime cat /app/build-provenance.json",
+        "host": "omninode-runtime",
+        "locus_kind": EnumExecutionLocusKind.CONTAINER,
+        "execution_locus": "9f2c1b0e4a55",
+        "packages": {"omnimarket": _LANE_MARKET_COMMIT},
+    }
+    base.update(overrides)
+    return ModelDeclaredTargetIdentity(**base)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestRefusals:
+    def test_local_venv_stamp_against_lane_declaration_is_refused(self) -> None:
+        """THE case: a laptop-local run claiming to prove the .201 dev lane."""
+        with pytest.raises(ProbeTargetMismatchError) as excinfo:
+            assert_probe_target(
+                stamped=_local_venv_stamp(), declared=_lane_declaration()
+            )
+        assert excinfo.value.kind is EnumProbeTargetDisagreement.MISMATCH
+        assert "host" in excinfo.value.detail
+
+    def test_stale_package_commit_is_refused(self) -> None:
+        """Right host, right container, wrong code — the OMN-17291 shape."""
+        stamped = ModelRuntimeIdentity(
+            host="omninode-runtime",
+            locus_kind=EnumExecutionLocusKind.CONTAINER,
+            execution_locus="9f2c1b0e4a55",
+            interpreter="/app/.venv/bin/python3.12",
+            packages={
+                "omnimarket": ModelPackageIdentity(
+                    name="omnimarket",
+                    version="0.4.11",
+                    commit="05e3882f9e2a" + "0" * 28,
+                    source=EnumPackageSourceKind.VCS,
+                ),
+            },
+            stamped_at=datetime(2026, 8, 31, 5, 38, 22, tzinfo=UTC),
+        )
+        with pytest.raises(ProbeTargetMismatchError) as excinfo:
+            assert_probe_target(stamped=stamped, declared=_lane_declaration())
+        assert excinfo.value.kind is EnumProbeTargetDisagreement.MISMATCH
+        assert "omnimarket" in excinfo.value.detail
+
+    def test_unresolvable_commit_is_refused_as_unknown(self) -> None:
+        """'I cannot tell' fails on the same terms as 'it ran elsewhere'."""
+        stamped = ModelRuntimeIdentity(
+            host="omninode-runtime",
+            locus_kind=EnumExecutionLocusKind.CONTAINER,
+            execution_locus="9f2c1b0e4a55",
+            interpreter="/app/.venv/bin/python3.12",
+            packages={
+                "omnimarket": ModelPackageIdentity(
+                    name="omnimarket",
+                    version="0.4.11",
+                    commit=None,
+                    source=EnumPackageSourceKind.REGISTRY,
+                ),
+            },
+            stamped_at=datetime(2026, 8, 31, tzinfo=UTC),
+        )
+        with pytest.raises(ProbeTargetMismatchError) as excinfo:
+            assert_probe_target(stamped=stamped, declared=_lane_declaration())
+        assert excinfo.value.kind is EnumProbeTargetDisagreement.UNKNOWN
+        assert "not evidence of content" in excinfo.value.detail
+
+    def test_package_absent_from_stamp_is_unknown_not_pass(self) -> None:
+        stamped = ModelRuntimeIdentity(
+            host="omninode-runtime",
+            locus_kind=EnumExecutionLocusKind.CONTAINER,
+            execution_locus="9f2c1b0e4a55",
+            interpreter="/app/.venv/bin/python3.12",
+            packages={
+                "omnibase_core": ModelPackageIdentity(
+                    name="omnibase_core",
+                    version="0.47.1",
+                    commit=None,
+                    source=EnumPackageSourceKind.REGISTRY,
+                ),
+            },
+            stamped_at=datetime(2026, 8, 31, tzinfo=UTC),
+        )
+        with pytest.raises(ProbeTargetMismatchError) as excinfo:
+            assert_probe_target(stamped=stamped, declared=_lane_declaration())
+        assert excinfo.value.kind is EnumProbeTargetDisagreement.UNKNOWN
+
+    def test_empty_declaration_is_refused(self) -> None:
+        """A comparison of zero fields must never report success."""
+        declaration = ModelDeclaredTargetIdentity(
+            target_name="dev lane",
+            declared_by="operator intent",
+        )
+        with pytest.raises(ProbeTargetMismatchError) as excinfo:
+            assert_probe_target(stamped=_lane_stamp(), declared=declaration)
+        assert excinfo.value.kind is EnumProbeTargetDisagreement.EMPTY_DECLARATION
+
+    def test_locus_kind_mismatch_is_refused(self) -> None:
+        with pytest.raises(ProbeTargetMismatchError) as excinfo:
+            assert_probe_target(
+                stamped=_local_venv_stamp(),
+                declared=_lane_declaration(host=None, execution_locus=None),
+            )
+        assert excinfo.value.kind is EnumProbeTargetDisagreement.MISMATCH
+        assert "does not relocate execution" in excinfo.value.detail
+
+
+@pytest.mark.unit
+class TestAcceptance:
+    def test_matching_stamp_returns_a_non_vacuous_verdict(self) -> None:
+        verdict = assert_probe_target(
+            stamped=_lane_stamp(), declared=_lane_declaration()
+        )
+        assert verdict.target_name == "dev lane (.201, omnibase-infra)"
+        assert verdict.compared_fields == [
+            "host",
+            "locus_kind",
+            "execution_locus",
+            "package:omnimarket",
+        ]
+
+    def test_verdict_records_the_declaring_surface(self) -> None:
+        verdict = assert_probe_target(
+            stamped=_lane_stamp(), declared=_lane_declaration()
+        )
+        assert "build-provenance.json" in verdict.declared_by
+
+
+@pytest.mark.unit
+class TestDeclarationValidation:
+    def test_abbreviated_commit_is_refused_at_the_model_boundary(self) -> None:
+        with pytest.raises(ValueError, match="40-character"):
+            ModelDeclaredTargetIdentity(
+                target_name="dev lane",
+                declared_by="build-provenance.json",
+                packages={"omnimarket": "2f123b4"},
+            )

--- a/tests/unit/validation/test_probe_target_assertion.py
+++ b/tests/unit/validation/test_probe_target_assertion.py
@@ -110,7 +110,7 @@ class TestRefusals:
         stamped = ModelRuntimeIdentity(
             host="omninode-runtime",
             locus_kind=EnumExecutionLocusKind.CONTAINER,
-            execution_locus="9f2c1b0e4a55",
+            execution_locus="9f2c1b0e4a55",  # pragma: allowlist secret
             interpreter="/app/.venv/bin/python3.12",
             packages={
                 "omnimarket": ModelPackageIdentity(
@@ -132,7 +132,7 @@ class TestRefusals:
         stamped = ModelRuntimeIdentity(
             host="omninode-runtime",
             locus_kind=EnumExecutionLocusKind.CONTAINER,
-            execution_locus="9f2c1b0e4a55",
+            execution_locus="9f2c1b0e4a55",  # pragma: allowlist secret
             interpreter="/app/.venv/bin/python3.12",
             packages={
                 "omnimarket": ModelPackageIdentity(
@@ -153,7 +153,7 @@ class TestRefusals:
         stamped = ModelRuntimeIdentity(
             host="omninode-runtime",
             locus_kind=EnumExecutionLocusKind.CONTAINER,
-            execution_locus="9f2c1b0e4a55",
+            execution_locus="9f2c1b0e4a55",  # pragma: allowlist secret
             interpreter="/app/.venv/bin/python3.12",
             packages={
                 "omnibase_core": ModelPackageIdentity(

--- a/tests/unit/validation/test_receipt_runtime_identity_gate.py
+++ b/tests/unit/validation/test_receipt_runtime_identity_gate.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Runtime-identity gate over committed receipts (OMN-17308)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from omnibase_core.enums.enum_runtime_identity_rule import EnumRuntimeIdentityRule
+from omnibase_core.validation.validator_receipt_runtime_identity import (
+    DEFAULT_REQUIRED_PACKAGES,
+    main,
+    scan_receipt_file,
+    scan_receipts_directory,
+)
+
+
+def _identity(**overrides: Any) -> dict[str, Any]:
+    packages: dict[str, Any] = {
+        name: {
+            "name": name,
+            "version": "0.0.1",
+            "commit": "a" * 40,
+            "source": "vcs",
+        }
+        for name in DEFAULT_REQUIRED_PACKAGES
+    }
+    base: dict[str, Any] = {
+        "host": "runtime-host",
+        "locus_kind": "container",
+        "execution_locus": "9f2c1b0e4a55",
+        "interpreter": "/app/.venv/bin/python3.12",
+        "packages": packages,
+        "config_source": "/app/contracts/node.yaml",
+        "stamped_at": "2026-08-31T08:10:54Z",
+        "schema_version": {"major": 1, "minor": 0, "patch": 0},
+    }
+    base.update(overrides)
+    return base
+
+
+def _receipt(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "skill_name": "delegate",
+        "node_name": "node_delegate_skill_orchestrator",
+        "status": "success",
+        "correlation_id": "b9cd305c-8f31-497a-b404-b75b45b98341",
+        "run_id": "0f0f0f0f-0000-4000-8000-000000000000",
+        "exit_code": 0,
+        "duration_ms": 12,
+        "result": {"answer": "alive"},
+        "result_model": "pkg.mod.ModelStub",
+        "schema_version": {"major": 1, "minor": 1, "patch": 0},
+        "runtime_identity": _identity(),
+    }
+    base.update(overrides)
+    return base
+
+
+def _write(tmp_path: Path, payload: object, name: str = "receipt.json") -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+@pytest.mark.unit
+class TestGatePasses:
+    def test_complete_stamp_is_clean(self, tmp_path: Path) -> None:
+        assert scan_receipt_file(_write(tmp_path, _receipt())) == []
+
+    def test_grandfathered_receipt_passes_without_identity(
+        self, tmp_path: Path
+    ) -> None:
+        """A pre-1.1.0 receipt predates the requirement and is left alone.
+
+        The alternative -- back-filling an identity -- would invent a claim
+        about a process nobody observed, which is the failure mode the gate
+        exists to prevent, committed by the gate itself.
+        """
+        payload = _receipt(
+            schema_version={"major": 1, "minor": 0, "patch": 0},
+        )
+        del payload["runtime_identity"]
+        assert scan_receipt_file(_write(tmp_path, payload)) == []
+
+    def test_absent_package_is_a_fact_not_a_gap(self, tmp_path: Path) -> None:
+        """source 'absent' satisfies the gate; omitting the key does not."""
+        identity = _identity()
+        identity["packages"]["omnimarket"] = {
+            "name": "omnimarket",
+            "version": None,
+            "commit": None,
+            "source": "absent",
+        }
+        assert (
+            scan_receipt_file(_write(tmp_path, _receipt(runtime_identity=identity)))
+            == []
+        )
+
+    def test_registry_install_without_commit_is_allowed(self, tmp_path: Path) -> None:
+        """A PyPI wheel genuinely has no commit; saying so is honest."""
+        identity = _identity()
+        identity["packages"]["omnibase_core"] = {
+            "name": "omnibase_core",
+            "version": "0.47.1",
+            "commit": None,
+            "source": "registry",
+        }
+        assert (
+            scan_receipt_file(_write(tmp_path, _receipt(runtime_identity=identity)))
+            == []
+        )
+
+    def test_non_receipt_json_is_ignored(self, tmp_path: Path) -> None:
+        assert scan_receipt_file(_write(tmp_path, {"unrelated": True})) == []
+
+
+@pytest.mark.unit
+class TestGateFails:
+    def test_missing_identity_at_current_schema(self, tmp_path: Path) -> None:
+        payload = _receipt()
+        del payload["runtime_identity"]
+        violations = scan_receipt_file(_write(tmp_path, payload))
+        assert [v.rule for v in violations] == [
+            EnumRuntimeIdentityRule.MISSING_IDENTITY
+        ]
+
+    def test_required_package_omitted(self, tmp_path: Path) -> None:
+        identity = _identity()
+        del identity["packages"]["omnimarket"]
+        violations = scan_receipt_file(
+            _write(tmp_path, _receipt(runtime_identity=identity))
+        )
+        assert [v.rule for v in violations] == [
+            EnumRuntimeIdentityRule.INCOMPLETE_IDENTITY
+        ]
+        assert "omnimarket" in violations[0].detail
+
+    def test_vcs_source_without_commit(self, tmp_path: Path) -> None:
+        """The OMN-17291 shape: a git claim that cannot name its content."""
+        identity = _identity()
+        identity["packages"]["omnimarket"]["commit"] = None
+        violations = scan_receipt_file(
+            _write(tmp_path, _receipt(runtime_identity=identity))
+        )
+        assert [v.rule for v in violations] == [
+            EnumRuntimeIdentityRule.UNRESOLVED_COMMIT
+        ]
+
+    def test_shadowed_import_is_a_violation(self, tmp_path: Path) -> None:
+        """Every version in the receipt names a tree that did not run.
+
+        Reproduced live 2026-08-31 while verifying OMN-17310: a stamp taken
+        under ``PYTHONPATH=<core-worktree>/src`` reported
+        ``omnibase_core=0.47.1@registry`` while 0.47.2 worktree source was
+        what actually executed.
+        """
+        identity = _identity()
+        identity["packages"]["omnibase_core"].update(
+            {
+                "source": "shadowed",
+                "commit": None,
+                "import_path": "/w/OMN-17308/omnibase_core/src/omnibase_core",
+            }
+        )
+        violations = scan_receipt_file(
+            _write(tmp_path, _receipt(runtime_identity=identity))
+        )
+        assert [v.rule for v in violations] == [EnumRuntimeIdentityRule.SHADOWED_IMPORT]
+        assert "/w/OMN-17308/omnibase_core/src/omnibase_core" in violations[0].detail
+
+    def test_unparseable_schema_version_fails_closed(self, tmp_path: Path) -> None:
+        payload = _receipt(schema_version="not-a-version")
+        del payload["runtime_identity"]
+        violations = scan_receipt_file(_write(tmp_path, payload))
+        assert [v.rule for v in violations] == [
+            EnumRuntimeIdentityRule.MALFORMED_RECEIPT
+        ]
+
+    def test_unreadable_json_fails_closed(self, tmp_path: Path) -> None:
+        path = tmp_path / "broken.json"
+        path.write_text("{not json", encoding="utf-8")
+        violations = scan_receipt_file(path)
+        assert [v.rule for v in violations] == [
+            EnumRuntimeIdentityRule.MALFORMED_RECEIPT
+        ]
+
+
+@pytest.mark.unit
+class TestCli:
+    def test_directory_scan_exit_codes(self, tmp_path: Path) -> None:
+        _write(tmp_path, _receipt(), name="good.json")
+        assert main(["--receipts-dir", str(tmp_path)]) == 0
+
+        bad = _receipt()
+        del bad["runtime_identity"]
+        _write(tmp_path, bad, name="bad.json")
+        assert main(["--receipts-dir", str(tmp_path)]) == 1
+
+    def test_explicit_files_exit_nonzero(self, tmp_path: Path) -> None:
+        payload = _receipt()
+        del payload["runtime_identity"]
+        path = _write(tmp_path, payload)
+        assert main([str(path)]) == 1
+
+    def test_missing_directory_is_an_error(self, tmp_path: Path) -> None:
+        assert main(["--receipts-dir", str(tmp_path / "nope")]) == 1
+
+    def test_required_package_set_is_overridable(self, tmp_path: Path) -> None:
+        identity = _identity()
+        del identity["packages"]["omnimarket"]
+        path = _write(tmp_path, _receipt(runtime_identity=identity))
+        assert main([str(path)]) == 1
+        assert (
+            main(
+                [
+                    "--require-package",
+                    "omnibase_core",
+                    "--require-package",
+                    "omnibase_infra",
+                    str(path),
+                ]
+            )
+            == 0
+        )
+
+    def test_directory_scan_is_recursive(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+        bad = _receipt()
+        del bad["runtime_identity"]
+        _write(nested, bad, name="deep.json")
+        assert len(scan_receipts_directory(tmp_path)) == 1
+
+
+@pytest.mark.unit
+class TestCommittedGoldens:
+    """The golden receipts under docs/evidence/ must stay real receipts.
+
+    They exist so the CI directory scan is non-vacuous. If they rot into
+    non-receipts, the gate silently returns to scanning nothing while still
+    reporting PASS — the OMN-14531 shape it is meant to avoid.
+    """
+
+    # Resolved from this file, never from the CWD (operating rule 6): a
+    # CWD-relative fixture path is how a suite quietly stops finding its
+    # fixtures and starts passing on an empty glob.
+    GOLDEN_DIR = (
+        Path(__file__).resolve().parents[3] / "docs" / "evidence" / "runtime-identity"
+    )
+
+    def test_goldens_are_recognised_and_clean(self) -> None:
+        violations = scan_receipts_directory(self.GOLDEN_DIR)
+        assert violations == []
+
+    def test_goldens_validate_against_the_real_receipt_model(self) -> None:
+        from omnibase_core.models.dispatch.model_skill_result import ModelSkillResult
+
+        paths = sorted(self.GOLDEN_DIR.glob("*.golden.json"))
+        assert len(paths) == 2
+        for path in paths:
+            ModelSkillResult.model_validate_json(path.read_text(encoding="utf-8"))
+
+    def test_scan_actually_saw_two_receipts(self) -> None:
+        from omnibase_core.validation.validator_receipt_runtime_identity import (
+            count_receipts,
+        )
+
+        assert count_receipts(sorted(self.GOLDEN_DIR.glob("*.json"))) == 2

--- a/tests/unit/validation/test_receipt_runtime_identity_gate.py
+++ b/tests/unit/validation/test_receipt_runtime_identity_gate.py
@@ -33,7 +33,7 @@ def _identity(**overrides: Any) -> dict[str, Any]:
     base: dict[str, Any] = {
         "host": "runtime-host",
         "locus_kind": "container",
-        "execution_locus": "9f2c1b0e4a55",
+        "execution_locus": "9f2c1b0e4a55",  # pragma: allowlist secret
         "interpreter": "/app/.venv/bin/python3.12",
         "packages": packages,
         "config_source": "/app/contracts/node.yaml",
@@ -272,3 +272,34 @@ class TestCommittedGoldens:
         )
 
         assert count_receipts(sorted(self.GOLDEN_DIR.glob("*.json"))) == 2
+
+
+class TestNoTargetPathRefusesLegibly:
+    """Handed no target at all, the gate refuses — it never crashes.
+
+    Previously this branch relied on ``argparse.ArgumentParser.error()`` to
+    terminate, which is true at runtime but not provable statically: CodeQL
+    reported three ``py/uninitialized-local-variable`` errors on PR #1634 for
+    ``candidates`` and ``target``. A validator whose own no-target path can
+    raise ``UnboundLocalError`` shows the operator a traceback instead of the
+    refusal it meant to give — and a traceback is much easier to wave off as
+    "the tool is broken" than an explicit refusal is.
+
+    The load-bearing assertion is that it is a REFUSAL (non-zero), never a
+    pass. A gate that reports success because it was handed nothing to scan is
+    the vacuous-PASS failure class (OMN-14531).
+    """
+
+    def test_no_arguments_refuses_without_raising(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code = main([])
+
+        assert exit_code != 0, (
+            "the gate reported success while scanning nothing — a vacuous PASS"
+        )
+        assert exit_code == 2
+        stderr = capsys.readouterr().err
+        assert "--receipts-dir" in stderr, (
+            "the refusal must name how to give the gate a target"
+        )

--- a/tests/validation/test_validator_requirements_consumer.py
+++ b/tests/validation/test_validator_requirements_consumer.py
@@ -344,6 +344,12 @@ def test_report_exit_code_zero_on_clean_repo(tmp_path: Path, spec_data: dict) ->
         "check-doc-content-scan",  # OMN-13572: doc-content scan (applies_to_repos: [omnibase_core])
         "no-new-os-environ",  # OMN-13566: canonical AST env-read gate (applies_to_repos: [omnibase_core])
         "check-duplicate-registry-ids",  # OMN-14401: duplicate registry id guard (applies_to_repos: [omnibase_core])
+        # OMN-17308: runtime-identity gate. Two entries because this list
+        # doubles as the synthetic repo's pre-commit hook ids AND its CI step
+        # names: the first satisfies pre_commit_hook_ids, the second matches
+        # the ci_workflow_keywords (the ci.yml job id).
+        "check-receipt-runtime-identity",
+        "runtime-identity-validator",
     ]
     _write_precommit(tmp_path, pre_commit_ids)
 


### PR DESCRIPTION
Closes OMN-17308. Child 1 of epic OMN-17306, and the pure-compare half of OMN-17312.

## The class this closes

Operator, 2026-08-31: *"how do we prevent this from happening again"*. Four stale-surface incidents in one week, one defect: **a version string was read as evidence of content, and the execution that produced the evidence never said what it actually was.**

| Incident | The lie |
| -- | -- |
| OMN-16932 / OMN-17295 | A Mac venv pinning `omnimarket 0.4.11` produced a probe read as a `.201` dev-lane result. The lane's logs had **zero** hits for the correlation id. |
| OMN-17291 | A lane container wore a fresh `0.38.16` registry label over `omnimarket` content 11 commits behind `origin/dev`. |
| OMN-17190 | A stale `onex` on PATH executed silently in place of the binary under test. |
| OMN-17291 defect 1 | A clone sync reported success without moving — `core.bare=true` makes `fetch` exit 0 while `checkout` exits 128. |

Every one was caught by a human diffing `direct_url.json` against `origin/dev` by hand. None was caught by a gate.

**A receipt that does not say which code ran, on which host, out of which venv or container, against which config, is not evidence — it is a claim.**

## What lands

**1. The stamp** — `ModelRuntimeIdentity` + `ModelPackageIdentity` in `omnibase_core.models.runtime`. Pure data, no I/O (collection is infra's job, OMN-17310). Per-package `version` **and** `commit` **and** `source`, plus host, `locus_kind`, `execution_locus`, `interpreter`, `config_source`, `stamped_at`.

**2. The enforcement is the type, not a scan.** `SKILL_RESULT_SCHEMA_VERSION` 1.0.0 → **1.1.0**, and a model validator refuses to construct a receipt at `>= 1.1.0` with `runtime_identity is None`. Because `schema_version` defaults to that constant, an un-self-identifying receipt is **unconstructable** — there is no emitting code path, so no artifact exists to scan later. A scanner alone could only report the problem *after* the misleading evidence had been read.

**3. Grandfathering by schema version — history is never rewritten.** `< 1.1.0` passes, reported `grandfathered`. Back-filling an identity onto an August receipt would manufacture a claim about a process nobody observed, which is the exact fiction this epic exists to stop. *"This receipt predates the requirement"* is a true statement, and the version field is how the receipt makes it.

**4. Probe-target assertion (OMN-17312 core half)** — `assert_probe_target(stamped, declared)`. **Fails closed on UNKNOWN, not only on MISMATCH**: in all four incidents the honest answer was "I cannot tell" and every surface rendered it "fine". An empty declaration is a refusal, and the verdict names every field actually compared so "asserted" can never mean "compared nothing" (OMN-14531 vacuous-check class).

**5. Wired as a gate in the same PR** (CLAUDE.md rule 5 — detection nobody adopts is not enforcement): pre-commit hook `check-receipt-runtime-identity` **and** CI job `runtime-identity-validator`, registered in `SPEC_REQUIRED_VALIDATOR_JOBS` so a red run turns `CI Summary` red. The scan is scoped to all JSON and recognises a receipt *structurally*, so one committed under an unexpected name cannot escape a path glob.

## Evidence — proven by running it, not by reading the diff

RED-first, proven by **mutation** rather than assertion:

- `if self.schema_version >= RUNTIME_IDENTITY_REQUIRED_FROM:` → `if False:` ⇒ `test_current_schema_receipt_without_identity_is_refused` fails **"DID NOT RAISE"** (1 failed / 33 passed). Restored ⇒ 34 passed.
- the `entry.commit is None` UNKNOWN branch → `continue` ⇒ `test_unresolvable_commit_is_refused_as_unknown` fails **"DID NOT RAISE"** (1 failed / 8 passed).

Gate behaviour, real exit statuses (`$?` read directly, never through a pipe):

| Case | Exit | Rule |
| -- | --: | -- |
| 1.1.0 receipt, no identity | `1` | `missing_identity` |
| `source: vcs`, `commit: null` | `1` | `unresolved_commit` — *"A version string is a label, not evidence of content."* |
| 1.0.0 receipt, no identity | `0` | grandfathered |
| clean repo scan | `0` | `PASSED: 0 violations across 2 receipt(s) in 56 JSON file(s)` — prints what it saw, so a vacuous scan is visible |

Hook fires: clean run `Passed`; against a planted bad receipt `HOOK_EXIT=1`.

**A defect found during verification and fixed here:** the 1.1.0 bump silently invalidated `ModelSkillResult`'s own class docstring — its example constructed a receipt with no `runtime_identity`, and `python -m doctest` reported *"2 of 3 in ModelSkillResult"* failing. Nothing collected doctests, so the example became un-runnable while still reading as authoritative — a docs-shaped instance of this very defect class. The example now shows both the stamped and the grandfathered path as executable code, and `TestDocumentedExampleStaysExecutable` runs the module's doctests in the unit suite asserting `attempted > 0` so the guard cannot pass vacuously.

## Gates

- `ruff format --check` 6204 files clean · `ruff check` all passed
- `mypy src/ --strict`: 9 errors, **all pre-existing** — identical count on `origin/dev` (verified by checkout + re-run), **zero** in any file this branch touches
- `pre-commit run --files <all 26 changed files>` → **exit 0**
- 554 passed (`tests/unit/models/dispatch` + `tests/unit/models/runtime`); 46 passed (probe-target + receipt-gate + requirements-consumer)
- Governed pre-push selector escalated to the full suite (`is_full_suite=True reason=shared_module`). **No `PREPUSH_*` override was set at any point**; the first attempt's load-threshold refusal was honoured and the push re-run when the host fell below it.

## Downstream — read before bumping the pin

`omnibase_infra` hard-pins `omnibase-core==0.47.1` (twice). The infra PR that moves that pin **must** land `collect_runtime_identity()` and stamp both construction branches in the same commit, or every receipt-mode dispatch fails construction. Blast radius is exactly two lines — `cli/receipt_mode.py:860` and `:887` — and zero sites in core, omnimarket or omniclaude. Detail in the OMN-17310 comment.

Evidence-Ticket: OMN-17308
Evidence-Source: OCC#7926
