### PR TITLE
ci(OMN-17172): require the KB doc gate on omnibase_core PRs

### DIFF
--- a/.github/workflows/kb-doc-gate.yml
+++ b/.github/workflows/kb-doc-gate.yml
@@ -1,13 +1,33 @@
 # SPDX-FileCopyrightText: 2026 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 #
-# KB Doc Gate — thin caller. OMN-16589.
-# Blocks new/regrown non-KB markdown docs, evaluated against the PR diff.
-# Validator lives in omniclaude (mirrors deploy-gate.yml's thin-caller pattern).
+# KB Doc Gate — thin caller. OMN-17172 (fleet rollout; OMN-16589 built the gate).
 #
-# Pilot wiring (P1): transition mode, NOT a required status check yet. The
-# required-check flip is explicit follow-up scope once this repo and
-# omnimarket both run green on real PRs — see OMN-16589 AC.
+# Canonical docs live in the knowledge-base repo. This gate keeps this repo's
+# markdown inside the allowed set stated by the operator ruling of 2026-09-01:
+# root README.md, root CLAUDE.md or anything under .claude/, CHANGELOG*.md,
+# LICENSE*, root SECURITY.md, .github/**, skills|commands|agents/**, and the
+# tests/**/{fixtures,data,golden}/** subtrees. Everything else is documentation
+# that must leave.
+#
+# mode: diff — fails a PR that ADDS or MODIFIES markdown outside that set.
+# Deletions always pass (that is the migration doing its job), and a rename is
+# judged on its destination. Flip this repo to 'strict' (fails if ANY markdown
+# outside the set EXISTS on the branch) by adding a .kb-doc-gate.yaml at this
+# repo's root containing 'mode: strict', once this repo's KB Wave-4 migration
+# lands and its residual doc count reaches zero. Doing it earlier blocks every
+# unrelated PR against the existing sprawl.
+#
+# Validator + reusable workflow live in omniclaude (mirrors deploy-gate.yml's
+# thin-caller pattern). Pinned by immutable SHA, not @main: omniclaude's main is
+# release-synced and carries neither the reusable workflow nor
+# scripts/kb_doc_gate.py. The pin is a SINGLE source of truth — the reusable
+# checks its validator out at github.job_workflow_sha, i.e. this very SHA — so
+# advancing the gate is one line here, via a normal PR.
+#
+# REQUIRED status check: the surfaced context is 'kb-doc-gate / kb-doc-gate'
+# (this job's id / the reusable job's name). Removing this file wedges the
+# branch rather than silently dropping the gate.
 
 name: KB Doc Gate
 
@@ -17,12 +37,6 @@ on:
 
 jobs:
   kb-doc-gate:
-    # Pinned by immutable SHA, not @main: the reusable workflow file exists
-    # only on omniclaude dev (this is dev's 2026-08-26 merge commit that
-    # introduced it, OMN-16589 #2047); main is release-synced and does not
-    # carry it yet (promotion deferred by policy), so @main fails with
-    # "reusable workflow not found" on every PR. Advance this pin via a
-    # normal PR when the gate is updated or main promotion lands.
-    uses: OmniNode-ai/omniclaude/.github/workflows/kb-doc-gate-reusable.yml@96dd18962cc7b02f9ae7beb43c13a1ed9df7b559
+    uses: OmniNode-ai/omniclaude/.github/workflows/kb-doc-gate-reusable.yml@a78b103e55f1ad595572ecde6ea818c2c585f025
     with:
-      mode: transition
+      mode: diff


### PR DESCRIPTION
## OMN-17172 — wire omnibase_core into the KB doc gate

Thin caller for the reusable gate that landed in omniclaude (`kb-doc-gate-reusable.yml`, OMN-16589 built it, omniclaude#2099 gave it its fleet shape). One workflow file; no repo logic.

### What the gate does here

Mode `diff`: a PR fails if it **adds or modifies** any markdown outside the allowed set. Deletions always pass — that is the KB migration doing its job — and a rename is judged on its destination, so `git mv docs/a.md docs/b.md` cannot launder a doc past it.

Allowed set (from the operator ruling of 2026-09-01, in `omniclaude/scripts/kb_doc_gate.py`): root `README.md`; root `CLAUDE.md` or anything under `.claude/`; `CHANGELOG*.md`; `LICENSE*`; root `SECURITY.md`; `.github/**`; `skills|commands|agents/**`; `tests/**/{fixtures,data,golden}/**`. Everything else belongs in the knowledge-base repo.

This PR does **not** touch any existing documentation. `diff` mode deliberately ignores the markdown already on this branch (199 files today) so the gate stops regrowth without blocking unrelated PRs against sprawl that the KB Wave-4 migration (epic OMN-16602) has yet to clear.

### Required status check

The surfaced context is `kb-doc-gate / kb-doc-gate` (caller job id / reusable job name). It is registered in this repo's `dev` branch protection in the same change window (readback in the ticket comment).

### Pin

`@a78b103e55f1ad595572ecde6ea818c2c585f025` — the omniclaude `dev` merge commit of #2099. Not `@main`: omniclaude's main is release-synced and carries neither the reusable workflow nor the validator script. One pin covers both, because the reusable checks its own validator out at `github.job_workflow_sha`.

### dod_evidence

- Gate behavior is tested in omniclaude (`tests/scripts/test_kb_doc_gate.py`, 60 tests) — add, modify, stub-shrink, rename-to-another-stray-path, rename-into-the-allowed-set, delete, config precedence, and exit-2-not-a-pass on a malformed config. Not re-tested per caller: this file is 4 lines of wiring.
- The gate runs on **this PR**, against this PR's own diff — a green `kb-doc-gate / kb-doc-gate` here is the live proof it is wired correctly in this repo, not an assertion about it.
- Validator pin verified resolvable before push: `gh api repos/OmniNode-ai/omniclaude/contents/scripts/kb_doc_gate.py?ref=a78b103e` returns the blob, and `compare/dev...a78b103e` reports `identical`.
- Local gates run in full before commit; governed pre-push selector ran on push with no overrides.
- This repo carried the OMN-16589 pilot caller (`mode: transition`, pinned at 96dd1896). This PR re-pins it to the fleet SHA and moves it to `mode: diff`; `transition` no longer exists in the validator, so a stale pin is the only thing that could keep the old semantics alive here.

Ticket: OMN-17172. Gate build: OMN-16589. Migration epic that unlocks `strict` mode per repo: OMN-16602.

Evidence-Ticket: OMN-17172
Evidence-Source: OCC#8013
