### PR TITLE
fix(OMN-17875): omnibase_core auto-merge arms with the org PAT so dev push workflows fire

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -38,6 +38,94 @@
 # failing loudly if a green+armed PR is not enqueued, so the gap surfaces
 # instead of stalling silently. The classify/verify decision logic is
 # unit-tested in scripts/ci/merge_queue_enqueue.py.
+#
+# OMN-17875 (2026-09-04): THE ARMING TOKEN MUST BE `secrets.CROSS_REPO_PAT`,
+# NOT `secrets.GITHUB_TOKEN`. GitHub's auto-merge system performs the eventual
+# squash merge as whatever identity ARMED it; when that identity is the default
+# `GITHUB_TOKEN`, GitHub's documented Actions-recursion prevention fires no
+# `push` event for the resulting commit on `dev`. Every push-triggered dev
+# workflow was therefore silently starved on every PR that landed through this
+# job. Ported from omnibase_infra#3178 (merged 2026-09-04T12:32:53Z), which
+# root-caused this on the sibling repo.
+#
+#   Measured 2026-09-04T15:20-15:25Z on THIS repo, over the 30 most recently
+#   merged dev PRs (#1613-#1645). Bot-merged dev commits got ZERO push-event
+#   runs; human-merged ones got 12-14:
+#     1bd884e57 (#1645, app/github-actions) -> 0 push runs
+#     5d6da6f50 (#1640, bot)                -> 0
+#     dbdb93a2c (#1639, bot)                -> 0
+#     38d4ba830 (#1638, bot)                -> 0
+#     f338525bf (#1635, bot)                -> 0
+#     fc20d0869 (#1633, bot)                -> 0
+#     d191ffb22 (#1643, jonahgabriel)       -> 12
+#     a3c3184e0 (#1634, jonahgabriel)       -> 14
+#     4edb9e596 (#1632, jonahgabriel)       -> 12
+#   Query:
+#     gh api "repos/OmniNode-ai/omnibase_core/actions/runs?head_sha=<oid>&event=push" --jq .total_count
+#   Totals over that window: 20 bot merges, ALL 20 with zero dev-branch push
+#   runs; 10 jonahgabriel merges, all 12-14.
+#
+#   Two of those bot merges (31e44e9db #1621, 9b8b5704b #1615) report
+#   total_count 2, but those two runs are Release + "Propagate config across
+#   downstream repos" on head_branch v0.47.1 / v0.47.0 with actor
+#   jonahgabriel — TAG pushes that happen to share the commit, not dev-branch
+#   pushes. Dev-branch suppression is 20 of 20.
+#
+#   `head_sha` MUST be the full 40-char oid. An abbreviated SHA matches
+#   nothing and returns a false `total_count: 0` — that false zero is what
+#   initially made these two look like clean bot merges (CLAUDE.md rule 16:
+#   an empty result is not evidence of absence; prove a zero with a positive
+#   control, here the 12-14 counts on the human merges).
+#
+# WHAT WAS SKIPPED (push-on-dev workflows in this repo): ci.yml,
+# security-scan.yml, cross-repo-validation.yml, precommit-parity-gate.yml,
+# receipt-honesty.yml, omni-standards-compliance.yml, check-db-ownership.yml,
+# check-handshake.yml, check-llm-refs-drift.yml,
+# validator-fsm-handler-drift.yml, validator-no-plugin-daemon-classes.yml,
+# validator-runtime-profiles.yml, plus propagate-config.yml (push, path-
+# filtered, no branch filter).
+#
+#   release.yml is NOT in the skipped set: its only push trigger is
+#   `tags: ['v[0-9]*.[0-9]*.[0-9]*']` with no `branches:` key, so a dev merge
+#   never fires it regardless of merger identity.
+#
+# WHY A PAT AND NOT A GITHUB APP TOKEN (OMN-16373): the org-wide CROSS_REPO_PAT
+# retirement moved other call sites to a short-lived `onexbot-occ-writer` App
+# installation token. That substitution does NOT work here. A controlled probe
+# on 2026-08-22 (branch test/omn16373-suppression-probe-1, since deleted)
+# isolated the identities against a push-triggered marker workflow:
+#   - CONTROL (ambient `jonahgabriel` auth): commit fd534b2a -> marker workflow
+#     FIRED (run 32562988366, event=push, conclusion=success).
+#   - APP TOKEN (onexbot-occ-writer[bot]): commit 38ffe1f4 on the same branch
+#     -> marker workflow did NOT fire; zero event=push runs at that head_sha.
+# App-token-authored pushes suppress push-triggered runs on this org exactly
+# like GITHUB_TOKEN-authored ones, so migrating this site to the App token
+# would reintroduce this defect on a different credential. omninode_infra's
+# own auto-merge.yml is the precedent: it kept CROSS_REPO_PAT for this exact
+# reason (OMN-15769, then re-affirmed by OMN-16373) and its dev merges have
+# never suffered this suppression.
+#
+# NO NEW CREDENTIAL IS MINTED. `CROSS_REPO_PAT` is an existing org secret with
+# `visibility: all` (readback 2026-09-04T15:19Z:
+# `gh api orgs/OmniNode-ai/actions/secrets/CROSS_REPO_PAT` ->
+# {"name":"CROSS_REPO_PAT","created_at":"2026-03-03T19:03:03Z",
+# "visibility":"all"}), and this repo ALREADY consumes it in ci.yml,
+# release.yml, propagate-config.yml, publish-downstream-pin-bump.yml,
+# cr-thread-gate.yml, cr-thread-gate-caller.yml and dependency-cascade.yml.
+#
+# NO FALLBACK EXPRESSION (`|| secrets.GITHUB_TOKEN`) is used: a fallback would
+# restore the defect silently on any run where the PAT is unavailable, which is
+# precisely the invisible-failure shape this ticket exists to remove.
+#
+# SCOPE OF THE SWAP: only the two steps in the `auto-merge` job that MUTATE
+# merge state carry the PAT — `Enable auto-merge`, which arms the squash merge,
+# and `Enqueue armed PR and verify it entered the queue`, which both pushes a
+# branch update (`gh pr update-branch`) and hands the merge to a queue
+# (`enqueuePullRequest`). The read-only `Resolve PR number and author without
+# checkout` step in the `pre-check` job stays on `GITHUB_TOKEN` — it only runs
+# `gh pr view` / `gh api` reads and creates no commit, so the suppression
+# mechanism cannot apply to it. Enforced by
+# tests/unit/validation/test_auto_merge_workflow_shape.py.
 name: Auto-Merge
 
 on:
@@ -178,7 +266,16 @@ jobs:
 
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # OMN-17875: MUST be CROSS_REPO_PAT. GitHub completes an armed
+          # auto-merge as the arming identity, and GITHUB_TOKEN-authored
+          # commits fire no `push` event — that starved every push-on-dev
+          # workflow (ci.yml, security-scan.yml, cross-repo-validation.yml and
+          # nine more) on all 20 bot-armed dev merges in the sampled window,
+          # while the 10 human merges alongside them got 12-14 runs each. An
+          # onexbot-occ-writer App token is NOT a substitute: it suppresses
+          # identically (OMN-16373 probe). Do not "modernise" this back to
+          # GITHUB_TOKEN or an App token.
+          GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
           GH_REPO: ${{ github.repository }}
           PR: ${{ needs.pre-check.outputs.pr }}
         run: |
@@ -222,7 +319,15 @@ jobs:
 
       - name: Enqueue armed PR and verify it entered the queue
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # OMN-17875: this step MUTATES merge state twice — `gh pr
+          # update-branch` pushes a merge commit onto the PR head branch, and
+          # `enqueuePullRequest` hands the eventual merge to a merge queue.
+          # Both land commits attributed to this token, so it carries the same
+          # non-suppressing identity as the arming step above. (This repo has
+          # no merge queue on dev today — registry-wide verify 2026-08-24 — so
+          # the enqueue path exits early; the PAT here is for the
+          # update-branch push and for the day a queue returns.)
+          GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
           GH_REPO: ${{ github.repository }}
           PR: ${{ needs.pre-check.outputs.pr }}
         run: |

--- a/tests/unit/validation/test_auto_merge_workflow_shape.py
+++ b/tests/unit/validation/test_auto_merge_workflow_shape.py
@@ -272,3 +272,161 @@ class TestAutoMergeEnableStepBehavior:
         assert result.returncode == 1
         assert "auto-merge failed:" in result.stdout
         assert "(squash)" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# OMN-17875: arming-token guard.
+#
+# Root cause (measured live 2026-09-04T15:20-15:25Z on this repo): the two
+# merge-state-mutating steps armed `gh pr merge --auto` with
+# `secrets.GITHUB_TOKEN`. GitHub completes an armed auto-merge as the identity
+# that armed it, and fires no `push` event for `GITHUB_TOKEN`-authored commits
+# (documented Actions-recursion prevention). Every push-on-`dev` workflow was
+# therefore skipped on every PR that landed through this job::
+#
+#     1bd884e57 (#1645, app/github-actions) -> 0 push runs
+#     d191ffb22 (#1643, jonahgabriel)       -> 12 push runs
+#
+# (`gh api "repos/OmniNode-ai/omnibase_core/actions/runs?head_sha=<full-oid>&event=push"
+# --jq .total_count`.) Over the 30 most recently merged dev PRs, ALL 20 bot
+# merges had zero dev-branch push runs while all 10 human merges had 12-14 --
+# the human counts are the positive control that makes those zeros evidence of
+# absence rather than a broken query (CLAUDE.md rule 16).
+#
+# Fix: arm with `secrets.CROSS_REPO_PAT` -- an existing org secret
+# (`visibility: all`) this repo already consumes in seven other workflows, and
+# the same credential omninode_infra's auto-merge.yml deliberately retained for
+# this exact property (OMN-15769, re-affirmed by OMN-16373). Ported from
+# omnibase_infra#3178.
+#
+# These assertions are the mechanical guard (CLAUDE.md rule 5: enforcement, not
+# detection) so the swap cannot be silently reverted to `GITHUB_TOKEN` -- or
+# "modernised" to an `onexbot-occ-writer` App installation token, which the
+# OMN-16373 controlled probe proved suppresses push events identically.
+# ---------------------------------------------------------------------------
+
+# The steps that cause a commit to be attributed to the token: arming the
+# merge, and update-branch/enqueue. Both must carry the non-suppressing
+# identity.
+MUTATING_STEP_NAMES: tuple[str, ...] = (
+    "Enable auto-merge",
+    "Enqueue armed PR and verify it entered the queue",
+)
+
+# The step that only reads PR/repo metadata. It lives in the `pre-check` job,
+# not `auto-merge`, and is safe under the default token because it creates no
+# commit.
+READ_ONLY_STEP_JOB = "pre-check"
+READ_ONLY_STEP_NAME = "Resolve PR number and author without checkout"
+
+REQUIRED_TOKEN_EXPR = "${{ secrets.CROSS_REPO_PAT }}"
+
+# Substrings that would reintroduce the suppression on a different credential.
+APP_TOKEN_MARKERS: tuple[str, ...] = (
+    "create-github-app-token",
+    "ONEXBOT_OCC_APP_ID",
+    "ONEXBOT_OCC_PRIVATE_KEY",
+)
+
+
+def _step_in_job(job_name: str, step_name: str) -> dict[str, object]:
+    data = yaml.safe_load(WORKFLOW_PATH.read_text())
+    steps = data["jobs"][job_name]["steps"]
+    matches = [
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == step_name
+    ]
+    assert len(matches) == 1, (
+        f"expected exactly one step named {step_name!r} in job {job_name!r}, "
+        f"got {len(matches)}"
+    )
+    return matches[0]
+
+
+@pytest.mark.parametrize("step_name", MUTATING_STEP_NAMES)
+def test_merge_state_mutating_steps_arm_with_cross_repo_pat(step_name: str) -> None:
+    """The arming/enqueue steps must authenticate as CROSS_REPO_PAT.
+
+    A GITHUB_TOKEN- or App-token-authored merge commit fires no push event, so
+    this assertion is the difference between ci.yml / security-scan.yml /
+    cross-repo-validation.yml (and nine more) running on every dev merge and
+    running on none of them.
+    """
+    step = _step_in_job("auto-merge", step_name)
+    env = step.get("env")
+    assert isinstance(env, dict)
+    token = env.get("GH_TOKEN")
+    assert token == REQUIRED_TOKEN_EXPR, (
+        f"{step_name!r} must arm with {REQUIRED_TOKEN_EXPR}; found {token!r}. "
+        "GITHUB_TOKEN- and GitHub-App-token-authored merges suppress "
+        "push-triggered workflow runs on dev (OMN-17875 / OMN-16373)."
+    )
+
+
+@pytest.mark.parametrize("step_name", MUTATING_STEP_NAMES)
+def test_mutating_steps_have_no_github_token_fallback(step_name: str) -> None:
+    """No ``|| secrets.GITHUB_TOKEN`` fallback on the mutating steps.
+
+    A fallback would restore the defect silently on any run where the PAT is
+    unavailable, which is exactly the invisible-failure shape this ticket
+    exists to remove: the job would report success while starving every
+    downstream push workflow.
+    """
+    step = _step_in_job("auto-merge", step_name)
+    env = step.get("env")
+    assert isinstance(env, dict)
+    token = str(env.get("GH_TOKEN", ""))
+    assert "GITHUB_TOKEN" not in token, (
+        f"{step_name!r} must not fall back to GITHUB_TOKEN; found {token!r}"
+    )
+
+
+def test_read_only_resolve_step_stays_on_default_token() -> None:
+    """The read-only ``pre-check`` step keeps GITHUB_TOKEN — it creates no commit.
+
+    Narrow blast radius is deliberate: the PAT is only granted to the steps
+    that actually need the non-suppressing identity.
+    """
+    step = _step_in_job(READ_ONLY_STEP_JOB, READ_ONLY_STEP_NAME)
+    env = step.get("env")
+    assert isinstance(env, dict)
+    assert env.get("GH_TOKEN") == "${{ secrets.GITHUB_TOKEN }}"
+
+    run = step.get("run", "")
+    assert isinstance(run, str)
+    for mutating_verb in (
+        "gh pr merge",
+        "gh pr update-branch",
+        "enqueuePullRequest",
+        "git push",
+    ):
+        assert mutating_verb not in run, (
+            f"{READ_ONLY_STEP_NAME!r} performs {mutating_verb!r} but runs under "
+            "GITHUB_TOKEN; move it to a CROSS_REPO_PAT step or the suppression "
+            "returns."
+        )
+
+
+def test_no_app_token_mint_is_introduced() -> None:
+    """An onexbot-occ-writer App token is not a valid substitute here.
+
+    The OMN-16373 controlled probe pushed commit ``38ffe1f4`` under the App
+    identity and the push-triggered marker workflow did not fire, while the
+    ``jonahgabriel`` control push (``fd534b2a``) fired run 32562988366.
+    """
+    raw = WORKFLOW_PATH.read_text()
+    body = raw.split("name: Auto-Merge", 1)[1]
+    for marker in APP_TOKEN_MARKERS:
+        assert marker not in body, (
+            f"auto-merge.yml must not mint a GitHub App token ({marker!r}); "
+            "App-token pushes suppress push-triggered runs identically to "
+            "GITHUB_TOKEN (OMN-16373)."
+        )
+
+
+def test_header_documents_the_defect_and_cites_the_evidence_tickets() -> None:
+    """The in-file rationale must survive, so the next reader does not revert it."""
+    header = WORKFLOW_PATH.read_text().split("name: Auto-Merge", 1)[0]
+    for citation in ("OMN-17875", "OMN-16373", "CROSS_REPO_PAT"):
+        assert citation in header, f"auto-merge.yml header must cite {citation}"


### PR DESCRIPTION
Closes OMN-17875 (AC4 — the `omnibase_core` sibling port).

Port of **[omnibase_infra#3178](https://github.com/OmniNode-ai/omnibase_infra/pull/3178)** (merged 2026-09-04T12:32:53Z, `b71159f3e0b1fb59a26c593fa4be2f78118ff51c`), which root-caused this defect on the sibling repo. Same change, same rationale, re-measured against this repo's own live data.

## Finding — measured here, 2026-09-04T15:20–15:25Z

`auto-merge.yml` armed `gh pr merge --auto` with the default workflow token. GitHub completes an armed auto-merge as the identity that armed it, and fires no `push` event for commits authored by that default token (documented Actions-recursion prevention). Every push-on-`dev` workflow was therefore skipped on every PR that landed through this job.

Query, over the 30 most recently merged `dev` PRs (#1613–#1645):

```
gh api "repos/OmniNode-ai/omnibase_core/actions/runs?head_sha=<full-40-char-oid>&event=push" --jq .total_count
```

| Commit | PR | Merged by | push-event runs |
| -- | -- | -- | -- |
| `1bd884e57` | #1645 | app/github-actions | **0** |
| `5d6da6f50` | #1640 | app/github-actions | **0** |
| `dbdb93a2c` | #1639 | app/github-actions | **0** |
| `38d4ba830` | #1638 | app/github-actions | **0** |
| `f338525bf` | #1635 | app/github-actions | **0** |
| `fc20d0869` | #1633 | app/github-actions | **0** |
| `d191ffb22` | #1643 | jonahgabriel | 12 |
| `a3c3184e0` | #1634 | jonahgabriel | 14 |
| `4edb9e596` | #1632 | jonahgabriel | 12 |
| `cccbdbbfe` | #1628 | jonahgabriel | 12 |

**Totals over that window: 20 bot merges, all 20 with zero dev-branch push runs; 10 `jonahgabriel` merges, all 12–14.**

Two of the bot merges (`31e44e9db` #1621, `9b8b5704b` #1615) report `total_count: 2`, but those two runs are `Release` + `Propagate config across downstream repos` on `head_branch` `v0.47.1` / `v0.47.0` with actor `jonahgabriel` — **tag** pushes that happen to share the commit, not dev-branch pushes. Dev-branch suppression is 20 of 20.

**Measurement gotcha worth recording:** `head_sha` must be the full 40-char oid. An abbreviated SHA matches nothing and returns a false `total_count: 0` — that false zero initially made those two look like clean bot merges. The 12–14 counts on the human merges are the positive control that makes the real zeros evidence of absence rather than a broken query (CLAUDE.md rule 16).

### What was skipped

Push-on-`dev` workflows in this repo: `ci.yml`, `security-scan.yml`, `cross-repo-validation.yml`, `precommit-parity-gate.yml`, `receipt-honesty.yml`, `omni-standards-compliance.yml`, `check-db-ownership.yml`, `check-handshake.yml`, `check-llm-refs-drift.yml`, `validator-fsm-handler-drift.yml`, `validator-no-plugin-daemon-classes.yml`, `validator-runtime-profiles.yml`, plus `propagate-config.yml` (push, path-filtered, no branch filter).

`release.yml` is **not** in the skipped set here: its only push trigger is `tags: ['v[0-9]*.[0-9]*.[0-9]*']` with no `branches:` key, so a dev merge never fires it regardless of merger identity. (This corrects the ticket body's "check its trigger" note for this repo, matching the same correction #3178 made for infra.)

## Mechanism, and why not an App token

A GitHub App installation token is **not** a substitute. The OMN-16373 controlled probe (2026-08-22, branch `test/omn16373-suppression-probe-1`, since deleted) isolated the identities against a push-triggered marker workflow:

- CONTROL, ambient `jonahgabriel` auth: commit `fd534b2a` → marker workflow FIRED (run `32562988366`, `event=push`, `conclusion=success`).
- APP TOKEN, `onexbot-occ-writer[bot]`: commit `38ffe1f4` on the same branch → marker workflow did NOT fire; zero `event=push` runs at that head SHA.

`omninode_infra/.github/workflows/auto-merge.yml` is the precedent — it kept the org PAT for exactly this property (OMN-15769, re-affirmed by OMN-16373) and its dev merges have never suffered this suppression.

## Exact changes

`.github/workflows/auto-merge.yml` (+109/−2):

| Step | Job | Was | Now |
| -- | -- | -- | -- |
| `Resolve PR number and author without checkout` | `pre-check` | default workflow token | **unchanged** — read-only (`gh pr view` / `gh api` reads), creates no commit, so the suppression mechanism cannot apply |
| `Enable auto-merge` | `auto-merge` | default workflow token | `secrets.CROSS_REPO_PAT` — this is the step that arms the merge |
| `Enqueue armed PR and verify it entered the queue` | `auto-merge` | default workflow token | `secrets.CROSS_REPO_PAT` — mutates merge state twice: `gh pr update-branch` pushes a merge commit onto the PR head branch, and `enqueuePullRequest` hands the merge to a queue |

Plus a header comment block carrying the measurements above, the OMN-16373 probe result, and an explicit "do not modernise this back to the default token or an App token" instruction, citing OMN-17875 / OMN-16373.

**No new credential is minted.** `CROSS_REPO_PAT` is an existing org secret with `visibility: all` — readback 2026-09-04T15:19Z, `gh api orgs/OmniNode-ai/actions/secrets/CROSS_REPO_PAT` → `{"name":"CROSS_REPO_PAT","created_at":"2026-03-03T19:03:03Z","visibility":"all"}`. This repo already consumes it in `ci.yml`, `release.yml`, `propagate-config.yml`, `publish-downstream-pin-bump.yml`, `cr-thread-gate.yml`, `cr-thread-gate-caller.yml` and `dependency-cascade.yml`.

No fallback expression was added. A fallback to the default token would restore the defect silently on any run where the PAT is unavailable — precisely the invisible-failure shape this ticket exists to remove.

**Precondition verified before porting:** `gh api repos/OmniNode-ai/omnibase_core --jq .allow_auto_merge` → `true`, `squash` only, `default_branch: dev`. So the arming step is live here (not the known-red unconditional-`--auto` defect that affects the repos where auto-merge is disabled).

## Enforcement (CLAUDE.md rule 5)

This repo **already had** a policy test pinning this workflow — `tests/unit/validation/test_auto_merge_workflow_shape.py` — so rather than adding a second file that could drift from it (infra had none and needed a new one), the 7 new assertions are appended there, keeping one home for `auto-merge.yml` shape:

- both mutating steps carry `secrets.CROSS_REPO_PAT` (parametrized, 2 cases);
- neither has a fallback to the default token (parametrized, 2 cases);
- the read-only `pre-check` resolve step stays on the default token **and** performs no mutating verb;
- no App-token mint step is introduced;
- the header keeps its OMN-17875 / OMN-16373 citations.

**Negative control** (rule 16 — a passing test is not evidence until it is shown to bite): reverting both tokens produces `4 failed, 13 passed`; the fix in place produces `17 passed`.

## Local verification

- `uv run pytest tests/unit/validation/test_auto_merge_workflow_shape.py -q` → `17 passed` (10 pre-existing + 7 new)
- Adjacent policy tests `tests/unit/validation/test_validator_github_token_env_reads.py` + `tests/ci/test_workflow_uses_refs_resolve.py` → `31 passed`
- `uv run ruff format` / `uv run ruff check` → clean
- `pre-commit` full hook set on commit → all passed
- Governed pre-push impacted-test selector (escalated to full suite) → `1901 passed in 293.63s`, `[prepush-smart-tests] impacted tests passed; allowing push.`

`mypy --strict` reports 9 errors in the test file, all of them pre-existing on `origin/dev` (identical count and lines against the unmodified file) and all in the pre-existing helpers, none in the appended block. `tests/` is explicitly outside this repo's gated mypy scope — the `mypy-type-check` hook is `files: ^src/omnibase_core/.*\.py$` with `exclude: ^(tests/|...)`. Nothing was suppressed to achieve that.

## Expected: this PR's own merge will still fire no push workflows

This PR will be armed and merged by the **current, unfixed** job — a workflow's `pull_request` / `check_suite` run uses the base-branch definition, not the PR's, so the version of `auto-merge.yml` doing the arming is the one on `dev`. This merge commit will therefore show `0` push-event runs, exactly like the 20 bot merges tabulated above. That is expected, it is the defect being fixed, and it is not a regression introduced here. Record it as **the last suppressed merge on this repo**; every merge after it should be non-zero.

## First post-merge verification

1. `gh api "repos/OmniNode-ai/omnibase_core/actions/runs?head_sha=<next-merge-sha>&event=push" --jq .total_count` → expected **non-zero** (12–14, matching the human-merge baseline), where the same query on every bot merge before this PR returned 0.
2. `gh api repos/OmniNode-ai/omnibase_core/pulls/<next-pr> --jq .merged_by.login` should read `jonahgabriel` (the PAT owner, a `User`) rather than `github-actions[bot]`.

## Scope

`omnibase_core` only. No `src/` code is touched — this changes CI workflow arming credentials and their policy test. The remaining AC4 siblings (`omniclaude` — claimed by a peer lane, `omnimarket`, `omnimemory`, `onex_change_control`, `omnidash`) stay on the ticket. No boot code is touched, so the codex-owned staging boot tickets are unaffected.

Evidence-Ticket: OMN-17875
Evidence-Source: OCC#8211
