### PR TITLE
fix(OMN-17272): grant release sync workflow-file scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,6 +281,10 @@ jobs:
           private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          # The release tag can legitimately contain workflow changes. GitHub
+          # rejects that protected-branch update unless the App token carries
+          # this explicit scope (run 33525584540, OMN-17272).
+          permission-workflows: write
 
       # OMN-16289: main = the last release. Once a release publishes
       # successfully, fast-forward main to the released tag's commit SHA.

--- a/tests/unit/validation/test_release_workflow_shape.py
+++ b/tests/unit/validation/test_release_workflow_shape.py
@@ -119,6 +119,13 @@ def _step(name: str) -> dict[object, object]:
     return _steps()[_step_index(name)]
 
 
+def test_main_sync_app_token_can_write_tagged_workflows() -> None:
+    """A release fast-forward may include changes beneath .github/workflows/."""
+    mint_step = _step("Mint onexbot-occ-writer app token")
+    token_scope = _as_mapping(mint_step["with"], "main-sync App token `with:`")
+    assert token_scope["permission-workflows"] == "write"
+
+
 def _partial_state_step() -> dict[object, object]:
     """The partial-state report lives in its own job, not in ``release``.
 


### PR DESCRIPTION
## Summary

The initial OMN-17272 identity repair correctly changed the pusher to `onexbot-occ-writer`, but recovery run 33525584540 proved the token lacked GitHub's separate `workflows` permission when the release tag contains `.github/workflows/**` changes. Request only `permission-workflows: write` on the existing release main-sync App token.

## Verification

- Recovery run 33525584540 reached the App-authenticated push and failed only with GitHub's missing-workflows-permission rejection.
- `uv run pytest tests/unit/validation/test_release_workflow_shape.py -q` — 23 passed.
- Governed pre-push impacted suite — 1,859 passed.
- Scoped pre-commit passed.

Evidence-Ticket: OMN-17272
Evidence-Source: OCC#7979
