### PR TITLE
fix(OMN-17272): release main-sync must push as onexbot-occ-writer, not github-actions[bot]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,6 +301,18 @@ jobs:
           TAG="$RELEASE_TAG"
           TAG_SHA=$(git rev-list -n 1 "$TAG")
           echo "Resolved tag $TAG -> commit $TAG_SHA"
+          # OMN-17272: actions/checkout persists the job's GITHUB_TOKEN as an
+          # http.<origin>.extraheader Authorization header in the local git
+          # config, and that header overrides the app token embedded in the
+          # push URL below -- so this push actually authenticated as
+          # github-actions[bot] (branch-activity-proven), which the OMN-16289
+          # main ruleset correctly declines (GH013), and which GitHub refuses
+          # to accept as a ruleset bypass actor ("The following actor(s) are
+          # invalid: GitHub Actions"). Drop the persisted header so the push
+          # authenticates as onexbot-occ-writer, the ruleset's bypass actor --
+          # the same identity omnimemory/omnimarket already sync main with,
+          # live-proven against their ACTIVE rulesets on 2026-08-31.
+          git config --local --unset-all "http.https://github.com/.extraheader" || true
           git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" "${TAG_SHA}:refs/heads/main"
           echo "main fast-forwarded to $TAG_SHA ($TAG)"
 


### PR DESCRIPTION
## Summary

OMN-17272: the OMN-16289 main ruleset declines release.yml's `Sync main to release tag` push with GH013 even though onexbot-occ-writer is a bypass actor (Integration 4361937, bypass_mode always). Diagnosis: the push never authenticated as the app. actions/checkout persists the job GITHUB_TOKEN as an `http.https://github.com/.extraheader` Authorization header in the local git config, and that header overrides the app token embedded in the push URL — so the pusher GitHub evaluates is github-actions[bot]. The branch-activity API records every historical main sync on this repo under that actor, never under onexbot-occ-writer[bot]. GitHub refuses to accept GitHub Actions as a ruleset bypass actor (updateRepositoryRuleset: "Bypass actors must be either GitHub Apps, organization roles, public teams, or users that are linked to the ruleset source. The following actor(s) are invalid: GitHub Actions"), so the ruleset cannot be widened to admit the actual pusher; the push identity must be fixed instead.

## Fix

One line in the sync step: `git config --local --unset-all "http.https://github.com/.extraheader" || true` immediately before the push, so the URL-embedded installation token is the only credential and the push authenticates as onexbot-occ-writer — the ruleset bypass actor, and the same identity omnimemory/omnimarket already sync main with (live-proven against their ACTIVE OMN-16289 rulesets on 2026-08-31 via the branch-activity API).

## dod_evidence

- Root cause proof: branch-activity API — main syncs recorded as github-actions[bot] on omnibase_core (v0.47.1 sync 2026-08-30T04:46Z), omnibase_infra (v0.38.14 sync 2026-08-30T13:57Z), omnibase_spi (v0.23.3 sync 2026-08-30T12:10Z); omnimemory/omnimarket record onexbot-occ-writer[bot] and synced THROUGH their active rulesets on 2026-08-31.
- Ruleset-side fix refused by GitHub: updateRepositoryRuleset error quoted above (attempted 2026-09-01; before/after ruleset JSON in OMN-17272).
- Live proof after merge: workflow_dispatch of release.yml on the stranded tag (core v0.47.2 -> a3c3184e0; infra v0.38.15 -> b5ac9622c) must fast-forward main by the workflow's own sync step; verified via git ls-remote.
- Failed run being remediated: https://github.com/OmniNode-ai/omnibase_core/actions/runs/33489042551 (v0.47.2 published to PyPI, GH Release created, sync declined GH013, cascade skipped).

Evidence-Ticket: OMN-17272
Evidence-Source: OCC#7965
