### PR TITLE
fix(OMN-15660): arm the terminal correlation predicate in host mode and stop reading a missing status as success (OMN-17567)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.2"
+version = "0.47.3"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -340,10 +340,16 @@ class RuntimeLocal:
         # distinct from one this runtime minted and then failed to stamp onto a
         # frozen payload. ``None`` until the event-driven path publishes.
         self._wire_correlation_id: uuid.UUID | None = None
-        # Correlation predicate for the terminal watcher. Set only in client
-        # mode: an in-process host on its own bus has exactly one producer of
-        # the terminal topic, so filtering there would change offline behaviour
-        # for no gain.
+        # Correlation predicate for the terminal watcher. Armed in BOTH modes
+        # from the correlation id that actually reached the wire (OMN-15660).
+        # It was client-only under OMN-17304 on the premise that an in-process
+        # host owns its bus and is therefore the only producer of the terminal
+        # topic. That premise holds only for the in-memory bus, which dies with
+        # the process; on a durable broker the terminal topic retains every
+        # earlier run's terminal, and `onex delegate` — the sole production
+        # caller — runs host mode. ``None`` only when no correlation reached
+        # the wire at all, which host mode still tolerates (see the arming site
+        # in ``_run_event_driven``).
         self._expected_correlation_id: uuid.UUID | None = None
 
     # ONEX_EXCLUDE: dict_str_any — event bus payload
@@ -358,7 +364,9 @@ class RuntimeLocal:
         ours is the same defect as a foreign one.
 
         Returns ``True`` unconditionally when no correlation predicate is armed
-        (host mode), preserving first-terminal-wins there.
+        — i.e. when no correlation id reached the wire, so there is nothing to
+        compare against. That is the only remaining unfiltered case; it is NOT
+        a host/client distinction (OMN-15660).
         """
         expected = self._expected_correlation_id
         if expected is None:
@@ -391,12 +399,99 @@ class RuntimeLocal:
             logger.warning("Duplicate terminal event received — ignoring (first wins).")
             return
 
-        status = payload.get("status", "success")
-        logger.info("RuntimeLocal: terminal event received (status=%s)", status)
+        declared = self._terminal_status_declarations(payload)
+        if not declared and self._is_envelope_shaped(payload):
+            msg = (
+                "RuntimeLocal: terminal envelope declares no status at either "
+                "the envelope or the payload level — this run's outcome is "
+                "UNKNOWN, and UNKNOWN is never read as success (OMN-17567). "
+                "correlation="
+                f"{payload.get('correlation_id', '(none)')}"
+            )
+            logger.error(msg)
+            self._last_error = msg
+            self._terminal_payload = payload
+            self._result = EnumWorkflowResult.FAILED
+            self._terminal_received.set()
+            return
+
+        logger.info(
+            "RuntimeLocal: terminal event received (status=%s)",
+            "/".join(sorted(declared)) if declared else "(absent)",
+        )
         self._terminal_payload = payload
-        self._result = self._classify_result(payload)
+        self._result = self._classify_terminal(payload, declared)
 
         self._terminal_received.set()
+
+    # ONEX_EXCLUDE: dict_str_any — event bus payload
+    @staticmethod
+    def _is_envelope_shaped(payload: RawWorkflowMap) -> bool:
+        """Whether a terminal message is a ``ModelEventEnvelope`` wire dict.
+
+        Same discriminator the inbound path already uses
+        (``runtime_local_adapter._unwrap_envelope_dict``): ``envelope_id`` plus a
+        mapping ``payload``. A bare domain payload that happens to carry its own
+        ``payload`` field (e.g. ``ModelRoutingIntent``) has no ``envelope_id``
+        and is not an envelope.
+        """
+        return "envelope_id" in payload and isinstance(payload.get("payload"), dict)
+
+    # ONEX_EXCLUDE: dict_str_any — event bus payload
+    @staticmethod
+    def _terminal_status_declarations(payload: RawWorkflowMap) -> set[str]:
+        """Every ``status`` a terminal declares, normalized, across both levels.
+
+        Two terminal shapes coexist on one topic: the single-output adapter path
+        publishes the bare domain payload (``status`` at the top level), the
+        fan-out path publishes a ``ModelEventEnvelope`` (``status`` under
+        ``payload``). Reading only the top level — and defaulting the miss to
+        ``"success"`` — meant an envelope-shaped terminal could never surface a
+        failure, so a FAILED delegation was reported as completed (OMN-17567).
+
+        Both levels are read, with the same precedence
+        ``_terminal_correlation_matches`` uses for correlation ids: collect what
+        is declared, then decide on the whole set rather than on whichever level
+        happened to be looked at first.
+        """
+        declared: set[str] = set()
+        for container in (payload, payload.get("payload")):
+            if not isinstance(container, dict):
+                continue
+            raw = container.get("status")
+            if isinstance(raw, str) and raw.strip():
+                declared.add(raw.strip().lower())
+        return declared
+
+    # ONEX_EXCLUDE: dict_str_any — event bus payload
+    def _classify_terminal(
+        self, payload: RawWorkflowMap, declared: set[str]
+    ) -> EnumWorkflowResult:
+        """Classify a terminal event from the statuses it actually declares.
+
+        Decision order:
+        1. a failure status declared at EITHER level → FAILED. Disagreement
+           fails closed — a terminal that says both is not a success.
+        2. every declared status a success value → COMPLETED.
+        3. otherwise → the shared ``_classify_result`` heuristics
+           (``cycles_failed`` / ``error_message`` / no marker) over the DOMAIN
+           payload, unwrapped when the message is envelope-shaped so those
+           fields are read where they actually live.
+
+        The no-status-anywhere case on an envelope never reaches here: the
+        caller refuses it outright rather than letting rule 3's "no failure
+        marker → COMPLETED" tail read an unclassifiable terminal as green. A
+        bare domain terminal with no status (e.g. ``{"kind": "completed"}``) is
+        the long-standing offline shape and keeps rule 3.
+        """
+        if declared & _FAILURE_STATUS_VALUES:
+            return EnumWorkflowResult.FAILED
+        if declared and declared <= _SUCCESS_STATUS_VALUES:
+            return EnumWorkflowResult.COMPLETED
+        domain: object = (
+            payload.get("payload") if self._is_envelope_shaped(payload) else payload
+        )
+        return self._classify_result(domain)
 
     # ------------------------------------------------------------------
     # Routing detection
@@ -1293,8 +1388,17 @@ class RuntimeLocal:
                 message=msg,
             )
         self._wire_correlation_id = correlation_id
-        if not self.host_handlers:
-            self._expected_correlation_id = correlation_id
+        # OMN-15660: arm the terminal correlation predicate in BOTH modes. Under
+        # OMN-17304 this was client-only, and client mode has zero production
+        # callers — `onex delegate` runs host mode — so on a Kafka-backed lane
+        # every delegation accepted whatever terminal the topic still retained
+        # from an earlier run. The predicate is the actual isolation boundary;
+        # run-scoping the terminal consumer group below is not sufficient on its
+        # own, because a brand-new group still reads the retained log from the
+        # beginning. ``None`` here means nothing correlated reached the wire, and
+        # a filter with no operand cannot be armed; client mode already refuses
+        # that case above, host mode keeps first-terminal-wins.
+        self._expected_correlation_id = correlation_id
 
         # --- 4. Wire adapters to bus ---
         unsubscribe_handles: list[UnsubscribeCallback] = []
@@ -1416,17 +1520,26 @@ class RuntimeLocal:
             payload = decoded if isinstance(decoded, dict) else {}
             self._on_terminal_event(cast("RawWorkflowMap", payload))
 
-        # OMN-17304 AC5: a client must not inherit another run's committed
+        # OMN-17304 AC5 / OMN-15660: no run may inherit another run's committed
         # offset on the terminal topic. The shared runtime-local group id is
-        # correct for a long-lived host; for a one-shot client it means a fresh
-        # invocation resumes wherever the last one stopped and works through a
-        # backlog of terminals that are, by construction, not its own. The
-        # group is run-scoped instead, and empty groups age out of the broker
-        # on the standard offset-retention window.
+        # only correct for a long-lived host on a bus that dies with it; on a
+        # durable broker it means a fresh invocation resumes wherever the last
+        # one stopped and works through a backlog of terminals that are, by
+        # construction, not its own. OMN-17304 run-scoped this for clients only
+        # and client mode has no production callers, so every `onex delegate`
+        # on a Kafka-backed lane shared one group. Empty groups age out of the
+        # broker on the standard offset-retention window.
+        #
+        # Gated on the correlation predicate being armed because the two are
+        # only safe together: a brand-new group reads the retained log from the
+        # beginning, so scoping WITHOUT a filter trades "the uncommitted tail"
+        # for "the entire retention window" — strictly worse. When nothing
+        # correlated reached the wire there is no operand to filter on, so the
+        # shared group is left exactly as it was rather than made worse.
         terminal_group_node = TERMINAL_CONSUMER_NODE_NAME
-        if not self.host_handlers:
+        if self._expected_correlation_id is not None:
             terminal_group_node = (
-                f"{TERMINAL_CONSUMER_NODE_NAME}_client_{self.run_id.hex[:12]}"
+                f"{TERMINAL_CONSUMER_NODE_NAME}_run_{self.run_id.hex[:12]}"
             )
         unsub = await bus.subscribe(
             terminal_topic,

--- a/tests/gates/test_consumer_group_name_authorization.py
+++ b/tests/gates/test_consumer_group_name_authorization.py
@@ -280,6 +280,17 @@ def _real_producer_group_names(
     names["runtime_local.terminal"] = runtime_local.derive_runtime_local_group_id(
         runtime_local.TERMINAL_CONSUMER_NODE_NAME
     )
+    # OMN-15660 run-scoped the terminal group for every correlated run, in host
+    # mode as well as client mode — so this variant, not the bare one, is what
+    # `onex delegate` now mints against MSK. An unauthorized name here is the
+    # OMN-15639 failure mode again (GroupAuthorizationFailedError before publish),
+    # so the gate has to see the shape that actually reaches the broker.
+    names["runtime_local.terminal_run_scoped"] = (
+        runtime_local.derive_runtime_local_group_id(
+            f"{runtime_local.TERMINAL_CONSUMER_NODE_NAME}_run_"
+            f"{_SAMPLE_CORRELATION_ID.hex[:12]}"
+        )
+    )
     names["runtime_local.handler"] = runtime_local.derive_runtime_local_group_id(
         "HandlerDelegateSkill"
     )

--- a/tests/unit/runtime/test_runtime_local_client_mode.py
+++ b/tests/unit/runtime/test_runtime_local_client_mode.py
@@ -359,13 +359,19 @@ async def test_client_mode_accepts_its_own_terminal_after_a_foreign_one(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_host_mode_terminal_is_not_correlation_filtered(tmp_path: Path) -> None:
-    """Counter-assertion: host mode keeps first-terminal-wins semantics.
+async def test_host_mode_terminal_is_correlation_filtered_too(tmp_path: Path) -> None:
+    """SUPERSEDED BY OMN-15660: host mode is filtered on the same terms.
 
-    In-process hosting on the in-memory bus has exactly one producer of the
-    terminal topic — this run's own handler — so adding a filter there would
-    change offline behaviour for no gain. Scoping the filter to client mode is
-    deliberate, and this test pins that scope.
+    This test previously asserted the opposite — that first-terminal-wins was
+    deliberately preserved in host mode because "in-process hosting on the
+    in-memory bus has exactly one producer of the terminal topic". That premise
+    is true only of the in-memory bus, which dies with the process. Host mode is
+    the DEFAULT (``host_handlers=True``) and the only mode any production caller
+    uses, so on a Kafka-backed lane the unfiltered path meant `onex delegate`
+    adopted whatever terminal the topic still retained from an earlier run —
+    observed live 2026-09-02, a run returning a 12-minute-old FAILED terminal as
+    its own success. The predicate is now armed wherever a correlation id
+    reached the wire, in either mode.
     """
     correlation_id = uuid.uuid4()
     runtime = _build_runtime(
@@ -381,7 +387,14 @@ async def test_host_mode_terminal_is_not_correlation_filtered(tmp_path: Path) ->
     )
     result = await task
 
-    assert result is EnumWorkflowResult.COMPLETED
+    assert result is EnumWorkflowResult.TIMEOUT, (
+        "host mode accepted a foreign terminal — the default (and only "
+        "production) mode still returns another run's result as its own"
+    )
+    written = json.loads(
+        (tmp_path / "state" / "workflow_result.json").read_text(encoding="utf-8")
+    )
+    assert "terminal_payload" not in written
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/test_runtime_local_terminal_isolation.py
+++ b/tests/unit/runtime/test_runtime_local_terminal_isolation.py
@@ -1,0 +1,606 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Terminal-event isolation for ``RuntimeLocal`` (OMN-15660, OMN-17567).
+
+Two defects, both proven live on 2026-09-02 against a Kafka-backed single-tenant
+lane, and both invisible to the OMN-17304 suite because that suite only exercises
+``host_handlers=False`` — a mode with **zero production callers**.
+
+**OMN-15660 — cross-run terminal adoption.** ``RuntimeLocal.__init__`` defaults
+``host_handlers=True``; ``onex delegate`` therefore always runs host mode. In host
+mode the OMN-17304 remedies were both gated off: the correlation predicate was
+never armed and the terminal consumer group was never run-scoped. On a durable
+broker every invocation joined one fixed group, inherited the previous run's
+committed offset, and adopted whatever terminal was still retained — a *sequential*
+manifestation (runs minutes apart), not the concurrent one the original ticket
+described. The state is self-perpetuating: a run that adopts a stale terminal
+returns before publishing its own, leaving that one retained-and-uncommitted for
+the next run.
+
+**OMN-17567 — optimistic status read.** ``_on_terminal_event`` read
+``payload.get("status", "success")`` at the *envelope* top level. A
+``ModelEventEnvelope``-shaped terminal carries no top-level ``status`` — it lives
+under ``payload.status`` — so a FAILED terminal was classified COMPLETED. Two
+terminal shapes coexist on the delegate topic (the single-output adapter path
+publishes a bare domain payload; the fan-out path publishes an envelope), which is
+what made the ambiguity reachable.
+
+Every positive assertion here is paired with a counter-assertion that pins the
+behaviour it must NOT destroy: the offline in-process path with a status-less
+domain terminal must stay COMPLETED, or "refuse everything" would satisfy these
+tests while deleting the offline runtime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+from omnibase_core.enums.enum_workflow_result import EnumWorkflowResult
+from omnibase_core.protocols.runtime.protocol_local_runtime_message import (
+    ProtocolLocalRuntimeMessage,
+)
+from omnibase_core.runtime.runtime_local import RuntimeLocal
+
+_MODULE = "tests.unit.runtime.test_runtime_local_terminal_isolation"
+
+_COMMAND_TOPIC = "onex.cmd.omn15660.terminal-isolation.v1"
+_TERMINAL_TOPIC = "onex.evt.omn15660.terminal-isolation-completed.v1"
+
+
+class ModelIsolationCommand(BaseModel):
+    """Frozen request model, shaped like ``ModelDelegateSkillRequest``."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    correlation_id: uuid.UUID = Field(...)
+    prompt: str = Field(default="")
+
+
+class HandlerIsolationEcho:
+    """Host-mode handler: echoes this run's correlation onto the terminal topic.
+
+    The ``sleep`` is load-bearing for the concurrent test: without a real yield
+    inside the publish chain, two ``run_async`` coroutines gathered together run to
+    completion one after the other and the "concurrent" case degenerates into a
+    sequential one that passes vacuously.
+    """
+
+    async def handle(self, payload: ModelIsolationCommand) -> dict[str, str]:
+        # The prompt carries this run's think-time so a concurrent test can put
+        # the slow run in the terminal wait at the exact moment the fast run's
+        # terminal lands. Without a real yield inside the publish chain, two
+        # gathered ``run_async`` coroutines run one after the other and every
+        # "concurrent" assertion passes vacuously.
+        await asyncio.sleep(0.30 if payload.prompt == "slow" else 0.01)
+        return {
+            "status": "success",
+            "correlation_id": str(payload.correlation_id),
+            "prompt": payload.prompt,
+        }
+
+
+# ---------------------------------------------------------------------------
+# A retaining broker double: Kafka semantics (retained log + per-group committed
+# offsets) with no Kafka. The in-memory bus dies with the process and is immune
+# to this defect by construction, so it cannot express the bug.
+# ---------------------------------------------------------------------------
+
+
+class _DurableMessage:
+    """Minimal ``ProtocolLocalRuntimeMessage`` stand-in."""
+
+    def __init__(self, value: bytes, topic: str) -> None:
+        self.value = value
+        self.key: bytes | None = None
+        self.topic = topic
+        self.headers: dict[str, str] = {}
+
+
+class _DurableBroker:
+    """Records survive the process that published them; groups carry offsets.
+
+    Subscribers live on the BROKER, not on a bus instance: a topic is shared by
+    every process attached to it, so a publish from one run must reach another
+    run's subscription. A bus instance that only fans out to its own subscribers
+    cannot express cross-run delivery at all, and every cross-talk test against it
+    would pass vacuously.
+    """
+
+    def __init__(self) -> None:
+        self.log: dict[str, list[bytes]] = {}
+        self.committed: dict[tuple[str, str], int] = {}
+        self.subscribers: list[
+            tuple[str, str, Callable[[ProtocolLocalRuntimeMessage], Awaitable[None]]]
+        ] = []
+
+    def append(self, topic: str, value: bytes) -> None:
+        self.log.setdefault(topic, []).append(value)
+
+    def seed(self, topic: str, payload: dict[str, Any]) -> None:
+        """Retain a record no consumer group has committed past (the live LAG-1)."""
+        self.append(topic, json.dumps(payload).encode("utf-8"))
+
+    async def drain(
+        self,
+        topic: str,
+        group_id: str,
+        on_message: Callable[[ProtocolLocalRuntimeMessage], Awaitable[None]],
+    ) -> None:
+        """Deliver every record this group has not committed past, in order."""
+        offset_key = (group_id, topic)
+        while self.committed.get(offset_key, 0) < len(self.log.get(topic, [])):
+            index = self.committed.get(offset_key, 0)
+            self.committed[offset_key] = index + 1
+            await on_message(_DurableMessage(self.log[topic][index], topic))  # type: ignore[arg-type]
+
+    async def deliver(self, topic: str) -> None:
+        for sub_topic, group_id, on_message in list(self.subscribers):
+            if sub_topic == topic:
+                await self.drain(topic, group_id, on_message)
+
+
+class _DurableBus:
+    """One process's view of :class:`_DurableBroker`.
+
+    A fresh instance per run — like a fresh ``onex delegate`` process — while the
+    broker (log, committed offsets, live subscribers) outlives every one of them.
+    """
+
+    def __init__(self, broker: _DurableBroker) -> None:
+        self.broker = broker
+        self.subscriptions: list[tuple[str, str]] = []
+        self.closed = False
+
+    @property
+    def subscribed_topics(self) -> list[str]:
+        return [topic for topic, _group in self.subscriptions]
+
+    def terminal_groups(self) -> list[str]:
+        return [
+            group for topic, group in self.subscriptions if topic == _TERMINAL_TOPIC
+        ]
+
+    async def start(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def publish(self, topic: str, key: object, value: bytes) -> object:
+        self.broker.append(topic, value)
+        await self.broker.deliver(topic)
+        return None
+
+    async def subscribe(
+        self,
+        topic: str,
+        *,
+        on_message: Callable[[ProtocolLocalRuntimeMessage], Awaitable[None]],
+        group_id: str,
+    ) -> Callable[[], Awaitable[None]]:
+        self.subscriptions.append((topic, group_id))
+        registration = (topic, group_id, on_message)
+        self.broker.subscribers.append(registration)
+        await self.broker.drain(topic, group_id, on_message)
+
+        async def _unsub() -> None:
+            if registration in self.broker.subscribers:
+                self.broker.subscribers.remove(registration)
+
+        return _unsub
+
+
+def _write_contract(target: Path) -> None:
+    contract: dict[str, Any] = {
+        "workflow_id": "omn-15660-terminal-isolation",
+        "name": "terminal_isolation_probe",
+        "terminal_event": _TERMINAL_TOPIC,
+        "event_bus": {
+            "subscribe_topics": [_COMMAND_TOPIC],
+            "publish_topics": [_TERMINAL_TOPIC],
+        },
+        "handler_routing": {
+            "routing_strategy": "operation_match",
+            "handlers": [
+                {
+                    "operation": "start",
+                    "handler": {"module": _MODULE, "name": "HandlerIsolationEcho"},
+                    "event_model": {"module": _MODULE, "name": "ModelIsolationCommand"},
+                    "output_topic": _TERMINAL_TOPIC,
+                }
+            ],
+        },
+    }
+    target.write_text(yaml.safe_dump(contract), encoding="utf-8")
+
+
+def _build_runtime(
+    run_dir: Path,
+    *,
+    correlation_id: uuid.UUID,
+    host_handlers: bool = True,
+    timeout: int = 2,
+    prompt: str = "probe",
+) -> RuntimeLocal:
+    """One runtime, with its own state_root — a distinct `onex delegate` process."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    contract_path = run_dir / "contract.yaml"
+    input_path = run_dir / "input.json"
+    _write_contract(contract_path)
+    input_path.write_text(
+        json.dumps({"correlation_id": str(correlation_id), "prompt": prompt}),
+        encoding="utf-8",
+    )
+    return RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=run_dir / "state",
+        input_path=input_path,
+        timeout=timeout,
+        host_handlers=host_handlers,
+    )
+
+
+def _bind(runtime: RuntimeLocal, bus: _DurableBus) -> None:
+    runtime._create_event_bus = lambda: bus  # type: ignore[assignment,method-assign]
+
+
+def _written(run_dir: Path) -> dict[str, Any]:
+    raw = (run_dir / "state" / "workflow_result.json").read_text(encoding="utf-8")
+    decoded: dict[str, Any] = json.loads(raw)
+    return decoded
+
+
+def _envelope(correlation_id: uuid.UUID, payload: dict[str, Any]) -> dict[str, Any]:
+    """A ``ModelEventEnvelope`` wire dict — the fan-out publish shape.
+
+    ``envelope_id`` + a dict ``payload`` is the discriminator the adapter already
+    uses (``_unwrap_envelope_dict``); note there is deliberately no top-level
+    ``status`` key, which is the whole of OMN-17567.
+    """
+    return {
+        "envelope_id": str(uuid.uuid4()),
+        "envelope_timestamp": "2026-09-02T11:59:00.005090Z",
+        "correlation_id": str(correlation_id),
+        "event_type": "omnimarket.delegate-skill-completed",
+        "payload": payload,
+    }
+
+
+# ---------------------------------------------------------------------------
+# OMN-15660: sequential cross-run adoption on a durable bus.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_host_mode_never_adopts_a_retained_terminal_from_an_earlier_run(
+    tmp_path: Path,
+) -> None:
+    """The live defect: run B adopts run A's retained terminal and exits.
+
+    Sequential, not concurrent — run A is already gone. The broker still holds A's
+    terminal because A never joined it (it had adopted an even older one), which is
+    the LAG-1 state observed on the lane. Run B must ignore A's record entirely and
+    complete only on the terminal its own handler publishes.
+    """
+    broker = _DurableBroker()
+    run_a_correlation = uuid.uuid4()
+    broker.seed(
+        _TERMINAL_TOPIC,
+        {"status": "success", "correlation_id": str(run_a_correlation)},
+    )
+
+    run_b_correlation = uuid.uuid4()
+    run_b_dir = tmp_path / "run_b"
+    runtime = _build_runtime(run_b_dir, correlation_id=run_b_correlation)
+    bus = _DurableBus(broker)
+    _bind(runtime, bus)
+
+    result = await runtime.run_async()
+
+    assert result is EnumWorkflowResult.COMPLETED
+    written = _written(run_b_dir)
+    assert written["terminal_payload"]["correlation_id"] == str(run_b_correlation), (
+        "host mode adopted an earlier run's retained terminal — this run reported "
+        f"correlation {written['terminal_payload'].get('correlation_id')} as its own "
+        f"result, but it published {run_b_correlation}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_host_mode_refuses_a_retained_failed_terminal_from_an_earlier_run(
+    tmp_path: Path,
+) -> None:
+    """The compounded live case: the adopted terminal was a FAILURE.
+
+    Offset 1 on the lane was an envelope whose ``payload.status`` was ``failed``;
+    the runtime reported the run ``completed``. Both defects have to be fixed for
+    this to hold — correlation isolation (OMN-15660) and the status read
+    (OMN-17567).
+    """
+    broker = _DurableBroker()
+    run_a_correlation = uuid.uuid4()
+    broker.seed(
+        _TERMINAL_TOPIC,
+        _envelope(
+            run_a_correlation,
+            {
+                "status": "failed",
+                "correlation_id": str(run_a_correlation),
+                "quality_gates_failed": ["coverage"],
+            },
+        ),
+    )
+
+    run_b_correlation = uuid.uuid4()
+    run_b_dir = tmp_path / "run_b"
+    runtime = _build_runtime(run_b_dir, correlation_id=run_b_correlation)
+    bus = _DurableBus(broker)
+    _bind(runtime, bus)
+
+    result = await runtime.run_async()
+
+    written = _written(run_b_dir)
+    assert written["terminal_payload"]["correlation_id"] == str(run_b_correlation), (
+        "this run reported another run's FAILED terminal as its own result"
+    )
+    assert result is EnumWorkflowResult.COMPLETED
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_host_mode_terminal_group_is_run_scoped(tmp_path: Path) -> None:
+    """A host must not inherit another run's committed terminal offset either.
+
+    OMN-17304 AC5 run-scoped this group for clients only. ``onex delegate`` is a
+    host, so on the lane every invocation joined one fixed group and resumed the
+    previous run's offset. Run-scoping alone does not fix adoption (a fresh group
+    reads the retained backlog from the beginning) — it must land together with the
+    armed correlation predicate, which the tests above cover.
+    """
+    broker = _DurableBroker()
+    correlation_id = uuid.uuid4()
+    run_dir = tmp_path / "run"
+    runtime = _build_runtime(run_dir, correlation_id=correlation_id)
+    bus = _DurableBus(broker)
+    _bind(runtime, bus)
+
+    await runtime.run_async()
+
+    groups = bus.terminal_groups()
+    assert len(groups) == 1
+    assert runtime.run_id.hex[:12] in groups[0], (
+        "host-mode terminal subscription reused the shared runtime-local group id "
+        f"{groups[0]!r}; a fresh run resumes another run's committed offset"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_two_sequential_host_runs_do_not_share_a_terminal_group(
+    tmp_path: Path,
+) -> None:
+    """End-to-end sequential proof: run A, let it finish, then run B.
+
+    Each run must join its own terminal group and return its own correlation. This
+    is the shape ``onex delegate`` actually takes on a Kafka-backed lane.
+    """
+    broker = _DurableBroker()
+
+    run_a_correlation = uuid.uuid4()
+    run_a_dir = tmp_path / "run_a"
+    runtime_a = _build_runtime(run_a_dir, correlation_id=run_a_correlation)
+    bus_a = _DurableBus(broker)
+    _bind(runtime_a, bus_a)
+    result_a = await runtime_a.run_async()
+
+    run_b_correlation = uuid.uuid4()
+    run_b_dir = tmp_path / "run_b"
+    runtime_b = _build_runtime(run_b_dir, correlation_id=run_b_correlation)
+    bus_b = _DurableBus(broker)
+    _bind(runtime_b, bus_b)
+    result_b = await runtime_b.run_async()
+
+    assert result_a is EnumWorkflowResult.COMPLETED
+    assert result_b is EnumWorkflowResult.COMPLETED
+    assert _written(run_a_dir)["terminal_payload"]["correlation_id"] == str(
+        run_a_correlation
+    )
+    assert _written(run_b_dir)["terminal_payload"]["correlation_id"] == str(
+        run_b_correlation
+    ), "the second run returned the first run's result"
+    assert bus_a.terminal_groups() != bus_b.terminal_groups(), (
+        "both runs joined the same terminal consumer group"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_slow_host_run_does_not_adopt_a_concurrent_runs_terminal(
+    tmp_path: Path,
+) -> None:
+    """OMN-15660's original concurrent framing, on the host path this time.
+
+    The slow run is parked in its terminal wait when the fast run's terminal is
+    published. Sharing one terminal consumer group, the slow run's callback is
+    served that record first and — with no correlation predicate armed — accepts
+    it, so the slow run returns the fast run's answer and the fast run gets
+    nothing. Ordering here is deterministic: the slow handler sleeps 30x longer.
+    """
+    broker = _DurableBroker()
+
+    slow_correlation = uuid.uuid4()
+    fast_correlation = uuid.uuid4()
+    slow_dir = tmp_path / "concurrent_slow"
+    fast_dir = tmp_path / "concurrent_fast"
+    slow = _build_runtime(
+        slow_dir, correlation_id=slow_correlation, timeout=5, prompt="slow"
+    )
+    fast = _build_runtime(
+        fast_dir, correlation_id=fast_correlation, timeout=5, prompt="fast"
+    )
+    _bind(slow, _DurableBus(broker))
+    _bind(fast, _DurableBus(broker))
+
+    slow_result, fast_result = await asyncio.gather(slow.run_async(), fast.run_async())
+
+    assert _written(slow_dir)["terminal_payload"]["correlation_id"] == str(
+        slow_correlation
+    ), "the slow run adopted the concurrent fast run's terminal"
+    assert _written(fast_dir)["terminal_payload"]["correlation_id"] == str(
+        fast_correlation
+    ), "the fast run's own terminal was consumed by the concurrent slow run"
+    assert slow_result is EnumWorkflowResult.COMPLETED
+    assert fast_result is EnumWorkflowResult.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# OMN-17567: the terminal status read.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_envelope_shaped_failed_terminal_is_classified_failed(tmp_path: Path) -> None:
+    """``payload.status == "failed"`` on an envelope must not read as success.
+
+    ``_on_terminal_event`` looked for ``status`` at the envelope top level only and
+    defaulted the miss to ``"success"``, so an envelope-shaped terminal could never
+    surface a failure through this path.
+    """
+    correlation_id = uuid.uuid4()
+    runtime = RuntimeLocal(
+        workflow_path=tmp_path / "contract.yaml",
+        state_root=tmp_path / "state",
+    )
+
+    runtime._on_terminal_event(
+        _envelope(
+            correlation_id,
+            {"status": "failed", "correlation_id": str(correlation_id)},
+        )
+    )
+
+    assert runtime._result is EnumWorkflowResult.FAILED
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("status", ["failure", "failed", "error", "ERROR"])
+def test_envelope_shaped_failure_statuses_all_classify_failed(
+    tmp_path: Path, status: str
+) -> None:
+    """The envelope path recognises the same failure vocabulary as the bare path."""
+    correlation_id = uuid.uuid4()
+    runtime = RuntimeLocal(
+        workflow_path=tmp_path / "contract.yaml",
+        state_root=tmp_path / "state",
+    )
+
+    runtime._on_terminal_event(
+        _envelope(
+            correlation_id,
+            {"status": status, "correlation_id": str(correlation_id)},
+        )
+    )
+
+    assert runtime._result is EnumWorkflowResult.FAILED
+
+
+@pytest.mark.unit
+def test_envelope_shaped_terminal_with_no_status_anywhere_is_refused(
+    tmp_path: Path,
+) -> None:
+    """An envelope that declares no status is UNKNOWN — and UNKNOWN is not success.
+
+    Symmetric with ``_terminal_correlation_matches``, which already refuses an
+    envelope that names no correlation: an unattributable terminal accepted as ours
+    is the same defect as a foreign one, and an unclassifiable one accepted as green
+    is the same defect as a failed one.
+    """
+    correlation_id = uuid.uuid4()
+    runtime = RuntimeLocal(
+        workflow_path=tmp_path / "contract.yaml",
+        state_root=tmp_path / "state",
+    )
+
+    runtime._on_terminal_event(
+        _envelope(correlation_id, {"correlation_id": str(correlation_id)})
+    )
+
+    assert runtime._result is not EnumWorkflowResult.COMPLETED
+    assert runtime._result is EnumWorkflowResult.FAILED
+    assert "status" in (runtime.last_error or "").lower(), (
+        f"refusal did not name the missing status: {runtime.last_error!r}"
+    )
+
+
+@pytest.mark.unit
+def test_envelope_shaped_success_terminal_is_completed(tmp_path: Path) -> None:
+    """Counter-assertion: a genuine envelope success still completes."""
+    correlation_id = uuid.uuid4()
+    runtime = RuntimeLocal(
+        workflow_path=tmp_path / "contract.yaml",
+        state_root=tmp_path / "state",
+    )
+
+    runtime._on_terminal_event(
+        _envelope(
+            correlation_id,
+            {"status": "success", "correlation_id": str(correlation_id)},
+        )
+    )
+
+    assert runtime._result is EnumWorkflowResult.COMPLETED
+
+
+@pytest.mark.unit
+def test_bare_domain_terminal_without_status_keeps_the_offline_classification(
+    tmp_path: Path,
+) -> None:
+    """Counter-assertion: the offline path publishes bare payloads with no status.
+
+    The single-output adapter path dumps the handler's return value directly, so a
+    terminal like ``{"kind": "completed"}`` is normal and has always been COMPLETED
+    via the ``_classify_result`` heuristics. Refusing it would delete the offline
+    runtime, so the OMN-17567 refusal is scoped to envelope-shaped messages, which
+    are structurally required to carry a domain status.
+    """
+    runtime = RuntimeLocal(
+        workflow_path=tmp_path / "contract.yaml",
+        state_root=tmp_path / "state",
+    )
+
+    runtime._on_terminal_event({"kind": "completed"})
+
+    assert runtime._result is EnumWorkflowResult.COMPLETED
+
+
+@pytest.mark.unit
+def test_envelope_payload_failure_beats_an_envelope_level_success(
+    tmp_path: Path,
+) -> None:
+    """Disagreement fails closed: a failure declared anywhere is a failure."""
+    correlation_id = uuid.uuid4()
+    runtime = RuntimeLocal(
+        workflow_path=tmp_path / "contract.yaml",
+        state_root=tmp_path / "state",
+    )
+
+    payload = _envelope(
+        correlation_id,
+        {"status": "failed", "correlation_id": str(correlation_id)},
+    )
+    payload["status"] = "success"
+
+    runtime._on_terminal_event(payload)
+
+    assert runtime._result is EnumWorkflowResult.FAILED

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.2"
+version = "0.47.3"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## OMN-15660 — the terminal isolation the runtime was never actually applying

`RuntimeLocal.__init__` defaults `host_handlers=True`, and no production caller passes `False` — the only occurrences outside `runtime_local.py` are in `tests/unit/runtime/test_runtime_local_client_mode.py`. `onex delegate` therefore always runs host mode. Both OMN-17304 remedies sat behind `if not self.host_handlers`, so neither has ever executed in production:

- the terminal correlation predicate (`_expected_correlation_id`) was never armed, and `_terminal_correlation_matches` returns `True` unconditionally when unarmed;
- the terminal consumer group was never run-scoped, so every invocation joined the fixed group `local.omnibase_core.runtime_local_terminal.consume.v1.__i.<instance>.__t.onex.evt.omnimarket.delegate-skill-completed.v1`.

On a durable broker that means a run inherits the previous run's committed offset and adopts whatever terminal is still retained.

### Observed live, 2026-09-02

On a Kafka-backed single-tenant lane (read-only `rpk` probes, no mutation): the terminal topic held 3 records under 7-day retention with the group at CURRENT-OFFSET 2 / LOG-END 3 / LAG 1. Run `61ff0925` joined that group, was served the 11:59 terminal for correlation `109c2285` sitting at offset 0, accepted it with no correlation check, and returned `result=completed` in the same second with no LLM call. Its own terminal arrived 3s later at offset 2 and was never joined — that is the standing lag. The state is self-perpetuating: a run that adopts a stale terminal returns before publishing its own, leaving that one retained-and-uncommitted for the next run.

Only the CLI-side OMN-17295 correlation join (`omnibase_infra/src/omnibase_infra/cli/receipt_mode.py:474-500`) caught it, because the CLI is the last boundary that still knows which correlation id it minted.

Not lane-specific: the same shared group exists on the stability-test lane. Tier-0 (in-memory bus, dies with the process) is immune; any configured Kafka/Redpanda transport is exposed. This is the beta delegation path.

## OMN-17567 — a FAILED terminal reported as completed

`_on_terminal_event` read `payload.get("status", "success")` against the **envelope** top level. Two terminal shapes coexist on that one topic: the single-output adapter path publishes the bare domain payload (`status` at the top), the fan-out path publishes a `ModelEventEnvelope` (`status` under `payload`). An envelope-shaped terminal has no top-level `status`, so it defaulted to `"success"` and `_classify_result` returned COMPLETED. Envelope-shaped terminals could never surface a failure through this path at all — and the terminal the probe above adopted was `status=failed` with `quality_gates_failed` populated.

## What changed

`src/omnibase_core/runtime/runtime_local.py`:

1. **Arm the predicate in both modes.** `_expected_correlation_id` is now set from the already-resolved wire correlation id with no `host_handlers` guard. This is the actual isolation boundary. `None` only when nothing correlated reached the wire; client mode already refuses that case, host mode keeps first-terminal-wins there.
2. **Run-scope the terminal group whenever the predicate is armed** (`runtime_local_terminal_run_<run_id[:12]>`). Deliberately gated on *armed* rather than made unconditional: a brand-new group reads the retained log from the beginning, so scoping without a filter would trade "the uncommitted tail" for "the entire retention window" — strictly worse. Group uniqueness alone was never sufficient, which is why OMN-15660 AC3 required both.
3. **Read the status at both levels, with no default.** `_terminal_status_declarations` collects `status` from the envelope and the domain payload using the same precedence `_terminal_correlation_matches` already uses for correlation ids. A failure declared at *either* level fails closed. An envelope that declares no status anywhere is UNKNOWN and is refused — symmetric with the existing refusal of an envelope that names no correlation. A **bare** domain terminal with no status (e.g. `{"kind": "completed"}`) is the long-standing offline shape and keeps the `_classify_result` heuristics; the refusal is scoped to envelope-shaped messages, which structurally carry a domain payload that declares its own status.
4. `tests/unit/runtime/test_runtime_local_client_mode.py::test_host_mode_terminal_is_not_correlation_filtered` asserted the behaviour this PR removes. It is inverted to `..._is_correlation_filtered_too`, with the superseding reason in its docstring rather than a silent deletion.
5. `tests/gates/test_consumer_group_name_authorization.py` now also derives the **run-scoped** terminal group name. That is the name `onex delegate` actually mints against MSK now, and an unauthorized name here is the OMN-15639 failure mode again (`GroupAuthorizationFailedError` before publish). Verified authorized under the managed environment: `onex-dev.omnibase_core.runtime_local_terminal_run_<hex>.consume.v1` matches `onex-dev.*`.
6. `pyproject.toml` + `uv.lock`: 0.47.2 -> 0.47.3 (OMN-13411 release-identity gate — packaged source changed).

### Production callers checked, none relied on first-terminal-wins

`grep` over omnibase_core / omnibase_infra / omnimarket / omniclaude / omnibase_spi / omnibase_compat: the only production `RuntimeLocal(...)` sites are `omnibase_infra/src/omnibase_infra/cli/receipt_mode.py:669` and `omnibase_infra/src/omnibase_infra/cli/cli_node.py:289`. Neither passes `host_handlers`, and `receipt_mode.py` was *compensating* for the missing filter with its own correlation join, not depending on its absence. No caller to fix.

## Tests (RED first)

New: `tests/unit/runtime/test_runtime_local_terminal_isolation.py`. It stands up a retaining broker double with per-`(group, topic)` committed offsets and broker-level subscribers, because the in-memory bus dies with the process and cannot express this defect at all. **12 of the 14 cases fail on `dev`**; the 2 that pass are counter-assertions pinning what must not break.

- `test_host_mode_never_adopts_a_retained_terminal_from_an_earlier_run` — the sequential case that actually bit: run A gone, its terminal still retained-and-uncommitted, run B must ignore it.
- `test_host_mode_refuses_a_retained_failed_terminal_from_an_earlier_run` — the compounded case; passes only when both fixes are present.
- `test_host_mode_terminal_group_is_run_scoped`, `test_two_sequential_host_runs_do_not_share_a_terminal_group`.
- `test_a_slow_host_run_does_not_adopt_a_concurrent_runs_terminal` — OMN-15660's original concurrent framing, on the host path. The handler's think-time is driven off the prompt so the slow run is deterministically parked in its terminal wait when the fast run's terminal lands; without that, two gathered `run_async` coroutines run one after the other and the "concurrent" assertion passes vacuously.
- Envelope status: `failed`/`failure`/`error`/`ERROR` all classify FAILED; payload-level failure beats an envelope-level success; no-status-anywhere is refused and names the missing status in `last_error`.
- Counter-assertions: envelope-level success still COMPLETED; bare `{"kind": "completed"}` still COMPLETED.

Local proof, re-run on the rebased tree (`da55f8d7`, off `origin/dev@d191ffb2`) rather than inherited from the earlier lane:

```
uv run pytest tests/unit/runtime tests/gates/test_consumer_group_name_authorization.py -q
419 passed, 1 warning in 65.68s

uv run pytest tests/unit/runtime/test_runtime_local_terminal_isolation.py -q
14 passed in 2.61s

uv run mypy src/omnibase_core/runtime/runtime_local.py --strict
Success: no issues found in 1 source file

uv run ruff format <the 4 changed source/test paths>   -> 4 files left unchanged
uv run ruff check  <the same 4 paths>                  -> All checks passed!
uv run python scripts/check_release_identity.py --base origin/dev
OK: version 0.47.3 is ahead of latest published 0.47.2.
```

### The RED was re-proven, not asserted

The claim "12 of the 14 cases fail on `dev`" is easy to inherit and wrong to assume, so it was re-run: `origin/dev`'s pre-fix `runtime_local.py` was swapped into this tree under a trap that always restores, and the new module was run against it.

```
12 failed, 2 passed in 7.72s
```

The two that pass are the counter-assertions, as claimed. The on-point failures are the defect stated in its own words:

```
test_host_mode_never_adopts_a_retained_terminal_from_an_earlier_run
  AssertionError: host mode adopted an earlier run's retained terminal
test_host_mode_refuses_a_retained_failed_terminal_from_an_earlier_run
  AssertionError: this run reported another run's FAILED terminal as its own
test_host_mode_terminal_group_is_run_scoped
  AssertionError: host-mode terminal subscription reused the shared runtime-local group id
  'local.omnibase_core.runtime_local_terminal.consume.v1'; a fresh run resumes another run's committed offset
test_envelope_shaped_failed_terminal_is_classified_failed
  AssertionError: assert <EnumWorkflowResult.COMPLETED> is <EnumWorkflowResult.FAILED>
```

The inverted client-mode test was checked the same way — against the pre-fix source `test_runtime_local_client_mode.py` is `1 failed, 9 passed`, the failure being `test_host_mode_terminal_is_correlation_filtered_too`. That confirms the inversion is a real behavioural flip, not a rename. Restore was verified: zero dirty paths afterwards.

### Hook status

`pre-commit run --files <the 6 changed paths>` — the check that actually gates a commit — is **RC=0, zero failures**.

`pre-commit run --all-files` reports 19 failed / 98 passed. **None of the 19 names any file this PR touches**, checked mechanically: grepping the log for `runtime/runtime_local.py`, `test_consumer_group_name_authorization`, `test_runtime_local_client_mode`, `test_runtime_local_terminal_isolation`, `pyproject.toml` and `uv.lock` returns 0 hits each. Those 19 are the repo's standing `--all-files` baseline (print-statement, exception-handling, hardcoded-path and TODO-marker scans over pre-existing source). The one hook that *was* attributable to this change, `check-release-identity` (OMN-13411), is fixed by the version bump and now passes.

## Residual, stated rather than hidden

`_run_single_handler` still subscribes its terminal topic with the bare shared group (`runtime_local.py:787`). That path resolves no correlation id at all, so there is nothing to arm — run-scoping it alone would be the strictly-worse trade described above. Left unchanged deliberately; it is not the delegation path.

## Version bump: 0.47.3 is a pyproject bump only — no tag, no release cut

`scripts/check_release_identity.py` requires `project.version` to be strictly greater than the
highest published tag, and the highest published tag is `v0.47.2`. Packaged source under `src/`
changed here, so the gate demands a bump; without it `check-release-identity` is the one hook that
fails and it fails *because of this diff*.

This PR bumps `pyproject.toml` + `uv.lock` to `0.47.3` and does **nothing else** about releases: no
git tag is created, no release is cut, nothing is published. That is deliberate rather than
incidental — `0.47.3` is spoken for by OMN-17842 (delegation v2, Task 1.3), whose own step 1 reads
"bump the version — reclaiming `0.47.3` from the abandoned worktree (fact 25) or taking the next
free number". This worktree *is* that abandoned worktree, so landing `0.47.3` on `dev` is that
ticket's documented first option, not a collision with it. The release cut remains OMN-17842's to
make.

Evidence-Ticket: OMN-15660
Evidence-Ticket: OMN-17567
Evidence-Source: OCC#8192
