### PR TITLE
fix(OMN-17319): remove dead async autouse fixture that hard-errors on pytest 9.1 + wire an async-fixture-decorator gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,16 @@ jobs:
       - name: Run import-layering growth ratchet (protocols->models + hubs)
         run: uv run python scripts/ci/check_import_ratchet.py
 
+      # Async-fixture decorator gate (OMN-17319) — blocking, fail-closed.
+      # An `async def` fixture declared with a bare `@pytest.fixture` does not run under
+      # pytest-asyncio STRICT mode — the body is silently skipped — and pytest >= 9.1
+      # errors on it at setup. Found when omnibase_core + pytest 9.1.1 errored 24 tests in
+      # test_model_service_orchestrator_integration.py that passed on 9.0.3, on a fixture
+      # that had never once executed. Runs in this job so it inherits the quality-gate
+      # blocking wiring; mirrored as the `async-fixture-decorator` pre-commit hook.
+      - name: Run async-fixture decorator gate
+        run: uv run python scripts/ci/check_async_fixture_decorators.py
+
       # Canonical handler-shape GROWTH RATCHET (OMN-14355) — WARN-only-on-baseline.
       # compliance_sweep checks handler hygiene but is blind to handler SHAPE, so a
       # non-canonical handler passes green CI. This classifies each node's

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -159,6 +159,21 @@ repos:
         files: ^(src/omnibase_core/.*\.py|scripts/ci/check_import_ratchet\.py|scripts/ci/import_ratchet_baseline\.py|\.importlinter|pyproject\.toml)$
         stages: [pre-commit]
 
+      # Async-fixture decorator gate (OMN-17319) -- fail-closed, whole-tree, sub-second.
+      # An `async def` fixture with a bare `@pytest.fixture` is NOT executed under
+      # pytest-asyncio STRICT mode (which tests/pytest.ini leaves in force): pytest hands
+      # the test an un-awaited async_generator and the body never runs, while
+      # tests/pytest.ini's --disable-warnings swallows the deprecation. pytest 9.1 turned
+      # that silent no-op into a hard setup error -- 24 tests errored on 9.1.1 that passed
+      # on 9.0.3. The silent-skip failure mode is the reason this is a gate and not a sweep.
+      - id: async-fixture-decorator
+        name: no bare @pytest.fixture on an async def (OMN-17319)
+        entry: uv run python scripts/ci/check_async_fixture_decorators.py
+        language: system
+        pass_filenames: false
+        files: ^((src|tests)/.*\.py|scripts/ci/check_async_fixture_decorators\.py)$
+        stages: [pre-commit]
+
       # Canonical handler-shape GROWTH RATCHET (OMN-14355)
       # compliance_sweep checks handler hygiene but is blind to handler SHAPE. This
       # classifies each node's contract-declared handler (definition B: typed-payload

--- a/scripts/ci/check_async_fixture_decorators.py
+++ b/scripts/ci/check_async_fixture_decorators.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Fail-closed gate: no ``async def`` fixture may use a bare ``@pytest.fixture``.
+
+OMN-17319. An ``async def`` fixture declared with a plain ``@pytest.fixture``
+is NOT executed under pytest-asyncio's STRICT mode -- pytest hands the
+requesting test an un-awaited ``async_generator`` object and the fixture body
+never runs. ``tests/pytest.ini`` (the effective config for ``tests/``) does not
+set ``asyncio_mode``, so STRICT is in force there regardless of the
+``asyncio_mode = "auto"`` in ``pyproject.toml``, and its ``--disable-warnings``
+plus ``filterwarnings = ignore::DeprecationWarning`` swallow the deprecation
+warning that would otherwise surface the mistake.
+
+pytest 9.1 promoted that silent no-op to a hard setup error
+(https://docs.pytest.org/en/stable/deprecations.html#sync-test-depending-on-async-fixture),
+which is how OMN-17319 was found: 24 tests errored on 9.1.1 that passed on
+9.0.3. The failure mode this gate prevents is the SILENT one -- cleanup or
+setup code that looks wired and is not.
+
+Correct forms: ``@pytest_asyncio.fixture`` for a fixture only async tests
+consume, or a synchronous ``@pytest.fixture`` when sync tests consume it too.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCAN_ROOTS = ("src", "tests")
+
+
+def _is_bare_pytest_fixture(decorator: ast.expr) -> bool:
+    """True when the decorator is ``pytest.fixture`` / ``fixture`` (not pytest_asyncio)."""
+    node = decorator.func if isinstance(decorator, ast.Call) else decorator
+
+    if isinstance(node, ast.Attribute):
+        # pytest.fixture(...) -> reject; pytest_asyncio.fixture(...) -> allow.
+        return node.attr == "fixture" and (
+            not isinstance(node.value, ast.Name) or node.value.id == "pytest"
+        )
+    if isinstance(node, ast.Name):
+        # A bare ``fixture`` from ``from pytest import fixture``.
+        return node.id == "fixture"
+    return False
+
+
+def find_violations() -> list[tuple[Path, int, str]]:
+    violations: list[tuple[Path, int, str]] = []
+    for scan_root in SCAN_ROOTS:
+        root = REPO_ROOT / scan_root
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.AsyncFunctionDef):
+                    continue
+                for decorator in node.decorator_list:
+                    if _is_bare_pytest_fixture(decorator):
+                        violations.append(
+                            (path.relative_to(REPO_ROOT), node.lineno, node.name)
+                        )
+                        break
+    return violations
+
+
+def main() -> int:
+    violations = find_violations()
+    if not violations:
+        sys.stdout.write("async-fixture-decorator gate: OK (0 violations)\n")
+        return 0
+
+    sys.stderr.write(
+        "async-fixture-decorator gate FAILED (OMN-17319): "
+        f"{len(violations)} async fixture(s) declared with a bare @pytest.fixture.\n"
+        "Under pytest-asyncio STRICT mode these fixtures SILENTLY DO NOT RUN, "
+        "and pytest >= 9.1 errors on them.\n"
+        "Fix: use @pytest_asyncio.fixture, or make the fixture synchronous if "
+        "synchronous tests also consume it.\n"
+    )
+    for path, lineno, name in violations:
+        sys.stderr.write(f"  {path}:{lineno}: async fixture '{name}'\n")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/models/nodes/node_services/test_model_service_orchestrator_integration.py
+++ b/tests/unit/models/nodes/node_services/test_model_service_orchestrator_integration.py
@@ -71,38 +71,6 @@ def service_orchestrator(mock_container):
     return service
 
 
-@pytest.fixture(autouse=True)
-async def cleanup_async_tasks():
-    """Cleanup any lingering async tasks after each test."""
-    yield
-
-    # After test completes, cancel health monitor and service event loop tasks
-    current_task = asyncio.current_task()
-    pending = [
-        t
-        for t in asyncio.all_tasks()
-        if not t.done()
-        and t is not current_task
-        and (
-            "_health_monitor_loop" in str(t.get_coro())
-            or "_service_event_loop" in str(t.get_coro())
-        )
-    ]
-
-    # Cancel health/service tasks
-    for task in pending:
-        task.cancel()
-
-    # Wait for cancellation to complete (with timeout to prevent hanging)
-    if pending:
-        try:
-            await asyncio.wait_for(
-                asyncio.gather(*pending, return_exceptions=True), timeout=1.0
-            )
-        except TimeoutError:
-            pass  # Tasks didn't cancel in time, but we tried
-
-
 @pytest.fixture
 def tool_invocation_event(service_orchestrator):
     """Create a sample tool invocation event for orchestrator."""

--- a/tests/unit/scripts/ci/test_async_fixture_decorators.py
+++ b/tests/unit/scripts/ci/test_async_fixture_decorators.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the async-fixture-decorator gate (OMN-17319).
+
+The gate exists because an ``async def`` fixture with a bare ``@pytest.fixture``
+fails SILENTLY under pytest-asyncio STRICT mode -- the body never executes.
+``test_bare_pytest_fixture_on_async_def_is_rejected`` is the RED case (the exact
+shape of the ``cleanup_async_tasks`` fixture this ticket removed);
+``test_repo_is_clean`` is the live repo-wide assertion.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from scripts.ci.check_async_fixture_decorators import (
+    _is_bare_pytest_fixture,
+    find_violations,
+)
+
+
+def _decorator_of(source: str) -> ast.expr:
+    """Return the sole decorator of the sole function in ``source``."""
+    tree = ast.parse(source)
+    func = tree.body[0]
+    assert isinstance(func, ast.AsyncFunctionDef | ast.FunctionDef)
+    return func.decorator_list[0]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "decorator_source",
+    [
+        "@pytest.fixture",
+        "@pytest.fixture(autouse=True)",
+        "@pytest.fixture(scope='session', autouse=True)",
+        "@fixture",
+        "@fixture(autouse=True)",
+    ],
+)
+def test_bare_pytest_fixture_on_async_def_is_rejected(decorator_source: str) -> None:
+    """RED case: the shape that silently never runs must be classified a violation."""
+    source = f"{decorator_source}\nasync def broken():\n    yield\n"
+    assert _is_bare_pytest_fixture(_decorator_of(source)) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "decorator_source",
+    [
+        "@pytest_asyncio.fixture",
+        "@pytest_asyncio.fixture(autouse=True)",
+        "@pytest_asyncio.fixture(loop_scope='function')",
+    ],
+)
+def test_pytest_asyncio_fixture_is_allowed(decorator_source: str) -> None:
+    """GREEN case: the correct decorator for an async fixture must not be flagged."""
+    source = f"{decorator_source}\nasync def ok():\n    yield\n"
+    assert _is_bare_pytest_fixture(_decorator_of(source)) is False
+
+
+@pytest.mark.unit
+def test_unrelated_decorators_are_not_flagged() -> None:
+    """A decorator that merely ends in a call must not be misread as a fixture."""
+    for source in ("@pytest.mark.asyncio\nasync def t():\n    pass\n",):
+        assert _is_bare_pytest_fixture(_decorator_of(source)) is False
+
+
+@pytest.mark.unit
+def test_repo_is_clean() -> None:
+    """No async fixture in src/ or tests/ may carry a bare @pytest.fixture."""
+    violations = find_violations()
+    assert violations == [], (
+        "async fixtures with a bare @pytest.fixture do not run under "
+        "pytest-asyncio STRICT mode and error on pytest >= 9.1: "
+        + ", ".join(f"{p}:{ln} ({name})" for p, ln, name in violations)
+    )


### PR DESCRIPTION
## OMN-17319 — remove the dead async autouse fixture that hard-errors on pytest 9.1, and wire a gate so it cannot come back

Closes OMN-17319.

### What broke

`tests/pytest.ini` sets no `asyncio_mode`, so `tests/` runs under `Mode.STRICT` (the session header confirms it) and the `asyncio_mode = "auto"` in `pyproject.toml` is shadowed. Under that mode `cleanup_async_tasks` — an `async def` decorated with a bare `@pytest.fixture(autouse=True)` — was silently inert. pytest 9.1 converted that long-standing deprecation into a hard setup error:

```
'test_validate_contract_available' requested an async fixture 'cleanup_async_tasks' with autouse=True,
with no plugin or hook that handled it. This is an error, as pytest does not natively support it.
```

The fixture was inert before and after; only the tolerance changed. **Deleting it is the correct fix, not a workaround.** There is no pytest 9.1 async-fixture *semantics* change to accommodate.

### AC1 — fixture removed

`cleanup_async_tasks` deleted (32 lines) from `tests/unit/models/nodes/node_services/test_model_service_orchestrator_integration.py`. Repo-wide AST scan of `src/` + `tests/` returns **0** bare-`@pytest.fixture` async defs.

### AC2 — full 2x2 A/B matrix, all four cells run

| tree | pytest 9.0.3 (pinned) | pytest 9.1.1 |
|---|---|---|
| pre-fix (`HEAD~1`) | 24 passed | **24 errors** |
| fixed (`HEAD`) | **24 passed** | **24 passed** |

9.1.1 obtained via `uv run --with "pytest==9.1.1"` — an overlay; the lockfile is untouched.

### AC3 — gate is RED-first and wired in this same PR

- `scripts/ci/check_async_fixture_decorators.py` — AST scan of `src/` + `tests/`.
- RED-first proven: on the pre-fix tree the gate exits **1** with 1 violation `(75, 'cleanup_async_tasks')`; on the fixed tree it exits **0**, `OK (0 violations)`.
- `tests/unit/scripts/ci/test_async_fixture_decorators.py` — 10 passed, covering the RED shapes (`@pytest.fixture`, `@pytest.fixture(autouse=True)`, `@fixture`) and asserting `pytest_asyncio.fixture` is allowed.
- Wired as enforcement, not detection: `.pre-commit-config.yaml` hook `async-fixture-decorator` **and** a blocking step in the `ci.yml` quality-gate job.

### AC4 — no pytest bump here

`pyproject.toml` and `uv.lock` are not in the diff. **The next pytest Dependabot bump on omnibase_core is unblocked by this landing** — 9.1.1 is proven green on the file that was the sole blocker.

### dod_evidence — governed pre-push, full escalated suite, green

Run `20260901T083122Z-omn17319-prepush2-3897824` on the sanctioned `.201` gate-runner (container `gate-runner-201`), exclusive heavy-suite slot **held**, 2026-09-01T08:31:22Z → 11:40:34Z:

**44485 passed, 55 skipped, 3 xpassed, 0 failed in 11331.15s (3:08:51)** — then `git push` succeeded.

The governed selector escalated to a whole-suite-equivalent selection (the diff touches `ci.yml` + `.pre-commit-config.yaml`, which map broadly) and refused to run on the local host, which was over the 1.0x-core threshold. Routed to the gate-runner per the documented remediation. **No `PREPUSH_*` override, no `--no-verify`, no skip token** was used at any point.

### Note on the branch rename (no code changed)

An earlier run of this same commit reported 6 failures in `tests/scripts/test_prepush_hook_host_identity_guard.py` — a file byte-identical to `dev` and untouched by this diff. Root cause, proven by A/B rather than asserted: that file's `_run_hook_forcing_full_suite` stubs `uv` with `case "$*" in *pytest*)`, and the hook passes `--ref-name <branch>` to the governed selector — so a branch whose **name** contains `pytest` makes the stub swallow the selector call and emit `STUB-PYTEST-INVOKED` instead of JSON.

Causal proof (branch name is the only variable):

| tree | branch name has `pytest` | result |
|---|---|---|
| pristine dev `fc20d0869`, detached | no | 30 passed |
| pristine dev `fc20d0869`, branch `probe/contains-pytest-in-name` | **yes** | **6 failed**, 24 passed |
| this branch, old name `...-pytest91` | **yes** | **6 failed**, 24 passed |

The middle row contains **zero** OMN-17319 code and reproduces it exactly. The branch was therefore renamed `...-pytest91` → `...-guard`; **patch-id unchanged at `8928a65ab7308d4b4205b9084a63840c00b1b559`**. Not one byte of the change moved, and the full suite still ran on the renamed branch.

That harness file belongs to open PR #1635 (OMN-17159), so it was deliberately **not** edited here. Follow-up owed to that lane: match only `run pytest` / `run python -m pytest` by argv position, not any substring — as written, any branch with `pytest` in its name red-lines 6 tests.

Evidence-Ticket: OMN-17319
Evidence-Source: OCC#7972
