### PR TITLE
fix(OMN-17931): backend_secret_discipline stops accepting api_key_env as a logical secret reference

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1481,7 +1481,9 @@ repos:
       # Backend Secret-Ref Discipline Gate (OMN-13305, ported from OMN-12971).
       # Rejects literal PEM/SA-JSON/bearer credentials in committed routing-authority
       # YAML. Requires every authenticated cloud backend to declare a logical
-      # secret ref (secret_ref/api_key_ref/api_key_env/credential_ref). ADC and
+      # secret ref (secret_ref/api_key_ref/credential_ref — api_key_env is NOT
+      # one, OMN-17931: only-api_key_env fails, api_key_env beside a real ref is
+      # migration debt). ADC and
       # API-key auth are mutually exclusive per backend. No warn-only mode.
       - id: check-backend-secret-discipline
         name: Backend Secret-Ref Discipline Gate (OMN-13305)

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -369,11 +369,13 @@
   name: Backend Secret Discipline (OMN-13290)
   description: >
     Reject literal credentials (PEM private keys, service-account JSON, bearer tokens, sk-/AIza/ya29.
-    keys) in committed config, and require a logical secret reference (secret_ref/api_key_ref/api_key_env
-    for API-key auth, or credential_ref for ADC) on every authenticated cloud backend in a bifrost routing-authority
-    config. ADC and api-key auth are mutually exclusive on one backend. Ported from omnimarket check_backend_secret_discipline
-    (OMN-12971) to core for fleet wiring. Credential VALUES live in the secret store, never in routing-authority
-    config. Suppression (test fixtures only): # backend-secret-ok: <reason> on the offending line.
+    keys) in committed config, and require a logical secret reference (secret_ref/api_key_ref for API-key
+    auth, or credential_ref for ADC) on every authenticated cloud backend in a bifrost routing-authority
+    config. api_key_env is NOT a logical reference (OMN-17931): a backend declaring only api_key_env fails,
+    and api_key_env beside a real reference is reported as migration debt. ADC and api-key auth are mutually
+    exclusive on one backend. Ported from omnimarket check_backend_secret_discipline (OMN-12971) to core
+    for fleet wiring. Credential VALUES live in the secret store, never in routing-authority config. Suppression
+    (test fixtures only): # backend-secret-ok: <reason> on the offending line.
   language: python
   entry: python -m omnibase_core.validators.backend_secret_discipline
   files: \.(ya?ml|json)$
@@ -385,8 +387,9 @@
   description: >
     Canonical COMPUTE hook for backend secret discipline. Rejects literal PEM, service-account JSON, bearer
     tokens, sk-/AIza/ya29-style keys in committed routing-authority config, and requires every authenticated
-    cloud backend to declare a logical secret reference (secret_ref / api_key_ref / api_key_env / credential_ref).
-    ADC and API-key auth are mutually exclusive per backend.
+    cloud backend to declare a logical secret reference (secret_ref / api_key_ref / credential_ref). api_key_env
+    is NOT a logical reference (OMN-17931): only-api_key_env fails; api_key_env beside a real reference
+    is migration debt. ADC and API-key auth are mutually exclusive per backend.
   language: python
   entry: python -m omnibase_core.validation.validator_backend_secret_discipline
   files: \.(ya?ml|json)$

--- a/src/omnibase_core/nodes/node_backend_secret_discipline_compute/contract.yaml
+++ b/src/omnibase_core/nodes/node_backend_secret_discipline_compute/contract.yaml
@@ -17,9 +17,11 @@ contract_version: {major: 1, minor: 0, patch: 0}
 description: >
   Backend secret-ref / credential-ref discipline gate (OMN-13305, ported from OMN-12971). Validates that
   committed routing-authority config contains no literal PEM/SA-JSON/bearer credentials, and that every
-  authenticated cloud backend declares a logical secret reference (secret_ref / api_key_ref / api_key_env
-  / credential_ref). ADC and API-key auth are mutually exclusive. Returns a ModelBackendSecretDisciplineOutput
-  verdict. #magic___^_^___line
+  authenticated cloud backend declares a logical secret reference (secret_ref / api_key_ref / credential_ref).
+  ADC and API-key auth are mutually exclusive. api_key_env is NOT a logical reference (OMN-17931, OMN-17372
+  AC3): it names a house environment variable, so a cloud backend declaring only api_key_env is reported
+  as missing a reference and api_key_env beside a real reference is reported as migration debt. Returns
+  a ModelBackendSecretDisciplineOutput verdict. #magic___^_^___line
 handler_routing:
   default_handler: handler:NodeBackendSecretDisciplineCompute
 

--- a/src/omnibase_core/validation/validator_backend_secret_discipline.py
+++ b/src/omnibase_core/validation/validator_backend_secret_discipline.py
@@ -27,11 +27,17 @@ What it checks (over the scanned config files or supplied file paths)
    - bearer/api-key-shaped literals (``Bearer <...>``, ``sk-...``, ``AIza...``,
      ``ya29.`` OAuth tokens, Google API keys)
 2. Every CLOUD backend that requires authentication declares a LOGICAL
-   reference (``secret_ref`` / ``api_key_ref`` / ``api_key_env`` for API-key
-   backends, or ``credential_ref`` for ADC backends) — not an inline value.
+   reference (``secret_ref`` / ``api_key_ref`` for API-key backends, or
+   ``credential_ref`` for ADC backends) — not an inline value.
 3. ADC and API-key auth are mutually exclusive on a single backend
-   (``credential_ref`` must not coexist with ``secret_ref`` / ``api_key_ref`` /
-   ``api_key_env``).
+   (``credential_ref`` must not coexist with ``secret_ref`` / ``api_key_ref``).
+4. ``api_key_env`` is NOT a logical reference (OMN-17931, OMN-17372 AC3). It
+   names a HOUSE environment variable, so a backend carrying it resolves a
+   platform-held provider credential from the runtime env. A cloud backend
+   whose only credential declaration is ``api_key_env`` is reported as missing
+   a logical reference; ``api_key_env`` beside a real reference is reported as
+   migration debt. This aligns the gate with the OMN-12878 guard in
+   ``omnibase_core.validation.api_key_ref_discipline``.
 
 The gate FAILS (exit 1) on any violation. There is no warn-only mode: a literal
 credential in committed config is never acceptable.
@@ -182,23 +188,32 @@ def scan_literal_credentials(rel: str, text: str) -> list[ModelCredentialViolati
     return violations
 
 
+# The only credential declarations that are LOGICAL references resolved through
+# the secret store. ``api_key_env`` is deliberately absent: it names a HOUSE
+# environment variable, so a backend carrying it resolves a platform-held
+# provider credential from the runtime env — the path OMN-17372 AC3 requires to
+# be unreachable by construction (OMN-17931; aligned with the OMN-12878 guard in
+# ``omnibase_core.validation.api_key_ref_discipline``).
+_LOGICAL_REF_KEYS: tuple[str, ...] = ("secret_ref", "api_key_ref", "credential_ref")
+_LEGACY_ENV_KEY = "api_key_env"
+
+
+def _declares(backend: dict[str, object], key: str) -> bool:
+    value = backend.get(key)
+    return isinstance(value, str) and bool(value.strip())
+
+
 def _backend_has_logical_ref(backend: dict[str, object]) -> bool:
-    for key in ("secret_ref", "api_key_ref", "api_key_env", "credential_ref"):
-        value = backend.get(key)
-        if isinstance(value, str) and value.strip():
-            return True
-    return False
+    return any(_declares(backend, key) for key in _LOGICAL_REF_KEYS)
+
+
+def _backend_declares_legacy_env(backend: dict[str, object]) -> bool:
+    return _declares(backend, _LEGACY_ENV_KEY)
 
 
 def _backend_auth_is_exclusive(backend: dict[str, object]) -> bool:
-    credential = backend.get("credential_ref")
-    has_credential = isinstance(credential, str) and bool(credential.strip())
-    has_api_key = False
-    for key in ("secret_ref", "api_key_ref", "api_key_env"):
-        value = backend.get(key)
-        if isinstance(value, str) and value.strip():
-            has_api_key = True
-            break
+    has_credential = _declares(backend, "credential_ref")
+    has_api_key = _declares(backend, "secret_ref") or _declares(backend, "api_key_ref")
     return not (has_credential and has_api_key)
 
 
@@ -232,14 +247,37 @@ def scan_bifrost_backends(
             continue
         if tier in _LOCAL_TIERS:
             continue
-        if tier in _CLOUD_TIERS and not _backend_has_logical_ref(backend_data):
+        has_logical_ref = _backend_has_logical_ref(backend_data)
+        declares_env = _backend_declares_legacy_env(backend_data)
+        if tier in _CLOUD_TIERS and not has_logical_ref:
+            if declares_env:
+                detail = (
+                    "only the legacy 'api_key_env' is declared — that is a HOUSE "
+                    "environment-variable name, not a logical secret reference "
+                    "(OMN-17931 / OMN-17372 AC3); declare a store-resolved ref and "
+                    "remove api_key_env"
+                )
+            else:
+                detail = "none declared"
             violations.append(
                 ModelBackendRefViolation(
                     file=rel,
                     message=(
                         f"{rel}: cloud backend {backend_id!r} (tier={tier!r}) requires a "
-                        f"logical secret reference (secret_ref/api_key_ref/api_key_env for "
-                        f"API-key auth, or credential_ref for ADC) — none declared"
+                        f"logical secret reference (secret_ref/api_key_ref for API-key "
+                        f"auth, or credential_ref for ADC) — {detail}"
+                    ),
+                )
+            )
+        elif declares_env:
+            violations.append(
+                ModelBackendRefViolation(
+                    file=rel,
+                    message=(
+                        f"{rel}: backend {backend_id!r} carries the legacy 'api_key_env' "
+                        f"beside its logical secret reference — migration debt: the "
+                        f"store-resolved ref is the only credential declaration allowed; "
+                        f"remove api_key_env (OMN-17931 / OMN-17372 AC3)"
                     ),
                 )
             )

--- a/src/omnibase_core/validators/backend_secret_discipline.py
+++ b/src/omnibase_core/validators/backend_secret_discipline.py
@@ -29,11 +29,17 @@ What it checks (over the supplied config files)
    - bearer/api-key-shaped literals (``Bearer <...>``, ``sk-...``, ``AIza...``,
      ``ya29.`` OAuth tokens, Google API keys)
 2. Every CLOUD backend that requires authentication declares a LOGICAL
-   reference (``secret_ref`` / ``api_key_ref`` / ``api_key_env`` for API-key
-   backends, or ``credential_ref`` for ADC backends) — not an inline value.
+   reference (``secret_ref`` / ``api_key_ref`` for API-key backends, or
+   ``credential_ref`` for ADC backends) — not an inline value.
 3. ADC and API-key auth are mutually exclusive on a single backend
-   (``credential_ref`` must not coexist with ``secret_ref`` / ``api_key_ref`` /
-   ``api_key_env``).
+   (``credential_ref`` must not coexist with ``secret_ref`` / ``api_key_ref``).
+4. ``api_key_env`` is NOT a logical reference (OMN-17931, OMN-17372 AC3). It
+   names a HOUSE environment variable, so a backend carrying it resolves a
+   platform-held provider credential from the runtime env. A cloud backend
+   whose only credential declaration is ``api_key_env`` is reported as missing
+   a logical reference; ``api_key_env`` beside a real reference is reported as
+   migration debt. This aligns the gate with the OMN-12878 guard in
+   ``omnibase_core.validation.api_key_ref_discipline``.
 
 The literal-credential scan applies to every supplied file. The backend-ref /
 exclusivity scan applies only to files that parse to a mapping carrying a
@@ -192,23 +198,32 @@ def scan_literal_credentials(rel: str, text: str) -> list[Finding]:
     return findings
 
 
+# The only credential declarations that are LOGICAL references resolved through
+# the secret store. ``api_key_env`` is deliberately absent: it names a HOUSE
+# environment variable, so a backend carrying it resolves a platform-held
+# provider credential from the runtime env — the path OMN-17372 AC3 requires to
+# be unreachable by construction (OMN-17931; aligned with the OMN-12878 guard in
+# ``omnibase_core.validation.api_key_ref_discipline``).
+_LOGICAL_REF_KEYS: tuple[str, ...] = ("secret_ref", "api_key_ref", "credential_ref")
+_LEGACY_ENV_KEY = "api_key_env"
+
+
+def _declares(backend: dict[str, object], key: str) -> bool:
+    value = backend.get(key)
+    return isinstance(value, str) and bool(value.strip())
+
+
 def _backend_has_logical_ref(backend: dict[str, object]) -> bool:
-    for key in ("secret_ref", "api_key_ref", "api_key_env", "credential_ref"):
-        value = backend.get(key)
-        if isinstance(value, str) and value.strip():
-            return True
-    return False
+    return any(_declares(backend, key) for key in _LOGICAL_REF_KEYS)
+
+
+def _backend_declares_legacy_env(backend: dict[str, object]) -> bool:
+    return _declares(backend, _LEGACY_ENV_KEY)
 
 
 def _backend_auth_is_exclusive(backend: dict[str, object]) -> bool:
-    credential = backend.get("credential_ref")
-    has_credential = isinstance(credential, str) and bool(credential.strip())
-    has_api_key = False
-    for key in ("secret_ref", "api_key_ref", "api_key_env"):
-        value = backend.get(key)
-        if isinstance(value, str) and value.strip():
-            has_api_key = True
-            break
+    has_credential = _declares(backend, "credential_ref")
+    has_api_key = _declares(backend, "secret_ref") or _declares(backend, "api_key_ref")
     return not (has_credential and has_api_key)
 
 
@@ -227,14 +242,36 @@ def scan_backends(rel: str, data: dict[str, object]) -> list[Finding]:
             continue
         if tier in _LOCAL_TIERS:
             continue
-        if tier in _CLOUD_TIERS and not _backend_has_logical_ref(backend):
+        has_logical_ref = _backend_has_logical_ref(backend)
+        declares_env = _backend_declares_legacy_env(backend)
+        if tier in _CLOUD_TIERS and not has_logical_ref:
+            if declares_env:
+                detail = (
+                    "only the legacy 'api_key_env' is declared — that is a HOUSE "
+                    "environment-variable name, not a logical secret reference "
+                    "(OMN-17931 / OMN-17372 AC3); declare a store-resolved ref and "
+                    "remove api_key_env"
+                )
+            else:
+                detail = "none declared"
             findings.append(
                 Finding(
                     "backend-ref",
                     rel,
                     f"{rel}: cloud backend {backend_id!r} (tier={tier!r}) requires a "
-                    f"logical secret reference (secret_ref/api_key_ref/api_key_env for "
-                    f"API-key auth, or credential_ref for ADC) — none declared",
+                    f"logical secret reference (secret_ref/api_key_ref for API-key "
+                    f"auth, or credential_ref for ADC) — {detail}",
+                )
+            )
+        elif declares_env:
+            findings.append(
+                Finding(
+                    "backend-ref",
+                    rel,
+                    f"{rel}: backend {backend_id!r} carries the legacy 'api_key_env' "
+                    f"beside its logical secret reference — migration debt: the "
+                    f"store-resolved ref is the only credential declaration allowed; "
+                    f"remove api_key_env (OMN-17931 / OMN-17372 AC3)",
                 )
             )
         if not _backend_auth_is_exclusive(backend):

--- a/tests/unit/validation/test_validator_backend_secret_discipline.py
+++ b/tests/unit/validation/test_validator_backend_secret_discipline.py
@@ -247,14 +247,18 @@ def test_local_tier_exempt() -> None:
 
 
 @pytest.mark.unit
-def test_api_key_env_counts_as_logical_ref() -> None:
+def test_api_key_env_does_not_count_as_logical_ref() -> None:
+    """OMN-17931 (OMN-17372 AC3): api_key_env names a HOUSE env var, not a ref."""
     import yaml
 
     data = yaml.safe_load(
         "backends:\n  - backend_id: cloud-x\n    tier: cheap_cloud\n    api_key_env: SOME_ENV_VAR\n"
     )
     violations = scan_bifrost_backends("ok.yaml", data)
-    assert violations == []
+    assert violations
+    assert any(
+        "cloud-x" in v.message and "api_key_env" in v.message for v in violations
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/validators/test_backend_secret_discipline_rejects_api_key_env.py
+++ b/tests/unit/validators/test_backend_secret_discipline_rejects_api_key_env.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+# api-key-env-ok: OMN-17931 — fixtures ARE intentional api_key_env declarations
+
+"""OMN-17931 (OMN-17372 AC3, mechanical half): ``api_key_env`` is not a logical ref.
+
+``api_key_env`` names a HOUSE environment variable. A cloud backend that carries
+one resolves a platform-held provider credential from the runtime env — the
+exact path OMN-17372 AC3 requires to be unreachable by construction. Before
+this ticket both backend-secret-discipline twins (the fleet-enforced CLI module
+``omnibase_core.validators.backend_secret_discipline`` and the COMPUTE twin
+``omnibase_core.validation.validator_backend_secret_discipline``) accepted
+``api_key_env`` as satisfying the logical-reference requirement, while
+``omnibase_core.validation.api_key_ref_discipline`` already rejected it
+(OMN-12878). These tests pin the aligned, stricter posture on BOTH twins:
+
+* a cloud backend whose only credential declaration is ``api_key_env`` is a
+  ``backend-ref`` finding that names the backend and ``api_key_env``;
+* ``api_key_env`` alongside a real logical ref is the migration-debt shape and
+  is ALSO a finding — the store-resolved ref is the only declaration allowed;
+* a backend with ``secret_ref`` / ``api_key_ref`` / ``credential_ref`` alone is
+  clean (positive control: the ratchet does not over-reject).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnibase_core.validation import validator_backend_secret_discipline as node_mod
+from omnibase_core.validators import backend_secret_discipline as cli_mod
+
+pytestmark = pytest.mark.unit
+
+_ONLY_API_KEY_ENV = (
+    "backends:\n"
+    "  - backend_id: cloud-openrouter\n"
+    "    tier: cheap_cloud\n"
+    "    api_key_env: OPENROUTER_API_KEY\n"
+)
+_API_KEY_ENV_BESIDE_SECRET_REF = (
+    "backends:\n"
+    "  - backend_id: cloud-openrouter\n"
+    "    tier: cheap_cloud\n"
+    "    secret_ref: llm.openrouter.api_key\n"
+    "    api_key_env: OPENROUTER_API_KEY\n"
+)
+_SECRET_REF_ONLY = (
+    "backends:\n"
+    "  - backend_id: cloud-openrouter\n"
+    "    tier: cheap_cloud\n"
+    "    secret_ref: llm.openrouter.api_key\n"
+)
+_API_KEY_REF_ONLY = (
+    "backends:\n"
+    "  - backend_id: cloud-openrouter\n"
+    "    tier: cheap_cloud\n"
+    "    api_key_ref: llm.openrouter.api_key\n"
+)
+_CREDENTIAL_REF_ONLY = (
+    "backends:\n"
+    "  - backend_id: cloud-vertex-gemini\n"
+    "    tier: frontier_api\n"
+    "    credential_ref: llm.vertex.adc\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# CLI twin — the module the fleet-enforced hooks / CI steps invoke
+# ---------------------------------------------------------------------------
+
+
+def test_cli_twin_only_api_key_env_is_a_missing_logical_ref() -> None:
+    findings = cli_mod.scan_backends("bifrost.yaml", yaml.safe_load(_ONLY_API_KEY_ENV))
+    assert findings, "api_key_env alone must NOT satisfy the logical-ref requirement"
+    messages = [f.message for f in findings]
+    assert any("cloud-openrouter" in m and "api_key_env" in m for m in messages), (
+        messages
+    )
+    assert all(f.category == "backend-ref" for f in findings)
+
+
+def test_cli_twin_api_key_env_beside_secret_ref_is_migration_debt() -> None:
+    findings = cli_mod.scan_backends(
+        "bifrost.yaml", yaml.safe_load(_API_KEY_ENV_BESIDE_SECRET_REF)
+    )
+    assert findings, "api_key_env beside a real ref is the migration-debt shape"
+    assert any(
+        "cloud-openrouter" in f.message and "api_key_env" in f.message for f in findings
+    )
+
+
+@pytest.mark.parametrize(
+    "text", [_SECRET_REF_ONLY, _API_KEY_REF_ONLY, _CREDENTIAL_REF_ONLY]
+)
+def test_cli_twin_real_logical_refs_stay_clean(text: str) -> None:
+    assert cli_mod.scan_backends("bifrost.yaml", yaml.safe_load(text)) == []
+
+
+def test_cli_twin_end_to_end_report_fails_on_api_key_env(tmp_path: Path) -> None:
+    """The exact surface omnimarket ci.yml / the pre-commit hooks call."""
+    cfg = tmp_path / "bifrost_delegation.yaml"
+    cfg.write_text(_ONLY_API_KEY_ENV, encoding="utf-8")
+    report = cli_mod.build_report([cfg], cwd=tmp_path)
+    assert report["passed"] is False
+    backend_msgs = report["backend_ref_violations"]
+    assert isinstance(backend_msgs, list)
+    assert any("api_key_env" in m for m in backend_msgs), backend_msgs
+    assert cli_mod.main([str(cfg)]) == 1
+
+
+# ---------------------------------------------------------------------------
+# COMPUTE twin — node_backend_secret_discipline_compute
+# ---------------------------------------------------------------------------
+
+
+def test_node_twin_only_api_key_env_is_a_missing_logical_ref() -> None:
+    violations = node_mod.scan_bifrost_backends(
+        "bifrost.yaml", yaml.safe_load(_ONLY_API_KEY_ENV)
+    )
+    assert violations, "api_key_env alone must NOT satisfy the logical-ref requirement"
+    assert any(
+        "cloud-openrouter" in v.message and "api_key_env" in v.message
+        for v in violations
+    )
+
+
+def test_node_twin_api_key_env_beside_secret_ref_is_migration_debt() -> None:
+    violations = node_mod.scan_bifrost_backends(
+        "bifrost.yaml", yaml.safe_load(_API_KEY_ENV_BESIDE_SECRET_REF)
+    )
+    assert violations
+    assert any(
+        "cloud-openrouter" in v.message and "api_key_env" in v.message
+        for v in violations
+    )
+
+
+@pytest.mark.parametrize(
+    "text", [_SECRET_REF_ONLY, _API_KEY_REF_ONLY, _CREDENTIAL_REF_ONLY]
+)
+def test_node_twin_real_logical_refs_stay_clean(text: str) -> None:
+    assert node_mod.scan_bifrost_backends("bifrost.yaml", yaml.safe_load(text)) == []
+
+
+def test_node_twin_report_fails_on_api_key_env() -> None:
+    report = node_mod.build_report_from_files({"bifrost.yaml": _ONLY_API_KEY_ENV})
+    assert report.passed is False
+    assert any("api_key_env" in v.message for v in report.backend_ref_violations)
+
+
+def test_twins_agree_with_api_key_ref_discipline() -> None:
+    """The two core validators must not disagree about api_key_env (OMN-12878)."""
+    from omnibase_core.validation.api_key_ref_discipline.handler import (
+        scan_bifrost_yaml,
+    )
+
+    guard = scan_bifrost_yaml("bifrost.yaml", _ONLY_API_KEY_ENV)
+    assert guard, "positive control: api_key_ref_discipline rejects api_key_env"
+    assert cli_mod.scan_backends("bifrost.yaml", yaml.safe_load(_ONLY_API_KEY_ENV))
+    assert node_mod.scan_bifrost_backends(
+        "bifrost.yaml", yaml.safe_load(_ONLY_API_KEY_ENV)
+    )


### PR DESCRIPTION
OMN-17931 — the mechanical half of OMN-17372 acceptance item 3 ("a mechanical check proves no customer-attributed delegation can resolve a platform-held provider credential, failing if one returns").

## The defect

The fleet-ENFORCED surfaces invoke `omnibase_core.validators.backend_secret_discipline` (omnimarket's `ci.yml` enforce step and its `backend-secret-discipline-gate` hook; omnibase_infra's `onex-validate-backend-secret-discipline`; core's own `check-backend-secret-discipline` on the COMPUTE twin). On dev, both twins accepted `api_key_env` as a valid logical secret reference.

`api_key_env` names a HOUSE environment variable. A cloud backend carrying one resolves a platform-held provider credential out of the runtime env — precisely the path OMN-17372 AC3 requires to be unreachable by construction.

Core's other validator, `validation/api_key_ref_discipline/handler.py`, has rejected `api_key_env` since OMN-12878. The two core validators disagreed with each other. omnimarket#2255 deleted every `api_key_env` from `bifrost_delegation.yaml`, but the only thing rejecting a re-added one was omnimarket's repo-local `house-inference-credential-gate`, whose own comment records that the core validator "still accepts `api_key_env` as a logical ref and is therefore NOT a substitute".

## What changed

Seven files, +304/-53, no version files.

1. `src/omnibase_core/validators/backend_secret_discipline.py` (the CLI module the enforce steps invoke) and 2. `src/omnibase_core/validation/validator_backend_secret_discipline.py` (the COMPUTE twin) — `api_key_env` is removed from the logical-reference set. A cloud backend whose only credential declaration is `api_key_env` is now a `backend-ref` finding naming the backend and the field; `api_key_env` beside a real `secret_ref`/`api_key_ref`/`credential_ref` is a separate migration-debt finding. `api_key_env` is likewise dropped from the ADC/API-key exclusivity test, so it can no longer make a `credential_ref` backend look non-exclusive.
3. `nodes/node_backend_secret_discipline_compute/contract.yaml` and 4./5. both `.pre-commit-hooks.yaml` descriptions plus the `.pre-commit-config.yaml` comment — prose no longer lists `api_key_env` as accepted.
6. `tests/unit/validators/test_backend_secret_discipline_rejects_api_key_env.py` (new, 13 tests, both twins).
7. `tests/unit/validation/test_validator_backend_secret_discipline.py` — `test_api_key_env_counts_as_logical_ref` is inverted to `test_api_key_env_does_not_count_as_logical_ref`.

## Blast radius: empirically zero live configs

The backend-ref scan applies only to files parsing to a mapping carrying a `backends` key. Every remaining `api_key_env` in the fleet is outside that shape, so nothing has to be fixed to absorb this:

- omnimarket `src/omnimarket/configs/bifrost_delegation.yaml` — the four matches are OMN-17372 comments recording the deletion; no live field.
- omnimarket `tests/.../graded_ladder/ladder_rungs.yaml` — top-level key is `rungs:`.
- omnimarket `model_policy.yaml`, `model_registry_v1.yaml`; omnibase_infra `docker/catalog/model_registry.yaml`; omniintelligence `review_pairing/model_registry.yaml` — top-level key is `models:`.

Verified by running the new validator against those five files: exit 0, no findings. POSITIVE CONTROL for that zero — a synthetic `backends:` file with one `api_key_env`-only cloud backend, same command, exits 1 with `backend-ref: ... only the legacy 'api_key_env' is declared — that is a HOUSE environment-variable name, not a logical secret reference`.

- Red first, re-verified independently at 2026-09-05T01:20:06Z rather than taken from the commit message: both twins reverted to dev via `git checkout origin/dev -- <2 modules>` with the new test file kept — 7 failed, 6 passed. The 6 passing are the positive control (`secret_ref`-only backends stay clean), so the file is not failing indiscriminately. Sources restored, `git status --porcelain` empty.
- Green: 46 passed in 14.46s across the new file and the inverted twin test.
- `uv run ruff format --check` — 4 files already formatted. `uv run ruff check` — All checks passed.
- `uv run mypy --strict` on both touched modules — Success: no issues found in 2 source files.
- `pre-commit run --files` over all 7 changed paths — exit 0, 103 passed, 0 failed. The canonical-shape/adequacy gate did not demand a receipt regeneration.
- Governed pre-push (`scripts/hooks/prepush_smart_tests.sh`) — the selector escalated fail-closed to the full suite (`is_full_suite=True reason=shared_module`). Two earlier attempts were correctly REFUSED because every lab heavy slot was held by peer lanes; the third acquired a slot and ran it off-box to completion. No `--no-verify`, no `PREPUSH_FULL_SUITE`, no `PREPUSH_ALLOW_*`, no `ENABLE_SMART_TESTS=off`, no `core.hooksPath`, no override grant minted (the hook offered the mint recipe and it was declined), no host-table edit, and no peer process killed.

## Scope boundary

This lands the stricter validator. It becomes fleet-enforced for consumers only when the next omnibase_core release propagates — that release cut is coordinated on OMN-17842 and is deliberately not performed here. `models/delegation/wire/` (OMN-17841) and `runtime/` (OMN-17859) are untouched.

https://claude.ai/code/session_012ua48B6iRgRyLhWwZbnRiD

Evidence-Ticket: OMN-17931
Evidence-Source: OCC#8244
