### PR TITLE
feat(OMN-17556): typed store-resolved credential carrier on the topology DB binding + tenant-projection runtime profile

### DIFF
--- a/src/omnibase_core/constants/constants_runtime_profiles.py
+++ b/src/omnibase_core/constants/constants_runtime_profiles.py
@@ -28,7 +28,10 @@ the orchestrator / effect / worker consumer lanes respectively. ``local-dev``,
 ``default``, ``staging``, and ``production`` are policy overlays (prefetch
 posture), not distinct consumer lanes; ``canary`` and ``projection-api`` run
 isolated lanes that do NOT consume the general command/event groups a
-REDUCER/EFFECT needs.
+REDUCER/EFFECT needs. ``tenant-projection`` (OMN-17556) is a real consumer
+lane: one consolidated writer process that owns every TENANT-domain projection
+contract, because it is the only process holding the ``tenant_projection``
+binding's store-resolved credential.
 
 A REDUCER or EFFECT contract that subscribes to topics but names *only*
 non-consumer-attached profiles is the second, subtler class of silent
@@ -51,6 +54,16 @@ REGISTERED_RUNTIME_PROFILES: frozenset[str] = frozenset(
         "canary",
         "staging",
         "production",
+        # OMN-17556: the consolidated TENANT-domain projection writer. Eight
+        # contracts resolve the `tenant_projection` topology binding, whose
+        # principal (`tenant_projection_writer`) the shared main/effects pods
+        # deliberately hold no credential for -- and never will, by operator
+        # ruling (2026-09-03: no credential env var on any shared pod). They
+        # run in ONE process booted under this profile, which is the only
+        # process that resolves that binding's `secret_ref` from the store.
+        # Consolidated, not one writer per contract: onex-dev sits at ~87% CPU
+        # requests with ~520m headroom and eight 100m writers do not fit.
+        "tenant-projection",
     }
 )
 
@@ -62,6 +75,13 @@ CONSUMER_ATTACHED_RUNTIME_PROFILES: frozenset[str] = frozenset(
         "main",
         "effects",
         "workers",
+        # OMN-17556. All eight contracts moving here are subscribing
+        # REDUCER/EFFECT archetypes naming ONLY this profile, so omitting it
+        # would leave them registered-but-undrained -- the second, subtler
+        # silent-orphan class `_check_no_consumer_lane` exists to catch. The
+        # writer is the ONEX runtime booted under a different profile (not a
+        # bespoke daemon), so it attaches a real consumer group.
+        "tenant-projection",
     }
 )
 

--- a/src/omnibase_core/models/core/model_deployment_topology_database_binding.py
+++ b/src/omnibase_core/models/core/model_deployment_topology_database_binding.py
@@ -3,16 +3,45 @@
 
 """Secret-free consumer binding for a deployment database."""
 
-from pydantic import BaseModel, ConfigDict, Field
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 __all__ = ["ModelDeploymentTopologyDatabaseBinding"]
 
 _REFERENCE_PATTERN = r"^[a-z_][a-z0-9_]*$"
 _ENVIRONMENT_VARIABLE_PATTERN = r"^[A-Z][A-Z0-9_]*$"
+# Dotted logical secret name: at least two segments, lower snake per segment.
+# The two-segment minimum is what makes a bare word (and, with the character
+# class, a DSN literal) unrepresentable here.
+_STORE_REFERENCE_PATTERN = r"^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$"
 
 
 class ModelDeploymentTopologyDatabaseBinding(BaseModel):
-    """Map a consumer to a LOGIN principal and DSN environment-variable name."""
+    """Map a consumer to a LOGIN principal and ONE credential carrier.
+
+    A binding names a workload identity and declares WHERE that identity's DSN
+    is sourced from. Exactly one carrier may be declared (OMN-17556):
+
+    ``dsn_env``
+        Legacy carrier -- a process environment variable holding the full DSN.
+        Delivering it requires materializing the credential into a container
+        env, manifest, or host, which ``feedback_no_required_env_secrets_from_
+        store_only`` forbids. Retained for the bindings not yet migrated.
+
+    ``secret_ref``
+        Store carrier -- a dotted logical secret name the runtime resolves
+        through ``SecretResolver`` at the *binding boundary* (connect time),
+        never at process-env read time. The checked-in topology carries the
+        REF; the store carries the VALUE.
+
+    Neither field is defaulted and neither is optional-by-convenience: a
+    defaulted carrier would reintroduce the silent-fallback class OMN-14951
+    closed one layer up. Both-set is rejected because two carriers for one
+    credential let a stale env var silently shadow the store; neither-set is
+    rejected because an unresolvable binding must fail at contract-load time,
+    naming the principal, rather than at first connect.
+    """
 
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
@@ -30,10 +59,51 @@ class ModelDeploymentTopologyDatabaseBinding(BaseModel):
         pattern=_REFERENCE_PATTERN,
         description="LOGIN workload-principal reference.",
     )
-    dsn_env: str = Field(
-        ...,
+    dsn_env: str | None = Field(
+        default=None,
         min_length=1,
         max_length=128,
         pattern=_ENVIRONMENT_VARIABLE_PATTERN,
-        description="Environment-variable name holding the DSN; never the DSN value.",
+        description=(
+            "Environment-variable name holding the DSN; never the DSN value. "
+            "Mutually exclusive with 'secret_ref'."
+        ),
     )
+    secret_ref: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=256,
+        pattern=_STORE_REFERENCE_PATTERN,
+        description=(
+            "Dotted logical secret name resolved from the secret store at the "
+            "binding boundary; never the DSN value. Mutually exclusive with "
+            "'dsn_env'."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _require_exactly_one_credential_carrier(
+        self,
+    ) -> ModelDeploymentTopologyDatabaseBinding:
+        """Reject both-set and neither-set, naming the principal either way."""
+        declared = [
+            name
+            for name, value in (
+                ("dsn_env", self.dsn_env),
+                ("secret_ref", self.secret_ref),
+            )
+            if value is not None
+        ]
+        if len(declared) == 1:
+            return self
+        detail = (
+            f"declares both {declared}"
+            if declared
+            else "declares neither, so its DSN is unresolvable"
+        )
+        raise ValueError(
+            "a topology database binding must declare exactly one credential "
+            f"carrier -- 'dsn_env' (env var) or 'secret_ref' (secret store). "
+            f"Binding for principal {self.principal!r} on database_ref "
+            f"{self.database_ref!r} {detail}."
+        )

--- a/tests/unit/constants/test_constants_runtime_profiles_tenant_projection.py
+++ b/tests/unit/constants/test_constants_runtime_profiles_tenant_projection.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""``tenant-projection`` is a registered, consumer-attached lane (OMN-17556).
+
+Eight TENANT-domain projection contracts (seven on ``main``, one on
+``effects``) resolve the ``tenant_projection`` topology binding, whose
+principal is ``tenant_projection_writer``. The shared runtime pods hold no
+credential for that principal and -- by operator ruling, 2026-09-03 -- never
+will: no credential env var on any shared pod. Those eight contracts therefore
+move to ONE consolidated writer process running ``RUNTIME_PROFILE=
+tenant-projection``, which is the only process that resolves the binding.
+
+Two registry facts make that move safe, and this module pins both:
+
+1. ``REGISTERED_RUNTIME_PROFILES`` must contain the name, or
+   ``ValidatorRuntimeProfiles._check_unregistered`` rejects every one of the
+   eight contracts at commit/CI time.
+2. ``CONSUMER_ATTACHED_RUNTIME_PROFILES`` must contain it too. All eight are
+   subscribing REDUCER/EFFECT contracts naming ONLY this profile, so a
+   registered-but-not-consumer-attached name would pass check 1 and then trip
+   ``_check_no_consumer_lane`` -- the subtler silent-orphan class where the
+   name is legal but no process ever drains the subscriptions.
+
+The writer really does attach a consumer group (it is the ONEX runtime booted
+under a different profile, not a bespoke daemon), so membership in the second
+set is a statement of fact about the deployed process, not a validator
+workaround.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnibase_core.constants.constants_runtime_profiles import (
+    CONSUMER_ATTACHED_RUNTIME_PROFILES,
+    REGISTERED_RUNTIME_PROFILES,
+)
+
+pytestmark = pytest.mark.unit
+
+_TENANT_PROJECTION = "tenant-projection"
+
+
+def test_tenant_projection_is_registered() -> None:
+    assert _TENANT_PROJECTION in REGISTERED_RUNTIME_PROFILES
+
+
+def test_tenant_projection_is_consumer_attached() -> None:
+    assert _TENANT_PROJECTION in CONSUMER_ATTACHED_RUNTIME_PROFILES
+
+
+def test_consumer_attached_stays_a_subset_of_registered() -> None:
+    """The invariant the two sets exist to express, re-asserted after the add."""
+    assert CONSUMER_ATTACHED_RUNTIME_PROFILES <= REGISTERED_RUNTIME_PROFILES
+
+
+def test_no_underscore_variant_is_registered() -> None:
+    """Profile names are hyphenated; an underscore twin would orphan silently.
+
+    ``tenant_projection`` (underscore) is the BINDING name in the topology and
+    ``tenant-projection`` (hyphen) is the RUNTIME PROFILE. They are adjacent
+    strings with different meanings, and a contract that names the binding
+    where it means the profile would be unregistered -- caught loudly by
+    ``_check_unregistered`` only as long as the underscore form never becomes
+    a registered alias.
+    """
+    assert "tenant_projection" not in REGISTERED_RUNTIME_PROFILES

--- a/tests/unit/models/core/test_model_deployment_topology_database_binding.py
+++ b/tests/unit/models/core/test_model_deployment_topology_database_binding.py
@@ -43,6 +43,16 @@ from omnibase_core.models.core.model_deployment_topology_database_binding import
 
 pytestmark = pytest.mark.unit
 
+# Logical secret NAMES and deliberately-synthetic DSN literals used as negative
+# fixtures. No real credential appears in this file; the pragmas mark that fact
+# once, here, instead of on every use site.
+_SECRET_REF = "database.application.tenant_projection.dsn"  # pragma: allowlist secret
+_OTHER_SECRET_REF = "database.application.other.dsn"  # pragma: allowlist secret
+_DSN_SHAPED_REF = "postgresql://user:pw@host:5432/db"  # pragma: allowlist secret
+_PASTED_DSN = (
+    "postgresql://tenant_projection_writer:pw@host:5432/db"  # pragma: allowlist secret
+)
+
 
 class TestDsnEnvCarrier:
     """The legacy env carrier keeps working, unchanged, on its own."""
@@ -72,9 +82,9 @@ class TestSecretRefCarrier:
         binding = ModelDeploymentTopologyDatabaseBinding(
             database_ref="application",
             principal="tenant_projection_writer",
-            secret_ref="database.application.tenant_projection.dsn",
+            secret_ref=_SECRET_REF,
         )
-        assert binding.secret_ref == "database.application.tenant_projection.dsn"
+        assert binding.secret_ref == _SECRET_REF
         assert binding.dsn_env is None
 
     @pytest.mark.parametrize(
@@ -85,7 +95,7 @@ class TestSecretRefCarrier:
             "database..dsn",
             "database.application.",
             ".database.application",
-            "postgresql://user:pw@host:5432/db",
+            _DSN_SHAPED_REF,
             "database.application.tenant projection.dsn",
         ],
     )
@@ -112,7 +122,7 @@ class TestExactlyOneCarrier:
                 database_ref="application",
                 principal="tenant_projection_writer",
                 dsn_env="ONEX_TENANT_DB_URL",
-                secret_ref="database.application.tenant_projection.dsn",
+                secret_ref=_SECRET_REF,
             )
         message = str(excinfo.value)
         assert "exactly one" in message
@@ -145,10 +155,10 @@ class TestBindingStaysSecretFree:
         binding = ModelDeploymentTopologyDatabaseBinding(
             database_ref="application",
             principal="tenant_projection_writer",
-            secret_ref="database.application.tenant_projection.dsn",
+            secret_ref=_SECRET_REF,
         )
         with pytest.raises(ValidationError):
-            binding.secret_ref = "database.application.other.dsn"  # type: ignore[misc]
+            binding.secret_ref = _OTHER_SECRET_REF  # type: ignore[misc]
 
     def test_binding_forbids_unknown_fields(self) -> None:
         """An unmodelled carrier (e.g. a pasted `dsn:`) cannot slip through."""
@@ -156,6 +166,6 @@ class TestBindingStaysSecretFree:
             ModelDeploymentTopologyDatabaseBinding(
                 database_ref="application",
                 principal="tenant_projection_writer",
-                secret_ref="database.application.tenant_projection.dsn",
-                dsn="postgresql://tenant_projection_writer:pw@host:5432/db",
+                secret_ref=_SECRET_REF,
+                dsn=_PASTED_DSN,
             )

--- a/tests/unit/models/core/test_model_deployment_topology_database_binding.py
+++ b/tests/unit/models/core/test_model_deployment_topology_database_binding.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Contract tests for the store-resolved topology database binding (OMN-17556).
+
+A binding names a workload identity and says WHERE that identity's DSN comes
+from. Two carriers exist and exactly one may be declared per binding:
+
+``dsn_env``
+    The legacy carrier: a process environment variable holding the full DSN.
+    Delivering it requires materializing the credential into a container env,
+    manifest, or host -- precisely what
+    ``feedback_no_required_env_secrets_from_store_only`` forbids.
+
+``secret_ref``
+    The store carrier: a dotted logical secret name the runtime resolves
+    through ``SecretResolver`` at the binding boundary (connect time), never at
+    process-env read time. The checked-in topology carries the REF; the store
+    carries the VALUE.
+
+Exactly-one is a hard structural invariant, not a preference:
+
+* Both set -- two carriers for one credential means the deployed lane decides
+  which one wins at runtime, and a stale env var silently shadows the store.
+  That is the "works by convention" surface this ticket exists to remove.
+* Neither set -- a binding with no credential source is unresolvable, and
+  under ``ONEX_WIRING_STRICT_MODE`` it must fail at contract-load time with the
+  binding named, not at first connect.
+
+There is deliberately NO default on either field. A defaulted carrier would
+reintroduce the silent-fallback class (cf. OMN-14951's convention-fallback
+defect) at the layer above.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.core.model_deployment_topology_database_binding import (
+    ModelDeploymentTopologyDatabaseBinding,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestDsnEnvCarrier:
+    """The legacy env carrier keeps working, unchanged, on its own."""
+
+    def test_dsn_env_alone_is_accepted(self) -> None:
+        binding = ModelDeploymentTopologyDatabaseBinding(
+            database_ref="application",
+            principal="tenant_projection_writer",
+            dsn_env="ONEX_TENANT_DB_URL",
+        )
+        assert binding.dsn_env == "ONEX_TENANT_DB_URL"
+        assert binding.secret_ref is None
+
+    def test_dsn_env_still_rejects_a_lowercase_name(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelDeploymentTopologyDatabaseBinding(
+                database_ref="application",
+                principal="tenant_projection_writer",
+                dsn_env="onex_tenant_db_url",
+            )
+
+
+class TestSecretRefCarrier:
+    """The store carrier is a dotted logical name, never a value."""
+
+    def test_secret_ref_alone_is_accepted(self) -> None:
+        binding = ModelDeploymentTopologyDatabaseBinding(
+            database_ref="application",
+            principal="tenant_projection_writer",
+            secret_ref="database.application.tenant_projection.dsn",
+        )
+        assert binding.secret_ref == "database.application.tenant_projection.dsn"
+        assert binding.dsn_env is None
+
+    @pytest.mark.parametrize(
+        "bad_ref",
+        [
+            "nodots",
+            "Database.Application.dsn",
+            "database..dsn",
+            "database.application.",
+            ".database.application",
+            "postgresql://user:pw@host:5432/db",
+            "database.application.tenant projection.dsn",
+        ],
+    )
+    def test_secret_ref_rejects_a_non_logical_name(self, bad_ref: str) -> None:
+        """A DSN value, a bare word, or a malformed dotted path is refused.
+
+        The DSN-shaped case is the one that matters: the pattern is what stops
+        a resolved credential from being pasted into the checked-in topology.
+        """
+        with pytest.raises(ValidationError):
+            ModelDeploymentTopologyDatabaseBinding(
+                database_ref="application",
+                principal="tenant_projection_writer",
+                secret_ref=bad_ref,
+            )
+
+
+class TestExactlyOneCarrier:
+    """Neither carrier and both carriers are equally rejected."""
+
+    def test_both_carriers_is_rejected(self) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            ModelDeploymentTopologyDatabaseBinding(
+                database_ref="application",
+                principal="tenant_projection_writer",
+                dsn_env="ONEX_TENANT_DB_URL",
+                secret_ref="database.application.tenant_projection.dsn",
+            )
+        message = str(excinfo.value)
+        assert "exactly one" in message
+        assert "dsn_env" in message
+        assert "secret_ref" in message
+
+    def test_neither_carrier_is_rejected(self) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            ModelDeploymentTopologyDatabaseBinding(
+                database_ref="application",
+                principal="tenant_projection_writer",
+            )
+        message = str(excinfo.value)
+        assert "exactly one" in message
+
+    def test_neither_carrier_names_the_principal_it_could_not_resolve(self) -> None:
+        """The error must be legible without opening the topology file."""
+        with pytest.raises(ValidationError) as excinfo:
+            ModelDeploymentTopologyDatabaseBinding(
+                database_ref="application",
+                principal="tenant_projection_writer",
+            )
+        assert "tenant_projection_writer" in str(excinfo.value)
+
+
+class TestBindingStaysSecretFree:
+    """Structural guarantees the rest of the topology layer relies on."""
+
+    def test_binding_is_frozen(self) -> None:
+        binding = ModelDeploymentTopologyDatabaseBinding(
+            database_ref="application",
+            principal="tenant_projection_writer",
+            secret_ref="database.application.tenant_projection.dsn",
+        )
+        with pytest.raises(ValidationError):
+            binding.secret_ref = "database.application.other.dsn"  # type: ignore[misc]
+
+    def test_binding_forbids_unknown_fields(self) -> None:
+        """An unmodelled carrier (e.g. a pasted `dsn:`) cannot slip through."""
+        with pytest.raises(ValidationError):
+            ModelDeploymentTopologyDatabaseBinding(
+                database_ref="application",
+                principal="tenant_projection_writer",
+                secret_ref="database.application.tenant_projection.dsn",
+                dsn="postgresql://tenant_projection_writer:pw@host:5432/db",
+            )


### PR DESCRIPTION
Evidence-Ticket: OMN-17556
Evidence-Source: OCC#8228

OMN-17556 — head of the four-repo store-resolved-DSN chain. This is the omnibase_core leg: the typed carrier the topology binding needs, plus the runtime profile the consolidated writer boots under.

## What changed

Four files, +325/-6, no version files.

1. `src/omnibase_core/models/core/model_deployment_topology_database_binding.py` — a binding now declares exactly ONE credential carrier: `dsn_env` (legacy; a process env var holding the DSN) or `secret_ref` (a dotted logical secret name the runtime resolves through `SecretResolver` at the binding boundary). Both-set and neither-set are rejected by a model validator that names the offending principal either way. Neither field is defaulted — a defaulted carrier would reintroduce the silent-fallback class one layer up, and two live carriers let a stale env var silently shadow the store.
2. `src/omnibase_core/constants/constants_runtime_profiles.py` — registers `tenant-projection` in `REGISTERED_RUNTIME_PROFILES` and in `CONSUMER_ATTACHED_RUNTIME_PROFILES`.
3. + 4. Two new test modules, 19 tests.

## Why the profile is in the consumer-attached set

Membership there is a statement of fact about the deployed process, not a validator workaround. `tenant-projection` is one consolidated writer process owning every TENANT-domain projection contract, because it is the only process holding that binding's store-resolved credential. All eight contracts moving there are subscribing REDUCER/EFFECT archetypes naming ONLY this profile, so omitting it would leave them registered-but-undrained.

## Why this exists at all

No onex-dev pod binds the `tenant_projection` DSN, so under `ONEX_WIRING_STRICT_MODE=1` eight projection handlers failed auto-wiring and held omninode-runtime/-effects in CrashLoopBackOff (OMN-17519 / OMN-17557). The operator ruling of 2026-09-03 forbids a credential env var on ANY pod, including a dedicated writer pod, so the fix is a store-resolved carrier plus a profile that moves the work to the one process holding the credential — not a fifth raw DSN env var.

## Version identity: no bump here, deliberately

The earlier form of this commit carried `0.47.2 -> 0.47.3`. On rebase onto dev that hunk collapsed to a no-op: #1645 (OMN-15660) already declared `0.47.3` on dev. Latest published tag and PyPI release are both `v0.47.2` / `0.47.2` — `0.47.3` exists nowhere outside dev's `pyproject.toml`. `scripts/check_release_identity.py` compares `project.version` against the latest PUBLISHED tag rather than against the previous dev commit, so dev's existing `0.47.3` satisfies it, and asserting a second bump here would fork a release identity three lanes are actively coordinating (OMN-16606, OMN-17841, OMN-17842).

Cutting `v0.47.3` is therefore NOT part of this PR. omnibase_infra's half of OMN-17556 pins `omnibase-core==0.47.3` and cannot resolve until that wheel is published; that publication is coordinated on OMN-17842 via the rolling ledger, not performed here.

## Evidence

- Rebased `dcdea94d -> ea03f892` onto origin/dev `94cd22c1` with zero conflicts; the pyproject/uv.lock hunks collapsed as identical-to-dev (`git diff origin/dev -- pyproject.toml uv.lock` is empty).
- New tests: `tests/unit/constants/test_constants_runtime_profiles_tenant_projection.py` + `tests/unit/models/core/test_model_deployment_topology_database_binding.py` — 19 passed in 2.79s.
- `uv run ruff format src/ tests/` — 6214 files left unchanged. `uv run ruff check --fix src/ tests/` — All checks passed.
- `pre-commit run --from-ref origin/dev --to-ref HEAD` — 96 hooks passed, 0 failed, exit 0. That is the changed-file range, which is the semantics the commit and push gates actually apply.
- `pre-commit run --all-files` exits 1 on this branch, and equally on a clean base: the failures are repo-wide baseline debt in files this PR does not touch (for example `src/omnibase_core/contracts/antipattern_registry.yaml:20` under the string-version detector). Zero failure lines name either changed source file. That corpus is already owned by OMN-17523 / OMN-17520 / OMN-17522 / OMN-17524 / OMN-17525 and is not fixed here.
- Governed pre-push (`scripts/hooks/prepush_smart_tests.sh`) — GREEN, first attempt, zero capacity refusals. The selector escalated to a fail-closed full-suite run and placed it off-box: verbatim probe line `h200=busy(queue=0 heavy_pids=10 lock=1 held=1 slot=1) h201=busy(queue=0 heavy_pids=2 lock=1 held=2 slot=1) h101=fit(0.137,authorizing) h101.2=fit(0.137,authorizing) h105=fit(0.121,authorizing) h105.2=fit(0.119,authorizing)`, dispatched to `h105.2 (omnibook, ratio 0.119, mode authorizing)`. Remote verdict `44723 passed, 59 skipped, 3 xpassed, 151 warnings in 6070.15s (1:41:10)`, wrapper exit 0, then `[prepush-smart-tests] SKIPPING the local full suite: it already ran GREEN on a designated lab host for this exact tree.` and `[prepush-smart-tests] impacted tests passed; allowing push.` Push rc=0 at 2026-09-04T21:01:01Z. No `--no-verify`, no `PREPUSH_FULL_SUITE`, no `ENABLE_SMART_TESTS=off`, no `PREPUSH_ALLOW_*`, no `core.hooksPath`, no override grant, no host-table edit.

## Chain position

omninode_infra#1148 (the consolidated writer manifest) and omninode_infra#1150 / #1154 (the credential attach seam and its registration) already merged. omnibase_infra's leg reads `secret_ref` at the binding boundary and cannot parse the new topology until this releases. omnimarket's leg (OMN-17641's allowlist revert) waits on the runtime image carrying the profile, and is not touched here.
