### PR TITLE
fix(OMN-17603): carry the pytest execution policy across the pre-push remote dispatch seam (3:36:06 -> 1:32:51 on h105)

### DIFF
--- a/scripts/hooks/prepush_dispatch.sh
+++ b/scripts/hooks/prepush_dispatch.sh
@@ -509,6 +509,15 @@ prepush_select_candidate() {
   PREPUSH_PICK_MODE="$(printf '%s' "$rec" | cut -d'|' -f8)"
   PREPUSH_PICK_SLOT="$(printf '%s' "$rec" | cut -d'|' -f9)"
   [ -n "$PREPUSH_PICK_SLOT" ] || PREPUSH_PICK_SLOT=1
+  # OMN-17603: the TARGET host's nominal core count, carried so the remote leg
+  # can size its own parallelism from the host that will actually run the
+  # suite. INDEX DIVERGENCE, deliberate and documented: omnibase_infra reads
+  # this at f11 because its record carries a tier_rank at f10
+  # (OMN-17392/OMN-17485). This repo has no placement_tier, so its record is
+  # nine fields and `cores` appends at f10. The NAME is what the remote leg
+  # couples to and the name is identical; whoever ports the tier ladder here
+  # moves this one index and this one comment.
+  PREPUSH_PICK_CORES="$(printf '%s' "$rec" | cut -d'|' -f10)"
   return 0
 }
 
@@ -535,7 +544,7 @@ prepush_select_candidate() {
 # it is a tiebreaker, not the placement key.
 pick_capacity_host() {
   local lc_host repo want_mode row label role name ssh_t uv floor workroot slotmode denied mode
-  local self ratio rc recs="" slots k slot_label
+  local self ratio rc recs="" slots k slot_label cores
   lc_host="$1"; repo="$2"; want_mode="${3:-authorizing}"
   PREPUSH_PROBE_LOG=""
   PREPUSH_PICK_LABEL=""
@@ -567,6 +576,10 @@ pick_capacity_host() {
     esac
     name="$(prepush_row_hostname "$row")"
     ssh_t="$(prepush_field "$row" 4)"
+    # OMN-17603: documentation column, and now also the input the remote leg
+    # sizes `-n` from. A row whose value is absent or non-numeric degrades to
+    # one worker in prepush_remote_xdist_workers -- it is never assumed ample.
+    cores="$(prepush_field "$row" 5)"
     uv="$(prepush_field "$row" 6)"
     floor="$(prepush_field "$row" 7)"
     workroot="$(prepush_field "$row" 8)"
@@ -630,7 +643,7 @@ pick_capacity_host() {
       fi
 
       PREPUSH_PROBE_LOG="${PREPUSH_PROBE_LOG}${slot_label}=fit(${ratio},${mode}) "
-      recs="${recs}${ratio}|${slot_label}|${name}|${ssh_t}|${uv}|${workroot}|${slotmode}|${mode}|${k}
+      recs="${recs}${ratio}|${slot_label}|${name}|${ssh_t}|${uv}|${workroot}|${slotmode}|${mode}|${k}|${cores}
 "
       k=$((k + 1))
     done
@@ -770,8 +783,124 @@ prepush_remote_gc() {
     > /dev/null 2>&1 || true
 }
 
-# prepush_remote_argv -- the EXACT pytest argv this call site would have run
-# locally, one item per line. The two local call sites carry DIFFERENT argv and
+# -----------------------------------------------------------------------------
+# The remote leg's EXECUTION POLICY (OMN-17603, ported from omnibase_infra's
+# OMN-17564 abc144fe6 -- kept diffable against it: same constant names, same
+# fit-record field, same min(row cores, cap) rule)
+# -----------------------------------------------------------------------------
+# THE DEFECT THIS CLOSES, measured live on h105 at 2026-09-02T19:24Z. The seam
+# shipped the SELECTION across and dropped the EXECUTION POLICY:
+# `prepush_remote_argv` emitted only test PATHS and the wrapper below ran
+# `"$UV" run pytest "${ARGV[@]}" --ignore=tests/integration --tb=short` -- no
+# `-n`, no `--dist`, no `--timeout`.
+#
+# THE NAIVE READING IS WRONG IN THIS REPO, so state the real mechanism. This is
+# NOT "the parallelism config was never written": `pyproject.toml`'s
+# `[tool.pytest.ini_options] addopts` ALREADY declares
+# `-n4 --dist=loadgroup --timeout=60 --timeout-method=signal`. That block is
+# simply NEVER READ. `tests/pytest.ini` is a real committed file whose own
+# addopts is `-v --tb=short --strict-markers --disable-warnings --color=yes`,
+# and both legs invoke pytest with `tests/` as the argument -- so pytest's
+# rootdir/inifile discovery starts in `tests/`, finds `pytest.ini`, and STOPS.
+# `pytest.ini` outranks `pyproject.toml` outright; the two do not merge. That
+# is the same shadowing OMN-14967 documents, and the LOCAL leg is immune only
+# because prepush_smart_tests.sh passes `PREPUSH_TIMEOUT_FLAGS` EXPLICITLY on
+# the command line, where no ini file can shadow it. This leg's pytest
+# invocation lives in the heredoc below rather than in that script, so
+# OMN-14967's guard never covered it.
+#
+# MEASURED, read-only, on a live dispatched run (h105, 2026-09-02T19:24Z):
+# `ps -Ao pid,ppid,pcpu,rss,etime,command` showed ONE python beneath the
+# wrapper -- no execnet/gw* workers at all -- at 759,888 KB RSS and 1h49m
+# elapsed, and that run's own suite.log header read
+# `rootdir: .../tree/tests` / `configfile: pytest.ini` / `collected 44720
+# items`. The xdist and pytest-timeout plugins were loaded and available; only
+# the FLAGS were missing.
+#
+# The cost is not the wall clock -- it is SLOT OCCUPANCY. Every capacity row
+# holds an EXCLUSIVE heavy-suite slot for the whole duration of the run, so a
+# 4-5x slower run holds the scarce resource 4-5x longer. A single-threaded core
+# heavy lane measured ~4h35m; the same tree under `-n4` locally runs at roughly
+# 5x the tests/s. With four capacity rows in the table, that arithmetic is the
+# difference between the lab being slot-starved and being merely busy.
+#
+# `--timeout-method=signal` is carried for the same reason OMN-15977 chose it
+# locally: a thread-based watchdog cannot kill a CPU-bound pure-Python loop
+# holding the GIL, so before this the OMN-15977 runaway protection covered only
+# local runs and every remote leg ran unwatched.
+#
+# CONSTANTS, not `${VAR:-...}`. An env indirection here would be a one-word
+# bypass of the policy (workers=1 restores the defect silently), and the hook
+# treats a PREPUSH_* override in the environment as a HARD REFUSAL (OMN-16480).
+PREPUSH_REMOTE_POLICY_FLAGS="--dist=loadgroup --timeout=60 --timeout-method=signal"
+
+# The worker CAP. This is PARITY with the local leg, not a new parallelism
+# policy: it is the worker count this repo's local heavy leg already runs
+# (`PREPUSH_TIMEOUT_FLAGS="-n4 --dist=loadgroup --timeout=60
+# --timeout-method=signal"` in prepush_smart_tests.sh) and the same value the
+# shadowed `pyproject.toml` addopts declares. Raising it is a separate change
+# and needs its own measurement -- `-n4` is also what that pyproject's own
+# comment block pins as the OOM-safe ceiling ("Limited to 4 workers to prevent
+# OOM").
+PREPUSH_REMOTE_XDIST_WORKER_CAP=4
+
+# LIVENESS BOUND for the execution ssh. `ConnectTimeout` governs the HANDSHAKE
+# only: a leg that has already connected and then stops hearing anything (zero
+# bytes, no WRAPPER_EXIT, no MARKER) holds its lane forever. Keepalives bound
+# transport silence; the timeout(1) wrapper bounds the whole run, which is the
+# pattern every PROBE ssh in this file already uses.
+#
+# 30s x 10 = 300s of unanswered keepalives before ssh gives up. The run budget
+# is sized off the measured worst case for the heaviest lane in the fleet --
+# the seven most recent completed heavy lanes on h201 ran 2h43m-3h06m (see that
+# row's note in prepush_hosts.tsv), the
+# longest recorded is 3h48m55s, and the single-threaded run this change exists
+# to end was ~4h35m -- with headroom, so it only ever fires for a run that has
+# already exceeded every suite this fleet has recorded.
+PREPUSH_REMOTE_SSH_ALIVE_INTERVAL_SECONDS=30
+PREPUSH_REMOTE_SSH_ALIVE_COUNT_MAX=10
+PREPUSH_REMOTE_EXEC_TIMEOUT_SECONDS=21600
+
+# prepush_remote_xdist_workers -- how many xdist workers the SELECTED host gets:
+# min(that row's `cores`, PREPUSH_REMOTE_XDIST_WORKER_CAP).
+#
+# Resolved from the TARGET, never from the pushing host and never hardcoded: a
+# fixed `-n4` oversubscribes a 2-core row, and the fleet spread is 10..32 cores
+# today. An absent or non-numeric `cores` degrades to ONE worker -- i.e.
+# exactly the behavior that shipped before this change -- rather than guessing
+# headroom on a host we cannot size. That is the same fail-closed posture the
+# load, slot and uv probes already carry: unreadable is never "assume ample".
+prepush_remote_xdist_workers() {
+  local cores="${PREPUSH_PICK_CORES:-}"
+  case "$cores" in '' | *[!0-9]*) printf '1'; return 0 ;; esac
+  [ "$cores" -ge 1 ] 2> /dev/null || { printf '1'; return 0; }
+  if [ "$cores" -lt "$PREPUSH_REMOTE_XDIST_WORKER_CAP" ]; then
+    printf '%s' "$cores"
+  else
+    printf '%s' "$PREPUSH_REMOTE_XDIST_WORKER_CAP"
+  fi
+  return 0
+}
+
+# prepush_remote_pytest_flags -- the execution policy, one item per line, in the
+# same shape prepush_remote_argv writes so the two concatenate into one argv
+# file. Deliberately SEPARATE from prepush_remote_argv: that function is the
+# SELECTION and the receipt records its output verbatim under
+# `selection_paths`, so folding flags into it would make an audit of "what did
+# that host actually run" read execution flags as coverage.
+prepush_remote_pytest_flags() {
+  printf '%s\n' "-n$(prepush_remote_xdist_workers)"
+  # shellcheck disable=SC2086
+  printf '%s\n' $PREPUSH_REMOTE_POLICY_FLAGS
+}
+
+# prepush_remote_argv -- the SELECTION this call site would have run locally,
+# one path per line. Execution POLICY (parallelism, the per-test watchdog) is
+# emitted separately by prepush_remote_pytest_flags above and appended to the
+# same argv file; keeping them apart is what lets the receipt record coverage
+# and policy as two distinct facts.
+#
+# The two local call sites carry DIFFERENT selections and
 # conflating them would be a silent coverage downgrade: the heavy site runs
 # $FULL_SUITE_TARGET **plus** ${RUNNABLE_INTEGRATION_PATHS[@]} to satisfy
 # OMN-16825's "an escalation must never run FEWER of the impacted tests than
@@ -881,7 +1010,7 @@ prepush_remote_run() {
   local heavy_what repo head_sha runid workroot ssh_t uv label rundir
   local bundle argvfile runner localdir marker rc=0 argv_sha log_sha
   local m_exit m_head m_argv m_log m_collected started ended dur
-  local readback wrapper_exit base_ref base_sha slot_idx
+  local readback wrapper_exit base_ref base_sha slot_idx remote_cmd tcmd
   heavy_what="$1"
   # Resolved by the hook before it ever reaches here; empty in a driver that
   # exercises the library alone, which the wrapper handles as "skip".
@@ -910,10 +1039,21 @@ prepush_remote_run() {
     return 1
   fi
   prepush_remote_argv > "$argvfile"
+  # The "nothing selected" refusal is decided on PATHS ALONE, before any flag is
+  # written (OMN-17603). Appending the policy first would make an empty
+  # selection look runnable: pytest handed nothing but flags falls back to the
+  # transplanted tree's own `testpaths` (tests/pytest.ini declares
+  # `testpaths = unit integration`), silently running a suite nobody selected
+  # and reporting it as this push's evidence.
   if [ ! -s "$argvfile" ]; then
     rm -rf "$localdir"
     return 1
   fi
+  # The execution policy travels WITH the selection, in the same file, so it is
+  # covered by argv_sha -- the marker binds the verdict to the flags the suite
+  # actually ran under, not just to the paths. A host that answered under a
+  # different policy therefore cannot satisfy this dispatch.
+  prepush_remote_pytest_flags >> "$argvfile"
   argv_sha="$(prepush_sha256_file "$argvfile")"
 
   # The remote wrapper is NAMED prepush_smart_tests.sh on purpose. .201's queue
@@ -1066,6 +1206,10 @@ REMOTE
 
   log "remote leg: dispatching ${heavy_what} to ${label} (${PREPUSH_PICK_HOSTNAME}, ratio ${PREPUSH_PICK_RATIO}, mode ${PREPUSH_PICK_MODE})"
   log "remote leg: probed -> ${PREPUSH_PROBE_LOG}"
+  # OMN-17603: the execution policy is on the record, not implied. A run that is
+  # slower than the fleet's measured norm can now be read back to the exact
+  # worker count it was given instead of being guessed at from wall clock.
+  log "remote leg: pytest policy -> $(prepush_remote_pytest_flags | tr '\n' ' ')(${PREPUSH_PICK_CORES:-unknown} cores declared, cap ${PREPUSH_REMOTE_XDIST_WORKER_CAP})"
   started="$(date -u '+%s')"
 
   if ! ssh -n -o ConnectTimeout=6 -o BatchMode=yes -o StrictHostKeyChecking=accept-new "$ssh_t" \
@@ -1090,9 +1234,42 @@ REMOTE
   # slot-contended, exit 94) wrapper aborts the remote shell BEFORE `rc=$?`
   # runs, so the one fact this leg needs -- WHY the wrapper stopped -- would be
   # the fact that never gets written. Each step is checked explicitly instead.
-  ssh -n -o ConnectTimeout=6 -o BatchMode=yes -o StrictHostKeyChecking=accept-new "$ssh_t" \
-    "cd '${rundir}' || exit 96; chmod +x prepush_smart_tests.sh || exit 97; ./prepush_smart_tests.sh '${rundir}' '${uv}' '${head_sha}' '${argv_sha}' '$(hostname -s 2> /dev/null || echo unknown):$$' '${workroot}' '${base_ref}' '${base_sha}' '${slot_idx}'; rc=\$?; echo REMOTE_WRAPPER_EXIT=\$rc; echo \$rc > '${rundir}/WRAPPER_EXIT'; exit 0" 2>&1 |
-    sed "s/^/[${label}] /" >&2 || true
+  #
+  # LIVENESS (OMN-17603). This was the ONLY ssh in this file with no bound but
+  # ConnectTimeout, which governs the handshake alone -- so a host that wedged
+  # AFTER connecting held the lane forever (zero bytes, no WRAPPER_EXIT, no
+  # MARKER, and the lane never recovered because the parent chain was alive and
+  # nothing would ever time it out). Keepalives bound transport silence and the
+  # timeout(1) wrapper bounds the run, the same pattern the probe legs above
+  # already use.
+  #
+  # Expiry introduces NO new classification: the pipeline just returns, the
+  # readback below finds no MARKER, and the leg is already classified
+  # "NO completion marker ... NO EVIDENCE (not a pass, not a failure)", which
+  # dispatch_to_lab_host treats as a placement miss and walks past. Fail-closed
+  # posture is unchanged -- a genuine remote RED still carries a marker and
+  # still refuses the push.
+  remote_cmd="cd '${rundir}' || exit 96; chmod +x prepush_smart_tests.sh || exit 97; ./prepush_smart_tests.sh '${rundir}' '${uv}' '${head_sha}' '${argv_sha}' '$(hostname -s 2> /dev/null || echo unknown):$$' '${workroot}' '${base_ref}' '${base_sha}' '${slot_idx}'; rc=\$?; echo REMOTE_WRAPPER_EXIT=\$rc; echo \$rc > '${rundir}/WRAPPER_EXIT'; exit 0"
+  tcmd="$(_prepush_timeout_cmd)"
+  if [ -n "$tcmd" ]; then
+    "$tcmd" "$PREPUSH_REMOTE_EXEC_TIMEOUT_SECONDS" \
+      ssh -n -o ConnectTimeout=6 \
+      -o "ServerAliveInterval=${PREPUSH_REMOTE_SSH_ALIVE_INTERVAL_SECONDS}" \
+      -o "ServerAliveCountMax=${PREPUSH_REMOTE_SSH_ALIVE_COUNT_MAX}" \
+      -o BatchMode=yes -o StrictHostKeyChecking=accept-new "$ssh_t" \
+      "$remote_cmd" 2>&1 |
+      sed "s/^/[${label}] /" >&2 || true
+  else
+    # timeout(1) ships on neither Mac in this fleet by default (see
+    # _prepush_timeout_cmd). Its absence degrades to the keepalive bound alone,
+    # which still closes the wedged-host case, rather than refusing to dispatch.
+    ssh -n -o ConnectTimeout=6 \
+      -o "ServerAliveInterval=${PREPUSH_REMOTE_SSH_ALIVE_INTERVAL_SECONDS}" \
+      -o "ServerAliveCountMax=${PREPUSH_REMOTE_SSH_ALIVE_COUNT_MAX}" \
+      -o BatchMode=yes -o StrictHostKeyChecking=accept-new "$ssh_t" \
+      "$remote_cmd" 2>&1 |
+      sed "s/^/[${label}] /" >&2 || true
+  fi
 
   readback="$(ssh -n -o ConnectTimeout=6 -o BatchMode=yes "$ssh_t" \
     "echo \"wrapper_exit=\$(cat '${rundir}/WRAPPER_EXIT' 2>/dev/null)\"; cat '${rundir}/MARKER' 2>/dev/null" 2> /dev/null || true)"
@@ -1130,7 +1307,7 @@ REMOTE
   fi
   log_sha="$m_log"
 
-  prepush_emit_receipt "{\"ts\":\"$(date -u '+%Y-%m-%dT%H:%M:%SZ')\",\"repo\":\"$(prepush_json_escape "$repo")\",\"head_sha\":\"${head_sha}\",\"chosen_host\":\"$(prepush_json_escape "$PREPUSH_PICK_HOSTNAME")\",\"chosen_label\":\"${label}\",\"chosen_slot\":${slot_idx},\"host_mode\":\"${PREPUSH_PICK_MODE}\",\"host_load_ratio\":\"${PREPUSH_PICK_RATIO}\",\"all_probed_ratios\":\"$(prepush_json_escape "$PREPUSH_PROBE_LOG")\",\"selection_paths\":\"$(prepush_json_escape "$(prepush_remote_argv | tr '\n' ' ')")\",\"pytest_exit\":${m_exit},\"collected\":${m_collected:-0},\"duration_s\":${dur},\"suite_log_sha256\":\"${log_sha}\"}"
+  prepush_emit_receipt "{\"ts\":\"$(date -u '+%Y-%m-%dT%H:%M:%SZ')\",\"repo\":\"$(prepush_json_escape "$repo")\",\"head_sha\":\"${head_sha}\",\"chosen_host\":\"$(prepush_json_escape "$PREPUSH_PICK_HOSTNAME")\",\"chosen_label\":\"${label}\",\"chosen_slot\":${slot_idx},\"host_mode\":\"${PREPUSH_PICK_MODE}\",\"host_load_ratio\":\"${PREPUSH_PICK_RATIO}\",\"all_probed_ratios\":\"$(prepush_json_escape "$PREPUSH_PROBE_LOG")\",\"selection_paths\":\"$(prepush_json_escape "$(prepush_remote_argv | tr '\n' ' ')")\",\"pytest_policy\":\"$(prepush_json_escape "$(prepush_remote_pytest_flags | tr '\n' ' ')")\",\"pytest_exit\":${m_exit},\"collected\":${m_collected:-0},\"duration_s\":${dur},\"suite_log_sha256\":\"${log_sha}\"}"
 
   if [ "$m_exit" -ne 0 ]; then
     # The refusal below tells the developer to read the failing output. The

--- a/tests/scripts/test_prepush_host_table.py
+++ b/tests/scripts/test_prepush_host_table.py
@@ -1229,8 +1229,22 @@ def test_the_verdict_is_read_from_a_marker_not_the_ssh_exit_code() -> None:
     assert "NO EVIDENCE" in lib
     # The streaming pipeline's status belongs to sed(1), and `|| true` follows
     # it, so nothing about the verdict can come from that command's exit code.
-    stream = lib[lib.index("./prepush_smart_tests.sh '${rundir}'") :][:400]
-    assert "|| true" in stream
+    #
+    # OMN-17603 lifted the wrapper invocation into `$remote_cmd` (it is now
+    # issued twice -- once timeout-wrapped, once not, depending on whether
+    # timeout(1) exists on the pusher), so the invocation and the pipeline that
+    # streams it are no longer adjacent and a fixed window after the invocation
+    # would pin nothing. Assert the property directly instead, on EVERY
+    # streaming branch: a branch added later without the discard would
+    # reintroduce exactly the fail-open shape this test exists for.
+    assert "./prepush_smart_tests.sh '${rundir}'" in lib, (
+        "the remote command no longer invokes the wrapper"
+    )
+    streams = [m.start() for m in re.finditer(r'"\$remote_cmd" 2>&1 \|', lib)]
+    assert streams, "no streaming invocation of $remote_cmd found"
+    for idx in streams:
+        window = lib[idx : idx + 200]
+        assert 'sed "s/^/[${label}] /" >&2 || true' in window, window
 
 
 def test_a_shadow_host_verdict_never_authorizes() -> None:
@@ -2118,11 +2132,34 @@ def test_the_picker_library_is_byte_identical_to_the_shipped_upstream() -> None:
     neither repo's `test_the_picker_library_is_not_edited_into_a_repo_specific_fork`
     can fire on the other's wording. Re-sync of the REST of the file (OMN-17392
     and the host-table columns it needs) is deliberately NOT bundled here.
+
+    THE BUMP IN OMN-17603 is this file's dev content (the OMN-17606 probe fix
+    above, digest ``6813caf5``) PLUS the remote-leg execution-policy seam ported
+    from omnibase_infra ``abc144fe6`` (OMN-17564) as a SUBSET, not a verbatim
+    re-copy. Two facts make a verbatim copy impossible
+    today, and both are somebody else's ticket:
+
+    1. That upstream file reads ``heavy_local`` at COLUMN 13 and ranks on a
+       ``placement_tier`` at column 14 (OMN-17392/OMN-17485). This repo's
+       ``prepush_hosts.tsv`` has thirteen columns with ``note`` at 13, so a
+       verbatim copy would read every row's free-text note as its heavy_local
+       policy. The columns must land here first.
+    2. That upstream file names this repo in three comment lines, which
+       ``test_the_picker_library_is_not_edited_into_a_repo_specific_fork``
+       below rejects outright.
+
+    So the two copies are NOT byte-identical and this constant cannot pretend
+    they are. What was ported is the OMN-17564 execution-policy seam verbatim
+    in behavior: same constant names, same ``PREPUSH_PICK_CORES`` name, same
+    ``min(row cores, cap)`` rule. One index diverges as a CONSEQUENCE of (1)
+    above -- upstream reads ``cores`` at fit-record f11 because its record
+    carries a ``tier_rank`` at f10; this record is nine fields, so ``cores``
+    appends at f10.
     """
     digest = hashlib.sha256(LIB.read_bytes()).hexdigest()
     assert (
         digest
-        == "6813caf5a8b9b13c9de2ecdb1702ebd74a9829055b391e9dfc39507da51bc67d"  # pragma: allowlist secret
+        == "7f44d020132ad43e2d8fd3458ad9e1a064c31d51538e5656384ca87ef5dd60ad"  # pragma: allowlist secret
     ), (
         "scripts/hooks/prepush_dispatch.sh has diverged from the pinned "
         "upstream copy. If the change is intentional, update this digest in "

--- a/tests/scripts/test_prepush_remote_leg_policy.py
+++ b/tests/scripts/test_prepush_remote_leg_policy.py
@@ -80,6 +80,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tomllib
 from pathlib import Path
 
@@ -689,14 +690,26 @@ def test_argv_flags_beat_the_inifile_shadow_that_ate_the_repo_addopts(
     )
 
     def _run_pytest(extra: list[str]) -> str:
+        # `sys.executable -m pytest`, NOT `uv run pytest`. The synthetic tree
+        # is deliberately not a uv project -- its pyproject.toml carries only
+        # `[tool.pytest.ini_options]`, because a `[project]` table is exactly
+        # what this fixture must NOT have to reproduce the shadow. `uv run`
+        # refuses such a tree outright ("No `project` table found in ...") on
+        # the uv that CI resolves, and worse, pointing UV_PROJECT_ENVIRONMENT
+        # at the real repo venv invites `uv run` to sync a throwaway fixture
+        # project INTO the venv running this suite. The interpreter already
+        # executing this test has pytest, xdist and pytest-timeout available
+        # by construction, so invoking it directly is both hermetic and
+        # uv-version-independent.
+        env = {k: v for k, v in os.environ.items() if not k.startswith("PYTEST_")}
         completed = subprocess.run(
-            ["uv", "run", "pytest", "tests/", "--tb=short", *extra],
+            [sys.executable, "-m", "pytest", "tests/", "--tb=short", *extra],
             cwd=tree,
             capture_output=True,
             text=True,
             timeout=600,
             check=False,
-            env={**os.environ, "UV_PROJECT_ENVIRONMENT": str(REPO_ROOT / ".venv")},
+            env=env,
         )
         return completed.stdout + completed.stderr
 

--- a/tests/scripts/test_prepush_remote_leg_policy.py
+++ b/tests/scripts/test_prepush_remote_leg_policy.py
@@ -1,0 +1,816 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""The remote execution leg must carry the same pytest EXECUTION POLICY the
+local leg runs under, and it must be liveness-bounded (OMN-17603).
+
+This is the omnibase_core port of the omnibase_infra fix landed as OMN-17564
+(``abc144fe6``). It is kept deliberately diffable against that file: same
+constant names, same fit-record field, same ``min(row cores, cap)`` rule.
+
+WHY THIS REPO NEEDED IT TOO -- and why the naive reading of the defect is
+WRONG here. In omnibase_infra the story was "the remote leg has no parallelism
+config anywhere". In omnibase_core that is false on its face:
+``pyproject.toml``'s ``[tool.pytest.ini_options] addopts`` ALREADY declares
+``-n4 --dist=loadgroup --timeout=60 --timeout-method=signal``. The remote leg
+ran single-threaded anyway, because THAT BLOCK IS NEVER READ.
+
+The mechanism is the one ``test_prepush_hook_has_bounded_timeout.py``
+(OMN-14967) already documents for the LOCAL leg: ``tests/pytest.ini`` is a real
+committed file whose own ``addopts`` is ``-v --tb=short --strict-markers
+--disable-warnings --color=yes`` -- no ``-n``, no ``--timeout``, no ``--dist``.
+Both legs invoke pytest with ``tests/`` as the argument, so pytest's
+rootdir/inifile discovery starts there, finds ``tests/pytest.ini``, and stops:
+``pytest.ini`` outranks ``pyproject.toml`` outright and the two do NOT merge.
+
+OMN-14967 closed that hole for the local leg by asserting both ``uv run
+pytest`` lines in ``prepush_smart_tests.sh`` pass ``-n``/``--timeout``
+EXPLICITLY on the command line, where no ini file can shadow them. The remote
+leg's pytest invocation does not live in that script -- it lives in the
+heredoc'd wrapper inside ``prepush_dispatch.sh`` -- so it was never covered by
+that guard, and it shipped ``"$UV" run pytest "${ARGV[@]}"
+--ignore=tests/integration --tb=short`` with ARGV holding PATHS ONLY. This
+module is the missing half of OMN-14967's invariant, at the dispatch seam.
+
+MEASURED, read-only probe of h105 (192.168.86.105) at 2026-09-02T19:24Z, on
+the live run ``omnibase_core-e69568dd5e02-80404``:
+
+* ``ps -Ao pid,ppid,pcpu,rss,etime,command`` showed pid 87006 as the ONLY
+  python process beneath the wrapper -- no ``execnet``/``gw*`` workers at all
+  -- 759,888 KB RSS, 1h49m elapsed.
+* that run's own ``suite.log`` header read ``rootdir:
+  .../tree/tests`` / ``configfile: pytest.ini`` / ``collected 44720 items``,
+  naming the shadowing file directly.
+
+So this change is PARITY, not a new parallelism policy: after it the remote
+leg runs under exactly the flags ``PREPUSH_TIMEOUT_FLAGS`` has always given
+the local leg, on an identical rootdir and an identical selection.
+
+The second face of the same seam, ported unchanged from OMN-17564: the
+execution ssh carried ``ConnectTimeout=6`` and nothing else, while EVERY probe
+ssh in the same file is ``timeout(1)``-wrapped. ``ConnectTimeout`` governs the
+handshake only, so a host that wedges AFTER connect holds the lane forever.
+
+What is pinned here:
+
+* The argv file shipped to the remote host carries the execution policy --
+  ``--dist=loadgroup --timeout=60 --timeout-method=signal`` and an ``-n<N>``.
+* ``N`` is resolved from the SELECTED ROW's ``cores`` column, capped, never a
+  hardcoded 4: a 2-core row gets ``-n2``, not four workers on two cores.
+* The policy flags never make an EMPTY selection look non-empty -- the
+  "no paths" refusal is decided on paths alone.
+* The execution ssh carries ``ServerAliveInterval``/``ServerAliveCountMax``
+  and is wrapped in the same ``timeout`` guard the probe legs already use.
+* Expiry is not a new code path: a leg that returns no MARKER is classified
+  NO EVIDENCE and the ranked walk ADVANCES to the next fit host, exactly as it
+  did for an unreachable host before this change.
+* The shadowing is pinned as a FACT, so if someone later deletes
+  ``tests/pytest.ini`` and assumes the repo-root addopts now applies, the
+  explicit flags are still proven present.
+
+The bash is extract-and-executed against fake ``ssh``/``scp``/``timeout``
+binaries that record their argv, so the assertions run THE code that ships
+rather than grepping for it.
+"""
+
+from __future__ import annotations
+
+import configparser
+import os
+import re
+import shutil
+import subprocess
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from omnibase_core.validators.no_unguarded_git_subprocess import (
+    scrub_git_location_env,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / "scripts" / "hooks" / "prepush_smart_tests.sh"
+LIB = REPO_ROOT / "scripts" / "hooks" / "prepush_dispatch.sh"
+
+pytestmark = pytest.mark.unit
+
+#: The execution policy the remote leg must carry. Held here as literals so a
+#: silent drop of any one of them turns this module red rather than costing
+#: another 4-5x slot-occupancy multiplier nobody measures for a week.
+POLICY_FLAGS = ("--dist=loadgroup", "--timeout=60", "--timeout-method=signal")
+
+#: The cap. It is the worker count this repo's LOCAL heavy leg already runs
+#: (``PREPUSH_TIMEOUT_FLAGS="-n4 --dist=loadgroup --timeout=60
+#: --timeout-method=signal"``, ``prepush_smart_tests.sh``), and the same value
+#: ``pyproject.toml``'s shadowed ``addopts`` declares -- i.e. this change is
+#: PARITY with the policy this repo has always intended, not a new one.
+XDIST_CAP = 4
+
+# A two-row synthetic table in THIS repo's column shape: 13 columns, with no
+# heavy_local/placement_tier (omnibase_infra carries those; omnibase_core has
+# not ported them -- OMN-17392/OMN-17485). The two rows differ only in `cores`,
+# which is the field under test.
+_TABLE = (
+    "#label\trole\thostname\tssh_target\tcores\tuv_abs_path\tuv_min_version"
+    "\tworkroot\tslot_mode\tslots\trepos_denied\tmode\tnote\n"
+    "hbig\tcapacity\thostbig\thostbig.lan\t32\t/bin/uv\t0.1.0\t/tmp/wbig"
+    "\tlockdir\t1\t-\tauthorizing\tthirty-two cores\n"
+    "hsmall\tcapacity\thostsmall\thostsmall.lan\t2\t/bin/uv\t0.1.0\t/tmp/wsmall"
+    "\tlockdir\t1\t-\tauthorizing\ttwo cores\n"
+)
+
+_FAKE_SSH = """#!/usr/bin/env bash
+printf 'SSH %s\\n' "$*" >> "$PREPUSH_TEST_LOG"
+exit 0
+"""
+
+# Records its argv and copies every LOCAL source file into the capture dir, so
+# the test can read the exact argv.txt that would have been shipped.
+_FAKE_SCP = """#!/usr/bin/env bash
+printf 'SCP %s\\n' "$*" >> "$PREPUSH_TEST_LOG"
+skip_next=0
+for a in "$@"; do
+  if [ "$skip_next" = "1" ]; then skip_next=0; continue; fi
+  case "$a" in
+    -o) skip_next=1; continue ;;
+    -*) continue ;;
+    *:*) continue ;;
+  esac
+  [ -f "$a" ] && cp "$a" "$PREPUSH_TEST_CAPTURE/" 2>/dev/null
+done
+exit 0
+"""
+
+# Records the budget it was handed, then runs the wrapped command, so wrapping
+# is proven without making every test wait on a real timeout(1).
+_FAKE_TIMEOUT = """#!/usr/bin/env bash
+printf 'TIMEOUT %s\\n' "$*" >> "$PREPUSH_TEST_LOG"
+shift
+exec "$@"
+"""
+
+
+def _extract_function(source: str, name: str) -> str:
+    lines = source.splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if line.startswith(f"{name}() {{")),
+        None,
+    )
+    assert start is not None, f"{name}() not found"
+    end = next((i for i in range(start + 1, len(lines)) if lines[i] == "}"), None)
+    assert end is not None, f"unterminated {name}()"
+    return "\n".join(lines[start : end + 1])
+
+
+def _synth_repo(tmp_path: Path, name: str = "synth") -> Path:
+    """A throwaway git repo whose HEAD carries the two-row table above.
+
+    The library reads the host table from HEAD, never the working tree, so the
+    repo has to be real and committed.
+    """
+    repo = tmp_path / name
+    (repo / "scripts" / "hooks").mkdir(parents=True)
+    (repo / "scripts" / "hooks" / "prepush_hosts.tsv").write_text(
+        _TABLE, encoding="utf-8"
+    )
+    (repo / "README.md").write_text("synthetic tree\n", encoding="utf-8")
+    # Every `git` call here passes env=scrub_git_location_env(os.environ)
+    # (OMN-14891). GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE are exported into
+    # every process a git hook spawns and OVERRIDE both `cwd=` and `-C`, and
+    # this module runs under the pre-push hook -- so an unscrubbed call would
+    # `git init` and COMMIT into the real invoking worktree rather than
+    # tmp_path. Spelled out at each call site so the guard can verify it
+    # statically.
+    subprocess.run(
+        ["git", "init", "-q", "."],
+        cwd=repo,
+        check=True,
+        env=scrub_git_location_env(os.environ),
+    )
+    subprocess.run(
+        ["git", "add", "-A"],
+        cwd=repo,
+        check=True,
+        env=scrub_git_location_env(os.environ),
+    )
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "table"],
+        cwd=repo,
+        check=True,
+        env=scrub_git_location_env(os.environ),
+    )
+    return repo
+
+
+def _fake_bin(tmp_path: Path) -> Path:
+    binbase = tmp_path / "fakebin"
+    binbase.mkdir()
+    for name, body in (
+        ("ssh", _FAKE_SSH),
+        ("scp", _FAKE_SCP),
+        ("timeout", _FAKE_TIMEOUT),
+    ):
+        p = binbase / name
+        p.write_text(body, encoding="utf-8")
+        p.chmod(0o755)
+    return binbase
+
+
+def _run(
+    repo_root: Path,
+    body: str,
+    env: dict[str, str] | None = None,
+    extra_prelude: str = "",
+) -> subprocess.CompletedProcess[str]:
+    """Run BODY with the real library sourced and the hook's own callbacks stubbed."""
+    bash = shutil.which("bash")
+    assert bash is not None, "bash not available"
+    script = f"""
+set -uo pipefail
+REPO_ROOT={repo_root}
+PREPUSH_LOAD_THRESHOLD=1.0
+log() {{ printf '[t] %s\\n' "$1" >&2; }}
+die() {{ printf 'DIE: %s\\n' "$1" >&2; exit 1; }}
+host_load_ratio() {{ printf '2.40 12 0.20\\n'; }}
+# The real resolver, copied from the hook that sources this library. It picks
+# the fake `timeout` this harness puts first on PATH.
+_prepush_timeout_cmd() {{
+  if command -v timeout > /dev/null 2>&1; then printf 'timeout'
+  elif command -v gtimeout > /dev/null 2>&1; then printf 'gtimeout'
+  fi
+}}
+. {LIB}
+{extra_prelude}
+{body}
+"""
+    return subprocess.run(
+        [bash, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+        stdin=subprocess.DEVNULL,
+        env={
+            **os.environ,
+            "PREPUSH_LOAD_OVERRIDE_MAP": "",
+            "PREPUSH_SLOT_OVERRIDE_MAP": "",
+            "PREPUSH_UV_OVERRIDE_MAP": "",
+            **(env or {}),
+        },
+    )
+
+
+def _leg_env(tmp_path: Path, **extra: str) -> dict[str, str]:
+    binbase = _fake_bin(tmp_path)
+    capture = tmp_path / "capture"
+    capture.mkdir()
+    log = tmp_path / "calls.log"
+    log.write_text("", encoding="utf-8")
+    base = {
+        "PATH": f"{binbase}{os.pathsep}{os.environ.get('PATH', '')}",
+        "PREPUSH_TEST_LOG": str(log),
+        "PREPUSH_TEST_CAPTURE": str(capture),
+        "PREPUSH_LOAD_OVERRIDE_MAP": "hbig=0.20,hsmall=0.20",
+        "PREPUSH_UV_OVERRIDE_MAP": "hbig=9.9.9,hsmall=9.9.9",
+        "PREPUSH_SLOT_OVERRIDE_MAP": "hbig=free,hsmall=free",
+    }
+    base.update(extra)
+    return base
+
+
+# =============================================================================
+# 0. The root cause this port exists to close: the repo-root addopts is SHADOWED
+# =============================================================================
+
+
+def test_the_repo_root_addopts_declares_the_policy_the_remote_leg_needs() -> None:
+    """``pyproject.toml`` is not the problem -- it already declares the policy.
+
+    Pinned so the next reader does not "fix" this by adding flags to a block
+    that is already correct and already ignored.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    addopts = data["tool"]["pytest"]["ini_options"]["addopts"]
+    assert f"-n{XDIST_CAP}" in addopts, addopts
+    for flag in POLICY_FLAGS:
+        assert flag in addopts, f"{flag} missing from repo-root addopts: {addopts}"
+
+
+def test_tests_pytest_ini_shadows_that_addopts_and_declares_none_of_it() -> None:
+    """The mechanism, asserted rather than described (OMN-14967's root cause).
+
+    Both legs invoke pytest with ``tests/`` as the argument, so config
+    discovery starts in ``tests/`` and stops at this file -- ``pytest.ini``
+    outranks ``pyproject.toml`` and the two do NOT merge. Live confirmation
+    from h105 on 2026-09-02: the dispatched suite's own log header read
+    ``rootdir: .../tree/tests`` / ``configfile: pytest.ini``.
+
+    If this file is ever deleted the assertion below flips and this test says
+    so plainly -- the explicit-flag guarantee further down does not depend on
+    it either way, which is the point of passing the flags on the argv.
+    """
+    ini_path = REPO_ROOT / "tests" / "pytest.ini"
+    assert ini_path.is_file(), (
+        "tests/pytest.ini is gone -- re-read this module's docstring: the "
+        "remote leg's flags are on the argv precisely so config discovery "
+        "cannot decide the policy either way"
+    )
+    parser = configparser.ConfigParser()
+    parser.read(ini_path, encoding="utf-8")
+    shadowing_addopts = parser["pytest"].get("addopts", "")
+    assert "-n" not in shadowing_addopts, shadowing_addopts
+    for flag in POLICY_FLAGS:
+        assert flag not in shadowing_addopts, (
+            f"{flag} is in tests/pytest.ini now; this module's premise moved"
+        )
+
+
+# =============================================================================
+# 1. Worker count is resolved from the selected row, capped, never hardcoded
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("cores", "expected"),
+    [
+        ("2", 2),  # a small row is NEVER oversubscribed to the cap
+        ("4", 4),
+        ("10", XDIST_CAP),
+        ("12", XDIST_CAP),
+        ("32", XDIST_CAP),
+        ("", 1),  # unresolvable -> today's single-worker behavior, never the cap
+        ("-", 1),
+        ("many", 1),
+        ("0", 1),
+    ],
+)
+def test_worker_count_is_min_of_the_rows_cores_and_the_cap(
+    tmp_path: Path, cores: str, expected: int
+) -> None:
+    """``-n`` follows the TARGET host, not the pushing host.
+
+    A fixed ``-n4`` would under-use a 32-core row and oversubscribe a 2-core
+    one; an unresolvable ``cores`` field degrades to one worker (exactly what
+    shipped before this change) rather than guessing headroom -- the same
+    fail-closed posture the load and slot probes already carry.
+    """
+    repo = _synth_repo(tmp_path)
+    out = _run(
+        repo,
+        f'PREPUSH_PICK_CORES="{cores}"\nprepush_remote_xdist_workers',
+    )
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert out.stdout.strip() == str(expected), out.stdout + out.stderr
+
+
+def test_the_flag_block_carries_the_whole_execution_policy(tmp_path: Path) -> None:
+    repo = _synth_repo(tmp_path)
+    out = _run(repo, 'PREPUSH_PICK_CORES="32"\nprepush_remote_pytest_flags')
+    assert out.returncode == 0, out.stdout + out.stderr
+    emitted = [line for line in out.stdout.splitlines() if line]
+    for flag in POLICY_FLAGS:
+        assert flag in emitted, f"{flag} missing from {emitted}"
+    assert f"-n{XDIST_CAP}" in emitted, emitted
+
+
+def test_the_picker_publishes_the_selected_rows_core_count(tmp_path: Path) -> None:
+    """``PREPUSH_PICK_CORES`` is what the worker count is resolved from, so the
+    picker has to publish it alongside every other ``PREPUSH_PICK_*`` field."""
+    repo = _synth_repo(tmp_path)
+    out = _run(
+        repo,
+        "pick_capacity_host somewhereelse synth authorizing\n"
+        'echo "PICK=${PREPUSH_PICK_LABEL} CORES=${PREPUSH_PICK_CORES}"',
+        env=_leg_env(tmp_path),
+    )
+    match = re.search(r"PICK=(\w+)", out.stdout)
+    assert match, out.stdout + out.stderr
+    label = match.group(1)
+    expected = "32" if label == "hbig" else "2"
+    assert f"CORES={expected}" in out.stdout, out.stdout + out.stderr
+
+
+def test_the_cores_field_does_not_disturb_the_ranking_key(tmp_path: Path) -> None:
+    """``cores`` is APPENDED, behind every field the ranking reads.
+
+    Index divergence from omnibase_infra is deliberate: infra reads ``cores``
+    at f11 because its record carries a ``tier_rank`` at f10
+    (OMN-17392/OMN-17485), which this repo has not ported -- so here the record
+    is nine fields and ``cores`` lands at f10. The coupling the remote leg
+    actually has is to the NAME ``PREPUSH_PICK_CORES``, which is identical in
+    both.
+
+    The records are sorted on field 1 (the load ratio) alone in this repo, so
+    appending must not change which host wins. Both synthetic rows are pinned
+    to the same ratio here, which means the ONLY way a specific host could be
+    selected is the append order -- i.e. the sort is proven not to have started
+    keying on the new column.
+    """
+    repo = _synth_repo(tmp_path)
+    out = _run(
+        repo,
+        "pick_capacity_host somewhereelse synth authorizing\n"
+        'printf "%s\\n" "$PREPUSH_FIT_RECORDS"',
+        env=_leg_env(tmp_path),
+    )
+    records = [line for line in out.stdout.splitlines() if "|" in line]
+    assert len(records) == 2, out.stdout + out.stderr
+    for record in records:
+        fields = record.split("|")
+        assert len(fields) == 10, record
+        assert fields[9] in {"32", "2"}, record
+
+
+# =============================================================================
+# 2. The argv FILE that is shipped carries the policy
+# =============================================================================
+
+
+def _dispatch_one_leg(
+    tmp_path: Path, cores: str = "32", body_extra: str = ""
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    """Drive the real ``prepush_remote_run`` against fake ssh/scp/timeout.
+
+    Nothing writes a MARKER, so the leg lands on the NO-EVIDENCE branch -- the
+    branch an expired or wedged host also lands on.
+    """
+    repo = _synth_repo(tmp_path)
+    env = _leg_env(tmp_path)
+    out = _run(
+        repo,
+        "IS_FULL=True\n"
+        'FULL_SUITE_TARGET="tests/"\n'
+        "RUNNABLE_INTEGRATION_PATHS=()\n"
+        "PATHS=()\n"
+        'PREPUSH_PICK_LABEL="hbig"\n'
+        'PREPUSH_PICK_HOSTNAME="hostbig"\n'
+        'PREPUSH_PICK_SSH="hostbig.lan"\n'
+        'PREPUSH_PICK_UV="/bin/uv"\n'
+        'PREPUSH_PICK_WORKROOT="/tmp/wbig"\n'
+        'PREPUSH_PICK_SLOTMODE="lockdir"\n'
+        'PREPUSH_PICK_MODE="authorizing"\n'
+        'PREPUSH_PICK_SLOT="1"\n'
+        'PREPUSH_PICK_RATIO="0.20"\n'
+        'PREPUSH_PROBE_LOG="hbig=fit"\n'
+        f'PREPUSH_PICK_CORES="{cores}"\n'
+        f"{body_extra}"
+        'rc=0; prepush_remote_run "full-suite escalation" || rc=$?\n'
+        'echo "RC=${rc}"',
+        env=env,
+    )
+    return out, Path(env["PREPUSH_TEST_CAPTURE"]), Path(env["PREPUSH_TEST_LOG"])
+
+
+def test_the_shipped_argv_file_carries_paths_then_the_execution_policy(
+    tmp_path: Path,
+) -> None:
+    out, capture, _ = _dispatch_one_leg(tmp_path, cores="32")
+    argv = (capture / "argv.txt").read_text(encoding="utf-8").splitlines()
+    assert argv, out.stdout + out.stderr
+    # The selection still leads, byte-identical to what it always was: the
+    # policy is APPENDED, so it can never displace or reorder a test path.
+    assert argv[0] == "tests/", argv
+    for flag in POLICY_FLAGS:
+        assert flag in argv, f"{flag} missing from shipped argv {argv}"
+    assert f"-n{XDIST_CAP}" in argv, argv
+
+
+def test_the_shipped_worker_count_follows_a_small_row_down(tmp_path: Path) -> None:
+    """End-to-end, not just at the helper: a 2-core row ships ``-n2``."""
+    _, capture, _ = _dispatch_one_leg(tmp_path, cores="2")
+    argv = (capture / "argv.txt").read_text(encoding="utf-8").splitlines()
+    assert "-n2" in argv, argv
+    assert f"-n{XDIST_CAP}" not in argv, argv
+
+
+def test_the_selection_paths_receipt_field_stays_paths_only(tmp_path: Path) -> None:
+    """``prepush_remote_argv`` is the SELECTION, and the receipt records it under
+    ``selection_paths``. Folding execution flags into it would make an audit of
+    "what did that host actually run" read flags as coverage."""
+    repo = _synth_repo(tmp_path)
+    out = _run(
+        repo,
+        "IS_FULL=True\n"
+        'FULL_SUITE_TARGET="tests/"\n'
+        "RUNNABLE_INTEGRATION_PATHS=()\n"
+        "PATHS=()\n"
+        'PREPUSH_PICK_CORES="32"\n'
+        "prepush_remote_argv",
+    )
+    assert out.stdout.splitlines() == ["tests/"], out.stdout + out.stderr
+
+
+def test_the_policy_flags_cannot_make_an_empty_selection_look_runnable(
+    tmp_path: Path,
+) -> None:
+    """The "nothing selected" refusal is decided on PATHS alone.
+
+    If the flags were written before the emptiness check, a selection that
+    resolved to zero paths would ship an argv file of pure flags -- pytest
+    would then collect ``testpaths`` from the transplanted tree's own config
+    (``tests/pytest.ini`` declares ``testpaths = unit integration``), silently
+    running something nobody selected and reporting it as this push's evidence.
+    """
+    out, capture, log = _dispatch_one_leg(
+        tmp_path,
+        cores="32",
+        body_extra='IS_FULL=False\nPATHS=()\nFULL_SUITE_TARGET="tests/"\n',
+    )
+    assert "RC=1" in out.stdout, out.stdout + out.stderr
+    assert not (capture / "argv.txt").exists(), "an empty selection was shipped"
+    assert "SCP" not in log.read_text(encoding="utf-8")
+
+
+# =============================================================================
+# 3. The execution ssh is liveness-bounded
+# =============================================================================
+
+
+def test_the_execution_ssh_carries_keepalives_and_a_timeout_guard(
+    tmp_path: Path,
+) -> None:
+    """``ConnectTimeout`` governs the handshake only.
+
+    The leg that sat 5h29m on a wedged h105 had connected successfully; what it
+    lacked was any bound on SILENCE after that. Keepalives bound the transport
+    and the ``timeout`` wrapper bounds the whole run, mirroring the probe legs
+    in this same file which are all ``timeout``-wrapped already.
+    """
+    out, _, log = _dispatch_one_leg(tmp_path)
+    calls = log.read_text(encoding="utf-8").splitlines()
+    exec_calls = [
+        c for c in calls if "prepush_smart_tests.sh" in c and c.startswith("SSH")
+    ]
+    assert exec_calls, f"no execution ssh recorded: {calls}\n{out.stderr}"
+    execline = exec_calls[0]
+    assert "ServerAliveInterval=" in execline, execline
+    assert "ServerAliveCountMax=" in execline, execline
+
+    wrapped = [c for c in calls if c.startswith("TIMEOUT") and "ssh" in c]
+    assert wrapped, f"the execution ssh was not wrapped in the timeout guard: {calls}"
+    budget = wrapped[0].split()[1]
+    assert budget.isdigit() and int(budget) > 0, wrapped[0]
+
+
+def test_the_execution_ssh_runs_unwrapped_when_no_timeout_binary_exists(
+    tmp_path: Path,
+) -> None:
+    """``timeout(1)`` ships on neither Mac in the lab by default.
+
+    Its absence must degrade to the keepalive bound alone -- which still closes
+    the wedged-host case -- rather than refusing to dispatch at all.
+    """
+    repo = _synth_repo(tmp_path)
+    env = _leg_env(tmp_path)
+    out = _run(
+        repo,
+        "IS_FULL=True\n"
+        'FULL_SUITE_TARGET="tests/"\n'
+        "RUNNABLE_INTEGRATION_PATHS=()\n"
+        "PATHS=()\n"
+        'PREPUSH_PICK_LABEL="hbig"\n'
+        'PREPUSH_PICK_HOSTNAME="hostbig"\n'
+        'PREPUSH_PICK_SSH="hostbig.lan"\n'
+        'PREPUSH_PICK_UV="/bin/uv"\n'
+        'PREPUSH_PICK_WORKROOT="/tmp/wbig"\n'
+        'PREPUSH_PICK_SLOTMODE="lockdir"\n'
+        'PREPUSH_PICK_MODE="authorizing"\n'
+        'PREPUSH_PICK_SLOT="1"\n'
+        'PREPUSH_PICK_RATIO="0.20"\n'
+        'PREPUSH_PROBE_LOG="hbig=fit"\n'
+        'PREPUSH_PICK_CORES="32"\n'
+        'rc=0; prepush_remote_run "full-suite escalation" || rc=$?\n'
+        'echo "RC=${rc}"',
+        env=env,
+        extra_prelude="_prepush_timeout_cmd() { printf ''; }\n",
+    )
+    calls = Path(env["PREPUSH_TEST_LOG"]).read_text(encoding="utf-8").splitlines()
+    exec_calls = [
+        c for c in calls if "prepush_smart_tests.sh" in c and c.startswith("SSH")
+    ]
+    assert exec_calls, f"no execution ssh recorded: {calls}\n{out.stderr}"
+    assert "ServerAliveInterval=" in exec_calls[0], exec_calls[0]
+    assert not [c for c in calls if c.startswith("TIMEOUT")], calls
+
+
+# =============================================================================
+# 4. Expiry falls through to the EXISTING no-evidence classification
+# =============================================================================
+
+
+def test_a_leg_that_writes_no_marker_is_no_evidence_not_a_verdict(
+    tmp_path: Path,
+) -> None:
+    out, _, _ = _dispatch_one_leg(tmp_path)
+    assert "RC=1" in out.stdout, out.stdout + out.stderr
+    assert "NO completion marker" in out.stderr, out.stderr
+    assert "not a pass, not a failure" in out.stderr, out.stderr
+
+
+def test_the_ranked_walk_advances_past_a_leg_that_produced_no_marker(
+    tmp_path: Path,
+) -> None:
+    """Timing a host out must cost the NEXT host, not the whole escalation.
+
+    This is the property that makes the ``timeout`` wrapper safe to add: it
+    creates no new classification. An expired leg returns exactly what an
+    unreachable-on-arrival leg has always returned, and ``dispatch_to_lab_host``
+    already treats that as a PLACEMENT miss.
+    """
+    repo = _synth_repo(tmp_path)
+    env = _leg_env(tmp_path)
+    out = _run(
+        repo,
+        "IS_FULL=True\n"
+        'FULL_SUITE_TARGET="tests/"\n'
+        "RUNNABLE_INTEGRATION_PATHS=()\n"
+        "PATHS=()\n"
+        'PREPUSH_LC_HOST="somewhereelse"\n'
+        'rc=0; dispatch_to_lab_host "full-suite escalation" || rc=$?\n'
+        'echo "RC=${rc}"',
+        env=env,
+        extra_prelude=_extract_function(
+            HOOK.read_text(encoding="utf-8"), "dispatch_to_lab_host"
+        ),
+    )
+    assert "RC=1" in out.stdout, out.stdout + out.stderr
+    # BOTH fit candidates were tried -- the walk did not stop at the first
+    # silent host, and it did not forge a verdict from either.
+    assert "hbig" in out.stderr and "hsmall" in out.stderr, out.stderr
+    assert "no fit lab host produced a verdict" in out.stderr, out.stderr
+    assert "REMOTE LAB RUN PASS" not in out.stderr, out.stderr
+
+
+# =============================================================================
+# 4b. The flags actually WIN against the config-discovery shadow
+# =============================================================================
+
+
+def test_argv_flags_beat_the_inifile_shadow_that_ate_the_repo_addopts(
+    tmp_path: Path,
+) -> None:
+    """The bug lives one level below "did we append the flags".
+
+    Everything above proves the flags reach ``argv.txt``. This proves they
+    still WIN once pytest resolves its config on the remote host -- which is
+    the exact step that silently discarded the repo-root ``addopts`` in the
+    first place. Reproduced hermetically in a synthetic tree with the same
+    shape as the transplanted one: a repo-root ``pyproject.toml`` declaring
+    ``-n4``, and a ``tests/pytest.ini`` declaring an ``addopts`` without it.
+
+    Both halves are asserted, because only the pair is evidence:
+
+    * invoked the OLD way (paths only), pytest reports ``configfile:
+      pytest.ini``, spins NO xdist workers and arms NO timeout -- the defect,
+      reproduced.
+    * invoked the NEW way (paths + this leg's policy flags), the same tree
+      reports the same ``configfile`` and DOES spin workers and arm the
+      signal-method timeout -- the shadow is still there, and the flags beat
+      it anyway.
+
+    That second point is why this fix is correct independently of whether
+    ``tests/pytest.ini`` is ever merged away: argv outranks every ini file.
+    """
+    tree = tmp_path / "tree"
+    (tree / "tests").mkdir(parents=True)
+    (tree / "pyproject.toml").write_text(
+        '[tool.pytest.ini_options]\naddopts = ["-n4"]\n', encoding="utf-8"
+    )
+    # The shadowing file, same shape as this repo's: an addopts with no -n.
+    (tree / "tests" / "pytest.ini").write_text(
+        "[pytest]\naddopts =\n    --tb=short\n    --strict-markers\n",
+        encoding="utf-8",
+    )
+    (tree / "tests" / "test_synthetic.py").write_text(
+        "def test_one() -> None:\n    assert True\n\n\n"
+        "def test_two() -> None:\n    assert True\n",
+        encoding="utf-8",
+    )
+
+    def _run_pytest(extra: list[str]) -> str:
+        completed = subprocess.run(
+            ["uv", "run", "pytest", "tests/", "--tb=short", *extra],
+            cwd=tree,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+            env={**os.environ, "UV_PROJECT_ENVIRONMENT": str(REPO_ROOT / ".venv")},
+        )
+        return completed.stdout + completed.stderr
+
+    # The defect, reproduced: the repo-root -n4 is discarded outright. xdist
+    # announces its pool as "N workers [...]" on the header line, so its
+    # ABSENCE is the single-threaded run this ticket exists to end.
+    before = _run_pytest([])
+    assert "configfile: pytest.ini" in before, before
+    assert "workers" not in before, (
+        "the synthetic tree did not reproduce the shadow -- the repo-root "
+        f"-n4 was honoured, so this test proves nothing:\n{before}"
+    )
+    assert "timeout method" not in before, before
+
+    # The fix: the same shadow, the same tree, flags on the argv.
+    after = _run_pytest([f"-n{XDIST_CAP}", *POLICY_FLAGS])
+    assert "configfile: pytest.ini" in after, after
+    assert f"created: {XDIST_CAP}/{XDIST_CAP} workers" in after, (
+        "the -n did NOT survive config discovery -- putting the policy on the "
+        f"argv is exactly what this change relies on:\n{after}"
+    )
+    # The watchdog half of the policy has to survive the same shadow, and it
+    # is the half that silently does nothing when it does not.
+    assert "timeout: 60.0s" in after, after
+    assert "timeout method: signal" in after, after
+
+
+# =============================================================================
+# 5. The policy must be HONOURABLE on the transplanted tree
+# =============================================================================
+
+
+def test_the_shipped_flags_are_backed_by_declared_test_dependencies() -> None:
+    """A flag the remote environment cannot honour is a FALSE RED, and a false
+    red on this leg HARD-BLOCKS the push.
+
+    The remote wrapper materializes the tree with ``uv sync --all-extras``,
+    which installs this project's default dependency groups. ``-n``/``--dist``
+    come from ``pytest-xdist`` and ``--timeout``/``--timeout-method`` from
+    ``pytest-timeout``; if either is dropped from the declared groups, pytest
+    exits on "unrecognized arguments" on EVERY dispatched suite and every
+    escalation becomes a refusal. Pin the coupling rather than discover it on a
+    host at 02:00.
+
+    Live corroboration that the sync does install them: the h105 run's own
+    suite.log header on 2026-09-02 listed ``xdist-3.8.0`` and ``timeout-2.4.0``
+    among its loaded plugins -- the plugins were present, only the FLAGS were
+    missing.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    dev = data["dependency-groups"]["dev"]
+    names = {re.split(r"[<>=!~\[ ]", spec, maxsplit=1)[0] for spec in dev}
+    assert "pytest-xdist" in names, "-n/--dist are shipped to the remote leg"
+    assert "pytest-timeout" in names, "--timeout/--timeout-method are shipped"
+
+
+def test_the_remote_pytest_invocation_is_otherwise_unchanged() -> None:
+    """The policy is ADDITIVE. The remote wrapper still ignores
+    ``tests/integration`` (the leg deliberately excludes service-dependent
+    suites) and still shortens tracebacks; nothing about the invocation moved
+    except the argv it is handed."""
+    lib = LIB.read_text(encoding="utf-8")
+    assert (
+        '"$UV" run pytest "${ARGV[@]}" --ignore=tests/integration --tb=short' in lib
+    ), "the remote pytest invocation changed shape"
+
+
+def test_the_policy_is_constants_not_env_indirection() -> None:
+    """``PREPUSH_*`` env overrides are forbidden by the hook (OMN-16480), and
+    the ``-n4`` local flags are already a bare constant for the same reason: an
+    env indirection here would let ``PREPUSH_REMOTE_XDIST_WORKER_CAP=1`` restore
+    the single-threaded defect in one word, silently."""
+    lib = LIB.read_text(encoding="utf-8")
+    for const in (
+        "PREPUSH_REMOTE_POLICY_FLAGS",
+        "PREPUSH_REMOTE_XDIST_WORKER_CAP",
+        "PREPUSH_REMOTE_SSH_ALIVE_INTERVAL_SECONDS",
+        "PREPUSH_REMOTE_SSH_ALIVE_COUNT_MAX",
+        "PREPUSH_REMOTE_EXEC_TIMEOUT_SECONDS",
+    ):
+        assert re.search(rf"^{const}=[^$]", lib, re.MULTILINE), (
+            f"{const} must be a bare constant, not a ${{VAR:-...}} indirection"
+        )
+
+
+def test_the_remote_policy_matches_the_local_legs_policy() -> None:
+    """PARITY IS THE WHOLE CLAIM.
+
+    The remote leg is not being given a new configuration -- it is being given
+    the one ``PREPUSH_TIMEOUT_FLAGS`` has always given the local leg. If the
+    local leg's policy is ever changed without the remote leg following, the
+    two legs stop being interchangeable evidence for the same gate, and this
+    test says so.
+    """
+    hook = HOOK.read_text(encoding="utf-8")
+    match = re.search(r'^PREPUSH_TIMEOUT_FLAGS="([^"]*)"', hook, re.MULTILINE)
+    assert match, "PREPUSH_TIMEOUT_FLAGS assignment not found in the hook"
+    local_flags = match.group(1).split()
+    lib = LIB.read_text(encoding="utf-8")
+    remote_match = re.search(
+        r'^PREPUSH_REMOTE_POLICY_FLAGS="([^"]*)"', lib, re.MULTILINE
+    )
+    assert remote_match, "PREPUSH_REMOTE_POLICY_FLAGS assignment not found"
+    remote_flags = set(remote_match.group(1).split())
+    for flag in local_flags:
+        if flag.startswith("-n"):
+            # The worker count is the ONE deliberate divergence: the local leg
+            # sizes it for THIS machine, the remote leg for the target row.
+            assert flag == f"-n{XDIST_CAP}", (
+                "the local leg's worker count moved; re-derive "
+                f"PREPUSH_REMOTE_XDIST_WORKER_CAP against it (local: {flag})"
+            )
+            continue
+        assert flag in remote_flags, (
+            f"the local leg runs {flag} and the remote leg does not -- the two "
+            "legs are no longer interchangeable evidence for the same gate"
+        )


### PR DESCRIPTION
## What

Ports `omnibase_infra`'s OMN-17564 (`abc144fe6`) into this repo's copy of the
governed pre-push picker. The remote leg shipped the **selection** across the
dispatch seam and dropped the **execution policy**: `prepush_remote_argv()`
emitted only test paths, and the remote wrapper ran

```
"$UV" run pytest "${ARGV[@]}" --ignore=tests/integration --tb=short
```

with no `-n`, no `--dist`, no `--timeout`, no `--reruns`. Same tree, same SHA,
completely different execution policy depending on whether the escalation was
placed locally or remotely.

## Root cause — the obvious reading is wrong, and the real cause is worse

The natural hypothesis is "`addopts` should have covered it". It does not, and
cannot. This repo's `pyproject.toml` `[tool.pytest.ini_options] addopts`
**already** declares `-n4 --dist=loadgroup --timeout=60 --timeout-method=signal
--reruns=2`. That block is simply **never read** on either leg.

`tests/pytest.ini` is a real committed file whose own `addopts` is
`-v --tb=short --strict-markers --disable-warnings --color=yes` — no `-n`, no
`--timeout`, no `--reruns`. Both legs invoke pytest with `tests/...` arguments,
so config discovery starts in `tests/`, finds `pytest.ini`, and **stops**.
`pytest.ini` outranks `pyproject.toml` outright, and their settings are never combined.

The local leg is immune only because `prepush_smart_tests.sh:760` puts the
policy on the command line explicitly (`PREPUSH_TIMEOUT_FLAGS`), where discovery
cannot lose it. This leg's pytest invocation lives in the heredoc'd wrapper
inside `prepush_dispatch.sh`, so OMN-14967's bounded-timeout guard never covered
it. **Argv outranks every ini file**, which is why this fix is correct
regardless of whether `tests/pytest.ini` is ever merged away.

`tests/pytest.ini` is **not touched** by this PR. That shadowing is a latent trap
for any invocation that passes `tests/` without explicit flags, changes local
behavior too, and needs its own blast-radius review — filed as a follow-up per
the ticket's "Out of scope" section.

---

## dod_evidence — OMN-17603

### The proof is this PR's own push: a controlled A/B on one host

The governed pre-push for **this very commit** placed the escalation on **h105
(`omnibook`)**, and the fix therefore bootstrapped itself — the run that
authorized this push ran *under* the policy this push adds. The immediately
preceding core full-suite escalation on the **same host** ran the **same 16
selection paths** without it. Both `suite.log` files read back live from
`/Users/Shared/onex-prepush/runs/` on h105.

| | PRE-fix (`108e089f`, OMN-17606 core) | POST-fix (`14200300`, this PR) |
|---|---|---|
| run dir | `omnibase_core-108e089f7e8f-1921` | `omnibase_core-142003006703-48548` |
| host | h105 `omnibook` (10-core M4) | h105 `omnibook` (10-core M4) |
| `configfile:` | `pytest.ini` | `pytest.ini` *(unchanged — the shadow is still there)* |
| workers | *(no `created:` line — sequential)* | `created: 4/4 workers` / `4 workers [44741 items]` |
| watchdog | *(no `timeout:` line — unwatched)* | `timeout: 60.0s` / `timeout method: signal` |
| **wall** | **12966.95s (3:36:06)** | **5571.03s (1:32:51)** |
| result | 44652 passed, 59 skipped, 3 xpassed | 44683 passed, 59 skipped, 3 xpassed |
| `argv.txt` tail | *(paths only)* | `... -n4 --dist=loadgroup --timeout=60 --timeout-method=signal` |

**2.33x faster; 7395.92s = 2h03m15s less exclusive slot occupancy per core
escalation.** Note the `configfile:` row: identical on both sides. The shadow is
not removed, it is *out-ranked* — which is exactly the claim being made.

The PRE-fix run's 3 failures were `test_prepush_hook_host_identity_guard.py`
host-identity tests, unrelated to this change and fixed separately by
OMN-16634 / #1640.

### Second push (`e615aac7`) — the measurement repeated, and a CI-only red fixed

The AC-8 hermetic test drove its synthetic tree with `uv run pytest`. That tree
deliberately has **no** `[project]` table (a `[project]` table is exactly what
the fixture must not have for the shadow to reproduce), which the uv this
workstation resolves tolerates and the uv CI resolves does not:

```
error: No `project` table found in: `.../tree/pyproject.toml`
```

It went red as `Tests (Split 7/40)` and nowhere else. Adding a `[project]` table
to satisfy `uv run` would have destroyed the fixture, so the uv layer is gone
instead: `sys.executable -m pytest`, with `PYTEST_*` scrubbed from the child env
so the outer run's state cannot leak into a test whose whole subject is which
config file the inner run resolves. That call also passed
`UV_PROJECT_ENVIRONMENT=<repo>/.venv`, so on a uv that *accepts* a bare-tool
pyproject it would invite `uv run` to sync a throwaway fixture project into the
venv running this very suite — a hazard removed along with the version
dependence. Module now 27/27 in 22.91s, down from several times that.

That second push is an independent repeat of the headline measurement, on the
same host and the same selection:

```
remote leg: pytest policy -> -n4 --dist=loadgroup --timeout=60 --timeout-method=signal (10 cores declared, cap 4)
remote leg: dispatching ... to h105.2 (omnibook, ratio 0.134, mode authorizing)
[h105.2] REMOTE_WRAPPER_EXIT=0
44683 passed, 59 skipped, 3 xpassed, 151 warnings in 5242.42s (1:27:22)
```

**1:27:22 against the 3:36:06 pre-fix baseline — 2.47x, 2h08m45s of slot
occupancy returned per core escalation.** The `(10 cores declared, cap 4)` line
is AC 2 resolving live: h105 declares 10 cores in the host table, `min(10, 4)`
is 4, and the count came from the *target* row rather than the 24-core pushing
host.

Both pushes placed on **h105 slot 2**, first attempt, zero capacity refusals.

### Governed pre-push receipt for the pushed head

`.onex_state/prepush_distribution/receipts.jsonl`:

```
"ts":"2026-09-04T01:51:04Z","head_sha":"142003006703e1280497f1d1e79336f657697be7",
"chosen_host":"omnibook","chosen_label":"h105.2","chosen_slot":2,
"host_mode":"authorizing","host_load_ratio":"0.125",
"pytest_policy":"-n4 --dist=loadgroup --timeout=60 --timeout-method=signal ",
"pytest_exit":0,"duration_s":5580
```

`chosen_slot: 2` — this is also the second live proof that the OMN-16634 /
OMN-17602 / OMN-17606 capacity stack made slot 2 genuinely placeable.

`pytest_policy` is a **new receipt field**, recorded separately from
`selection_paths` on purpose (see AC 3 below).

### Local gates

| gate | result |
|---|---|
| `tests/scripts/` (292 tests) | green |
| `ruff format --check` | `2 files already formatted` |
| `ruff check` | `All checks passed!` |
| `mypy --strict` | `Success: no issues found in 2 source files` |
| `shellcheck -S error scripts/hooks/prepush_dispatch.sh` | silent, rc=0 |
| `pre-commit run --all-files` | pass |

### Acceptance criteria — all eight

1. **Five policy constants**, as constants and **not** `${VAR:-...}`
   (`prepush_dispatch.sh:835,845,860-862`). An env indirection would be a
   one-word bypass — `workers=1` restores the defect silently — and a `PREPUSH_*`
   override in the environment is already a HARD REFUSAL (OMN-16480).
2. **`prepush_remote_xdist_workers()`** — `-n min(target row cores, 4)`,
   resolved from the **target row**, never the pushing host, never hardcoded.
   Absent or non-numeric `cores` degrades to **1 worker** (today's behavior), not
   to a guess — the same fail-closed posture the load/slot/uv probes carry.
3. **`prepush_remote_pytest_flags()`**, kept a **separate function** from
   `prepush_remote_argv`, appended to `argv.txt` **after** the paths-only
   emptiness check so it is covered by `argv_sha`. The marker therefore binds the
   verdict to the flags the suite actually ran under; a host that answered under
   a different policy cannot satisfy the dispatch. Keeping the functions apart is
   what stops an audit of "what did that host run" from reading execution flags
   as coverage.
4. **`cores` carried on the fit record**, so `PREPUSH_PICK_CORES` resolves.
5. **ssh keepalives + `timeout(1)` wrapper on the execution ssh**, with the
   documented no-`timeout(1)` fall-through. `ConnectTimeout` bounds the handshake
   only — the 2026-09-02 leg that sat 5h29m against a wedged h105 had already
   connected. Expiry introduces no new classification: no MARKER is read back,
   which the existing code already treats as a placement miss and walks past.
6. **`omnibase_infra` untouched.** OMN-17564 owns that side.
7. **`tests/scripts/test_prepush_remote_leg_policy.py`** (27 tests) drives the
   real bash against fake `ssh`/`scp`/`timeout` binaries that record their argv,
   so the shipped argv file, the execution ssh command line and the ranked-walk
   advance are asserted on the code that ships rather than grepped for.
8. **The flags are proven to win against config discovery, hermetically.** A
   synthetic tree reproduces the shadow (repo-root `-n4`, `tests/pytest.ini`
   without it) and is run twice: paths-only reports `configfile: pytest.ini` with
   no workers and no timeout armed — the defect, reproduced — and paths+policy
   reports the **same** configfile but `created: 4/4 workers`, `timeout: 60.0s`,
   `timeout method: signal`.

---

## Divergences from infra, stated rather than hidden

This is a **documented subset port, not a verbatim re-copy.** Two independently
verified blockers make a verbatim copy impossible:

1. **`PREPUSH_PICK_CORES` index.** infra reads `cores` at fit-record **f11**
   because its record carries a `tier_rank` at f10 (OMN-17392 / OMN-17485). This
   repo has no `placement_tier`, so its record is nine fields and `cores` appends
   at **f10** — `cut -d'|' -f10`, with the divergence commented at the read site.
   The env var **name** is identical, which is what the remote leg couples to;
   only the index differs. The tier ladder stays out of scope.
2. **Host-table column layout.** infra reads `heavy_local` at column 13 and ranks
   on `placement_tier` at column 14; this repo's TSV has 13 columns with `note`
   at 13. A verbatim copy would read every row's free-text note as its
   `heavy_local` policy.
3. **Repo-name scrub.** infra's `abc144fe6` introduces three occurrences of this
   repo's own name into the shared library, which
   `test_the_picker_library_is_not_edited_into_a_repo_specific_fork` rejects
   outright. Verified this was added by OMN-17564 rather than pre-existing:
   `git show e4b69a281:scripts/hooks/prepush_dispatch.sh | grep -c <name>` = 0.
   My own comments were scrubbed of the repo name for the same reason — that
   guard is correct.

Two further deliberate deltas:

- **`test_prepush_host_table.py`** — `test_the_verdict_is_read_from_a_marker_not_the_ssh_exit_code`
  pinned `|| true` inside a fixed 400-char window after the wrapper invocation.
  Lifting that invocation into `$remote_cmd` (it is now issued twice —
  timeout-wrapped and not) moved the anchor, so the assertion now checks the
  property directly on **every** streaming branch instead of a magic window.
- **`scrub_git_location_env(os.environ)`** on every git subprocess in the new
  module (OMN-14891). This module runs under the pre-push hook, where
  `GIT_DIR`/`GIT_WORK_TREE` override both `cwd=` and `-C`; an unscrubbed
  `git init`/`commit` would have targeted the real invoking worktree instead of
  `tmp_path`.

---

## Why the cost is slot occupancy, not just wall clock

Every capacity row holds an **exclusive** heavy-suite slot for the duration of a
run, so a ~2.3x slower run holds the scarce resource ~2.3x longer. OMN-17603's
own comment thread measured three concurrent single-threaded core legs holding
**all three** h201 slots for 7h56m / 10h10m / 11h02m while that 32-core box sat
at load1 5.64 = 0.18x — 29 idle cores, and omnimarket pushes refused for want of
capacity. A single-threaded core lane also measured ~4h35m, which is **above** the
~2h10m–2h30m macOS detached-Bash ceiling, so such a lane cannot be landed at all
from a detached lane. `1:32:51` is comfortably under it.

Evidence-Ticket: OMN-17603
Evidence-Source: 7f16b19b383255f73238ee93349449c15224736e
