### PR TITLE
fix(OMN-17754): core vendored provenance record + the registry-root half of the picker

### DIFF
--- a/scripts/hooks/prepush_dispatch.sh
+++ b/scripts/hooks/prepush_dispatch.sh
@@ -1069,6 +1069,10 @@ prepush_remote_run() {
 set -uo pipefail
 RUNDIR="$1"; UV="$2"; HEAD_SHA="$3"; ARGV_SHA="$4"; ORIGIN="$5"; WORKROOT="$6"
 BASE_REF="${7:-}"; BASE_SHA="${8:-}"; SLOT_INDEX="${9:-1}"
+# The repo this bundle carries, so the registry root below can name it. Passed
+# rather than derived: RUNDIR's basename is `<repo>-<sha12>-<pid>` and repo
+# names contain both separators, so splitting it back apart is guesswork.
+REPO_NAME="${10:-}"
 cd "$RUNDIR" || exit 90
 # Re-arm BOTH guards explicitly. ssh forwards neither, so without this the
 # remote repo's own suite -- which subprocesses this very hook from
@@ -1183,6 +1187,38 @@ git checkout -q "$HEAD_SHA" 2> /dev/null || true
 if [ -n "$BASE_REF" ] && [ -n "$BASE_SHA" ] && git rev-parse --verify --quiet "${BASE_SHA}^{commit}" > /dev/null 2>&1; then
   git update-ref "refs/remotes/origin/${BASE_REF#origin/}" "$BASE_SHA" 2> /dev/null || true
 fi
+# THE TRANSPLANTED TREE NEEDS A REGISTRY ROOT (OMN-17741).
+# `ssh` forwards no environment, so without this the suite runs with OMNI_HOME
+# UNSET on every target host. Code that resolves a workspace then either fails,
+# or -- the case actually measured -- falls back to a home-relative default
+# that EXISTS on the lab Macs and is TCC-denied to `sshd`. OMN-17459 recorded
+# that shape: a real full suite on h101, 17,883 tests in 13m58s, 12 failures,
+# ALL 12 green locally, one root cause. Same standing as the PATH block above
+# -- a false red here HARD-BLOCKS a push, so this is part of the verdict
+# meaning anything, not a convenience.
+#
+# The value is CONSTRUCTED HERE, never forwarded. Exporting the launcher's
+# `$OMNI_HOME` would be strictly worse than leaving it unset: that path exists
+# on every lab Mac and is TCC-denied, so forwarding converts a fail-fast into a
+# PermissionError deep inside a test. What is true of a transplant is that it
+# contains exactly ONE repo, so a one-entry registry naming that repo is an
+# honest workspace root and a lie about nothing. It is the same shape a
+# vendoring repo's own aislop-sweep smoke test already builds for itself (a
+# tmpdir plus a symlink to the repo under its own name).
+#
+# It lives under $RUNDIR, so `prepush_remote_gc` already sweeps it and this
+# adds no new class of stranded state. Failure to build it exits 98 -- an
+# unhandled wrapper exit produces no MARKER, which the dispatcher classifies as
+# "NO EVIDENCE" and walks past to the next fit host. That is the correct
+# classification: a workspace that could not be created on the TARGET says
+# nothing about the tree under test.
+[ -n "$REPO_NAME" ] || { echo "NO_REPO_NAME_FOR_REGISTRY_ROOT" >&2; exit 98; }
+rm -rf "$RUNDIR/omni_home" 2> /dev/null || true
+mkdir -p "$RUNDIR/omni_home" || { echo "REGISTRY_ROOT_MKDIR_FAILED" >&2; exit 98; }
+ln -s "$RUNDIR/tree" "$RUNDIR/omni_home/$REPO_NAME" || { echo "REGISTRY_ROOT_LINK_FAILED" >&2; exit 98; }
+OMNI_HOME="$RUNDIR/omni_home"
+export OMNI_HOME
+
 "$UV" sync --all-extras > "$RUNDIR/sync.log" 2>&1 || { echo "UV_SYNC_FAILED" >&2; exit 93; }
 # THE COLLECTED COUNT IS READ FROM A MACHINE-READABLE REPORT (OMN-17787).
 # `--junitxml` is asked for HERE, next to the invocation, because the count it
@@ -1313,7 +1349,7 @@ REMOTE
   # dispatch_to_lab_host treats as a placement miss and walks past. Fail-closed
   # posture is unchanged -- a genuine remote RED still carries a marker and
   # still refuses the push.
-  remote_cmd="cd '${rundir}' || exit 96; chmod +x prepush_smart_tests.sh || exit 97; ./prepush_smart_tests.sh '${rundir}' '${uv}' '${head_sha}' '${argv_sha}' '$(hostname -s 2> /dev/null || echo unknown):$$' '${workroot}' '${base_ref}' '${base_sha}' '${slot_idx}'; rc=\$?; echo REMOTE_WRAPPER_EXIT=\$rc; echo \$rc > '${rundir}/WRAPPER_EXIT'; exit 0"
+  remote_cmd="cd '${rundir}' || exit 96; chmod +x prepush_smart_tests.sh || exit 97; ./prepush_smart_tests.sh '${rundir}' '${uv}' '${head_sha}' '${argv_sha}' '$(hostname -s 2> /dev/null || echo unknown):$$' '${workroot}' '${base_ref}' '${base_sha}' '${slot_idx}' '${repo}'; rc=\$?; echo REMOTE_WRAPPER_EXIT=\$rc; echo \$rc > '${rundir}/WRAPPER_EXIT'; exit 0"
   tcmd="$(_prepush_timeout_cmd)"
   if [ -n "$tcmd" ]; then
     "$tcmd" "$PREPUSH_REMOTE_EXEC_TIMEOUT_SECONDS" \

--- a/scripts/hooks/prepush_vendored.tsv
+++ b/scripts/hooks/prepush_vendored.tsv
@@ -1,0 +1,104 @@
+# PROVENANCE of the pre-push files this repo VENDORS from omnibase_infra
+# (OMN-17754). Read by tests/scripts/test_prepush_host_table.py.
+#
+# WHY VENDORED AND NOT SHARED -- the decision, on the facts, not on preference:
+#
+#   * A sibling-clone source (`. "$OMNI_HOME/omnibase_infra/scripts/hooks/..."`)
+#     makes a FAIL-CLOSED gate depend on a second repository being checked out
+#     next to this one. An isolated single-repo clone, a CI runner checkout, or
+#     a contributor without the whole workspace would then hit `die` on every
+#     heavy push. A placement optimisation must not be able to brick a push.
+#   * A pip-installed picker moves the gate behind a synced `.venv`, which a
+#     pre-push hook cannot assume exists -- and the hook must run BEFORE the
+#     machinery that would install it.
+#   * A git submodule has the same failure shape as the sibling clone, one
+#     `git clone` flag away (`--recurse-submodules` omitted -> empty dir).
+#
+# So the copy is local, and the DRIFT is what gets mechanically controlled:
+# each file's sha256 is pinned, and the upstream revision it was taken from is
+# recorded HERE so "has upstream moved?" is answerable by anyone with network
+# access, without this repo depending on that access at push time.
+#
+# WHAT THIS FILE ADDS OVER THE BARE DIGEST PIN this repo carried from OMN-17159
+# until OMN-17754 (a sha256 literal inside
+# test_the_picker_library_is_byte_identical_to_the_shipped_upstream): a digest
+# alone detects a LOCAL edit. It cannot tell you the copy is STALE. Measured
+# 2026-09-01: this repo's OMN-17159 copy pinned omnibase_infra 81955c0d0
+# (OMN-17269) while omnibase_infra dev had already shipped 3e1c975b0
+# (OMN-17392) -- a full feature behind before its own PR merged, and nothing
+# in this repo could say so. Recording the upstream commit next to the digest
+# is what makes that question answerable.
+#
+# TO UPDATE: re-copy (or re-port, see below) the file from the named upstream
+# path, update BOTH the sha256 and the upstream_commit here in the same commit,
+# re-run tests/scripts/test_prepush_host_table.py and
+# tests/scripts/test_prepush_remote_leg_policy.py, and name the upstream
+# revision in the PR body. Editing a vendored file WITHOUT touching this record
+# is the thing that cannot happen quietly.
+#
+#
+# THIS REPO'S COPIES ARE NOT VERBATIM, AND THIS HEADER SAYS EXACTLY HOW. The
+# `sha256` column pins the bytes THIS repo ships. The `upstream_commit` column
+# names the upstream revision those bytes were last taken from -- for a
+# verbatim copy that is the whole story; for a port it names the revision the
+# ported blocks came from, and the divergence is recorded here so the next
+# re-sync knows what it is looking at.
+#
+#   scripts/hooks/prepush_dispatch.sh -- a SUBSET PORT of upstream 812d0b545
+#     (OMN-17787, #3179, which is on top of OMN-17741's 4053dc3c0, #3161).
+#     1471 lines here against 1917 upstream. What is IN this copy, executable
+#     lines byte-identical to upstream: the OMN-17606 slot-probe fix, the
+#     OMN-17564/OMN-17603 remote-leg execution policy seam, the OMN-17787
+#     `--junitxml` collected count + zero-collection NO EVIDENCE gate, and (as
+#     of OMN-17754) the OMN-17741 registry root -- the wrapper constructs
+#     `$RUNDIR/omni_home/<repo>` on the target, exports OMNI_HOME to it, and
+#     the repo name travels as the TENTH positional of the remote command.
+#     What is NOT in this copy, and why:
+#       1. OMN-17392/OMN-17485 (memory-aware admission, prefer_remote,
+#          placement_tier ranking). Upstream reads `heavy_local` at host-table
+#          column 13 and `placement_tier` at column 14; this repo's
+#          prepush_hosts.tsv has THIRTEEN columns with `note` at 13, so a
+#          verbatim take of upstream's reader would parse every row's free-text
+#          note as its heavy_local policy. The columns must land here first
+#          (OMN-17756 is the tracked port). One fit-record index diverges as a
+#          consequence: upstream reads `cores` at f11 because its record
+#          carries a `tier_rank` at f10; this record is nine fields, so `cores`
+#          appends at f10.
+#       2. ONE DELIBERATE ADDITION upstream does not have: the two banner
+#          fallbacks behind the junit count are read through
+#          `prepush_banner_stream`, a normalizer that strips SGR colour codes
+#          and CR progress writes first. `tests/pytest.ini` addopts carries
+#          `--color=yes` and the remote leg's rootdir resolves into `tests/`,
+#          so this repo's serial collector banner arrives as
+#          `ESC[1mcollecting ... ESC[0mcollected N items` and upstream's plain
+#          `^collected` anchor never matched here. Upstream ships no
+#          tests/pytest.ini and never sees the colorized form.
+#       3. Upstream's prose names the vendoring repos in comment lines;
+#          test_the_picker_library_is_not_edited_into_a_repo_specific_fork
+#          forbids those tokens inside the shared library, so the same facts
+#          are stated repo-neutrally here.
+#     Convergence check that IS mechanical from this repo, comment lines
+#     stripped, against upstream 812d0b545 (verified 2026-09-04, recorded in
+#     the OMN-17754 PR body): the OMN-17741 registry block diffs EMPTY; the
+#     OMN-17787 wrapper block diffs by exactly the normalizer in (2) and
+#     nothing else.
+#
+#   scripts/hooks/prepush_override_grant.py -- VERBATIM copy of upstream
+#     eddf4a9d2 (digest identical to omnimarket's pin of the same revision).
+#     Upstream has since moved to 4349bb362 (OMN-17441, inherited
+#     PREPUSH_*_OVERRIDE_MAP rejection at both hook entry points); that re-take
+#     is NOT bundled into OMN-17754 and is recorded here as the outstanding
+#     delta rather than silently carried.
+#
+#   scripts/hooks/pytest_full_suite_host_guard.py -- a PORT of upstream
+#     eddf4a9d2 taken under OMN-17159: 11 lines differ, all of them this
+#     repo's own wording (the host-table pointer in the refusal message, the
+#     narrow-target example path, the OMN-17159 history note). Upstream has
+#     since moved to 65cb31cdf (OMN-17441 placement-map rejection at
+#     pytest_configure, OMN-16607 runbook pointer); same outstanding delta,
+#     same rule -- recorded, not hidden.
+#
+#path	upstream_repo	upstream_path	upstream_commit	upstream_branch	sha256	copied_at
+scripts/hooks/prepush_dispatch.sh	OmniNode-ai/omnibase_infra	scripts/hooks/prepush_dispatch.sh	812d0b5451c1b157dd764cc26a83b9c7e12bcf71	dev	3731ca42fea56fa61dec993a3818e9046b70890c7d8da2ed0b71d2b8768ad71b	2026-09-04
+scripts/hooks/prepush_override_grant.py	OmniNode-ai/omnibase_infra	scripts/hooks/prepush_override_grant.py	eddf4a9d20a294bed00a3c7e73ab14f73f2c6911	dev	6777c592a944fe1964a195bf088c00c7747551e5e9a20705ca49d9e59dbc3f3c	2026-09-01
+scripts/hooks/pytest_full_suite_host_guard.py	OmniNode-ai/omnibase_infra	scripts/hooks/pytest_full_suite_host_guard.py	eddf4a9d20a294bed00a3c7e73ab14f73f2c6911	dev	73a104fc080bfa49cbab263830c43f53d473d5c51f31bc2fa37018d34c3c67d8	2026-09-01

--- a/tests/scripts/test_prepush_host_table.py
+++ b/tests/scripts/test_prepush_host_table.py
@@ -1654,6 +1654,10 @@ def remote_run_env(tmp_path: Path) -> dict[str, Path]:
     fake_uv = tmp_path / "uv"
     fake_uv.write_text(
         "#!/bin/sh\n"
+        # OMN-17741: record the workspace root the wrapper handed us. Written
+        # on BOTH the `sync` and the pytest invocation, so a wrapper that
+        # establishes the registry too late (after `uv sync`) is still caught.
+        'printf "%s\\n" "${OMNI_HOME:-<unset>}" > "$OMNI_HOME_WITNESS"\n'
         'if [ "$1" = "sync" ]; then exit 0; fi\n'
         # Proof that the target-host slot is held for the DURATION of the run,
         # not merely acquired and dropped before the expensive part.
@@ -1669,6 +1673,7 @@ def remote_run_env(tmp_path: Path) -> dict[str, Path]:
         "rundir": rundir,
         "uv": fake_uv,
         "witness": witness,
+        "omni_home_witness": tmp_path / "omni_home_witness",
         "head": head,  # type: ignore[dict-item]
     }
 
@@ -1678,13 +1683,28 @@ def _run_wrapper(
     *,
     extra_env: dict[str, str] | None = None,
     extra_argv: list[str] | None = None,
+    repo: str = "omnibase_core",
 ) -> subprocess.CompletedProcess[str]:
     env = {
         **os.environ,
         "LOCK_PROBE": str(env_info["workroot"] / "LOCK"),
         "LOCK_WITNESS": str(env_info["witness"]),
+        "OMNI_HOME_WITNESS": str(env_info["omni_home_witness"]),
     }
+    # FIDELITY, not tidiness (OMN-17741): `ssh` forwards no environment, so on
+    # a real target host the wrapper starts with OMNI_HOME UNSET. This pytest
+    # process inherits a developer shell where it IS set, and leaking that in
+    # would let a wrapper that establishes nothing pass the registry assertions
+    # on the launcher's value.
+    env.pop("OMNI_HOME", None)
     env.update(extra_env or {})
+    # The wrapper's trailing positionals are optional on the remote side but
+    # POSITIONAL, so they are padded here rather than appended: a caller that
+    # passes only BASE_REF/BASE_SHA must still land the repo name in slot 10.
+    tail = list(extra_argv or [])
+    base_ref = tail[0] if len(tail) > 0 else ""
+    base_sha = tail[1] if len(tail) > 1 else ""
+    slot = tail[2] if len(tail) > 2 and tail[2] else "1"
     return subprocess.run(
         [
             "bash",
@@ -1695,7 +1715,10 @@ def _run_wrapper(
             "argvsha",
             "origin-host:1",
             str(env_info["workroot"]),
-            *(extra_argv or []),
+            base_ref,
+            base_sha,
+            slot,
+            repo,
         ],
         capture_output=True,
         text=True,
@@ -1732,6 +1755,128 @@ def test_the_remote_leg_holds_the_target_hosts_lock_for_the_whole_run(
     )
 
 
+# =============================================================================
+# The transplanted tree needs a registry root (OMN-17741)
+# =============================================================================
+# Ported from omnibase_infra (OMN-17741, merge 4053dc3c065b0bc94e98001a28ea9415
+# ffd782cb, PR #3161) under OMN-17754, and re-run here against THIS repo's copy
+# of the library. `ssh` forwards no environment, so the wrapper starts with
+# OMNI_HOME unset on every target host. Code the suite runs that resolves a
+# workspace then either fails, or -- the case actually measured upstream --
+# falls back to a home-relative default that EXISTS on the lab Macs and is
+# TCC-denied to `sshd`. OMN-17459 recorded that shape: a real full suite on
+# h101, 17,883 tests in 13m58s, 12 failures, all 12 green locally, one root
+# cause.
+#
+# A false red here HARD-BLOCKS a push (`dispatch_to_lab_host` rc=3 -> `die`,
+# "a remote red is never satisfied by minting an override grant"), so this is
+# part of the verdict meaning anything -- the same standing the PATH-parity
+# block already has.
+
+
+def test_the_remote_wrapper_gives_the_transplanted_tree_a_registry_root(
+    remote_run_env: dict[str, Path],
+) -> None:
+    """The value must be a REAL registry the remote process can write, holding
+    the transplanted repo under its own name -- not an unset variable and not a
+    bare rundir, which contains no directory named for the repo at all."""
+    result = _run_wrapper(remote_run_env, repo="omnibase_core")
+    assert result.returncode == 0, result.stderr
+
+    recorded = remote_run_env["omni_home_witness"].read_text().strip()
+    assert recorded != "<unset>", (
+        "the suite ran with no OMNI_HOME: every workspace-resolving call site "
+        "in the transplanted tree is left to guess, and the lab Macs have a "
+        "TCC-denied ~/Code/omni_home for it to guess wrong onto"
+    )
+    registry = Path(recorded)
+    assert registry == remote_run_env["rundir"] / "omni_home", recorded
+    assert registry.is_dir()
+
+    linked = registry / "omnibase_core"
+    assert linked.is_symlink(), "the repo must be reachable under its own name"
+    assert linked.resolve() == (remote_run_env["rundir"] / "tree").resolve()
+    assert (linked / "tests" / "test_a.py").is_file(), (
+        "the registry entry must resolve to the tree that was actually cloned"
+    )
+
+    # Writability is the whole point: the measured failure was PermissionError
+    # on mkdir, not a missing path.
+    (registry / ".onex_state" / "probe").mkdir(parents=True)
+
+
+def test_the_registry_root_is_established_on_target_never_inherited(
+    remote_run_env: dict[str, Path],
+) -> None:
+    """Forwarding the LAUNCHER's OMNI_HOME is strictly worse than leaving it
+    unset: the launcher's workspace path exists on every lab Mac and is
+    TCC-denied to `sshd`, so forwarding converts a fail-fast into a
+    PermissionError deep inside a test. Pin that an inherited value loses."""
+    launcher_value = "/nonexistent/launcher/Code/omni_home"
+    result = _run_wrapper(
+        remote_run_env,
+        repo="omnibase_core",
+        extra_env={"OMNI_HOME": launcher_value},
+    )
+    assert result.returncode == 0, result.stderr
+    recorded = remote_run_env["omni_home_witness"].read_text().strip()
+    assert recorded != launcher_value, (
+        "the wrapper forwarded the launcher's workspace path to the target host"
+    )
+    assert recorded == str(remote_run_env["rundir"] / "omni_home")
+    assert (Path(recorded) / "omnibase_core").is_symlink()
+
+
+def test_the_registry_root_is_named_by_the_dispatch_not_hardcoded(
+    remote_run_env: dict[str, Path],
+) -> None:
+    """One wrapper serves omnibase_infra, omnibase_core and omnimarket, so the
+    repo name has to travel with the dispatch. `prepush_remote_run` already
+    computes it as `basename "$REPO_ROOT"`; assert it is passed through as the
+    tenth positional, and that a dispatch naming a different repo gets a
+    registry entry under THAT name."""
+    lib = LIB.read_text(encoding="utf-8")
+    idx = lib.index('remote_cmd="cd ')
+    invocation = lib[idx : lib.index("\n", idx)]
+    assert "'${repo}'" in invocation, (
+        "the remote command does not pass the repo name to the wrapper: " + invocation
+    )
+    remote = _remote_wrapper_text()
+    assert "REPO_NAME=" in remote, "the wrapper does not bind a repo name positional"
+    for hardcoded in ("omni_home/omnibase_core", "omni_home/omnimarket"):
+        assert hardcoded not in remote
+
+    result = _run_wrapper(remote_run_env, repo="some-other-repo")
+    assert result.returncode == 0, result.stderr
+    registry = Path(remote_run_env["omni_home_witness"].read_text().strip())
+    assert (registry / "some-other-repo").is_symlink()
+    assert not (registry / "omnibase_core").exists()
+
+
+def test_the_registry_root_lives_under_the_gc_swept_workroot() -> None:
+    """It must not become a new class of stranded state. `prepush_remote_gc`
+    sweeps `<workroot>/runs`, so the registry belongs inside the rundir."""
+    remote = _remote_wrapper_text()
+    idx = remote.index("OMNI_HOME=")
+    assignment = remote[idx : remote.index("\n", idx)]
+    assert "$RUNDIR/" in assignment, assignment
+
+
+def test_a_dispatch_that_names_no_repo_is_no_evidence_not_a_verdict(
+    remote_run_env: dict[str, Path],
+) -> None:
+    """A registry that cannot be built on the TARGET says nothing about the
+    tree under test. The wrapper exits 98 before the suite runs, which produces
+    no MARKER -- the classification the dispatcher already walks past."""
+    result = _run_wrapper(remote_run_env, repo="")
+    assert result.returncode == 98, (result.returncode, result.stderr)
+    assert "NO_REPO_NAME_FOR_REGISTRY_ROOT" in result.stderr
+    assert not (remote_run_env["rundir"] / "MARKER").exists()
+    assert not (remote_run_env["workroot"] / "LOCK").exists(), (
+        "the slot must be released even when the registry cannot be built"
+    )
+
+
 def test_the_remote_leg_releases_the_lock_even_when_the_suite_fails(
     remote_run_env: dict[str, Path],
 ) -> None:
@@ -1758,7 +1903,9 @@ def test_the_remote_wrapper_locks_a_numbered_lockdir_for_slot_two(
         **os.environ,
         "LOCK_PROBE": str(slot2_probe),
         "LOCK_WITNESS": str(remote_run_env["witness"]),
+        "OMNI_HOME_WITNESS": str(remote_run_env["omni_home_witness"]),
     }
+    env.pop("OMNI_HOME", None)
     result = subprocess.run(
         [
             "bash",
@@ -1772,6 +1919,7 @@ def test_the_remote_wrapper_locks_a_numbered_lockdir_for_slot_two(
             "",
             "",
             "2",
+            "omnibase_core",
         ],
         capture_output=True,
         text=True,
@@ -2095,95 +2243,82 @@ def test_the_wrapper_runs_normally_when_no_base_ref_is_supplied(
 # =============================================================================
 
 
-def test_the_picker_library_is_byte_identical_to_the_shipped_upstream() -> None:
-    """`prepush_dispatch.sh` is a BYTE-FOR-BYTE copy of omnibase_infra's.
+# =============================================================================
+# Vendored-file provenance: digest + upstream commit (OMN-17754)
+# =============================================================================
+# Three repos are meant to run one picker, not three that drifted. The obvious
+# assertion -- "all three copies are identical" -- is NOT implementable from a
+# repo-local harness: this suite cannot read a sibling checkout, and a test
+# that reaches for `$OMNI_HOME/omnibase_infra` would pass or fail on whether an
+# unrelated clone happens to exist. So each repo pins the sha256 of the copy IT
+# ships, and a local edit is a deliberate, reviewed digest bump rather than a
+# silent fork.
+#
+# Until OMN-17754 this repo pinned that digest as a literal inside this test,
+# which detects a LOCAL edit but says nothing about whether the copy is STALE
+# -- measured 2026-09-01, core's copy sat a whole feature (OMN-17392) behind
+# upstream before its own PR merged, and nothing here could say so. The record
+# now lives in scripts/hooks/prepush_vendored.tsv, the same shape omnimarket
+# adopted under OMN-17435: each row carries the upstream COMMIT alongside the
+# digest, so "has upstream moved?" is answerable by anyone with network access
+# without this repo needing that access at push time. The header of that file
+# records where and why this repo's copy diverges from a verbatim take.
 
-    Three repos are meant to run one picker, not three that drifted. The
-    obvious assertion -- "all three copies are identical" -- is NOT
-    implementable from a repo-local harness: this suite cannot read a sibling
-    checkout, and a test that reaches for `$OMNI_HOME/omnibase_infra` would
-    pass or fail on whether an unrelated clone happens to exist. OMN-17159's
-    DoD names the workable form instead: each repo pins the sha256 of the copy
-    IT ships, so a local edit is a deliberate, reviewed digest bump rather than
-    a silent fork.
+VENDORED = REPO_ROOT / "scripts" / "hooks" / "prepush_vendored.tsv"
 
-    Updating this constant is the correct move when the upstream library
-    legitimately changes -- re-copy the file, re-run, paste the new digest, and
-    say in the PR body which upstream commit it tracks. Editing the library
-    WITHOUT touching this constant is the thing that cannot happen quietly.
 
-    WHAT THIS DIGEST TRACKS, AND WHAT IT DOES NOT (OMN-17606). The name of this
-    test overstates what it can currently assert, and has since OMN-17159: this
-    repo's copy is 1114 lines while omnibase_infra's is 1511, because core never
-    took the OMN-17392 memory-aware admission block. The digest therefore pins
-    "core's copy has not changed without review", not "core's copy equals
-    omnibase_infra's" -- the two have not been byte-identical for some time, and
-    saying so here is cheaper than letting the name keep asserting it.
+def _vendored_rows() -> list[list[str]]:
+    rows = []
+    for line in VENDORED.read_text(encoding="utf-8").splitlines():
+        line = line.split("#", 1)[0]
+        if not line.strip():
+            continue
+        rows.append(line.split("\t"))
+    return rows
 
-    The bump in OMN-17606 is the three-defect slot-probe fix (zsh `nomatch`
-    killing the `held` glob, one remote leg counted as two processes, and an
-    existing-but-empty QUEUE file shifting every field left). The shared block
-    it lands in -- from the `# multi-slot row it lets a legitimately-held`
-    comment through the end of `prepush_slot_state` -- is BYTE-IDENTICAL to the
-    copy already merged on omnimarket dev (omnimarket#2276, omnimarket dev
-    b79d8983), verified by `diff` at 2026-09-03T08:55Z. That parity is the
-    point: the comment above the probe names only ticket ids and host labels,
-    never a repo, so the next vendor re-sync of lines 140-300 sees no diff and
-    neither repo's `test_the_picker_library_is_not_edited_into_a_repo_specific_fork`
-    can fire on the other's wording. Re-sync of the REST of the file (OMN-17392
-    and the host-table columns it needs) is deliberately NOT bundled here.
 
-    THE BUMP IN OMN-17754 is the OMN-17787 port from omnibase_infra (that
-    repo's merge ``812d0b5451c1b157dd764cc26a83b9c7e12bcf71``, PR #3179): the
-    remote wrapper now asks pytest for a ``--junitxml`` report and reads the
-    collected count out of it, the marker's ``collected`` field is normalized
-    to a number before it is compared, and acceptance refuses a green run that
-    collected zero as NO EVIDENCE rather than accepting it as a PASS.
+def test_every_vendored_file_matches_its_recorded_digest() -> None:
+    """The shipped bytes and the provenance record cannot disagree.
 
-    ONE DELIBERATE DIVERGENCE FROM UPSTREAM, and it is not cosmetic. Upstream's
-    two banner fallbacks are read straight off ``suite.log``; here they are read
-    through a normalizer that strips SGR colour codes and CR progress writes
-    first. ``tests/pytest.ini`` addopts carries ``--color=yes`` and this leg's
-    rootdir resolves into ``tests/``, so this repo's serial collector banner
-    arrives as ``ESC[1mcollecting ... ESC[0mcollected N items`` -- a line that
-    does not begin with ``collected``. Upstream ships no ``tests/pytest.ini``
-    and so never sees the colorized form. A verbatim copy would have shipped a
-    fallback that is dead in this repo, which is measurably how the count read
-    zero here even on runs with no xdist involved.
-
-    THE BUMP IN OMN-17603 is this file's dev content (the OMN-17606 probe fix
-    above, digest ``6813caf5``) PLUS the remote-leg execution-policy seam ported
-    from omnibase_infra ``abc144fe6`` (OMN-17564) as a SUBSET, not a verbatim
-    re-copy. Two facts make a verbatim copy impossible
-    today, and both are somebody else's ticket:
-
-    1. That upstream file reads ``heavy_local`` at COLUMN 13 and ranks on a
-       ``placement_tier`` at column 14 (OMN-17392/OMN-17485). This repo's
-       ``prepush_hosts.tsv`` has thirteen columns with ``note`` at 13, so a
-       verbatim copy would read every row's free-text note as its heavy_local
-       policy. The columns must land here first.
-    2. That upstream file names this repo in three comment lines, which
-       ``test_the_picker_library_is_not_edited_into_a_repo_specific_fork``
-       below rejects outright.
-
-    So the two copies are NOT byte-identical and this constant cannot pretend
-    they are. What was ported is the OMN-17564 execution-policy seam verbatim
-    in behavior: same constant names, same ``PREPUSH_PICK_CORES`` name, same
-    ``min(row cores, cap)`` rule. One index diverges as a CONSEQUENCE of (1)
-    above -- upstream reads ``cores`` at fit-record f11 because its record
-    carries a ``tier_rank`` at f10; this record is nine fields, so ``cores``
-    appends at f10.
+    Updating a vendored file is a legitimate, expected operation -- re-copy (or
+    re-port) from the named upstream path, update BOTH the sha256 and the
+    upstream_commit in the same commit, and name the upstream revision in the
+    PR body. Editing the file WITHOUT touching the record is the thing that
+    cannot happen quietly.
     """
-    digest = hashlib.sha256(LIB.read_bytes()).hexdigest()
-    assert (
-        digest
-        == "ab998c7c147c0b926a236212caf12165a3412ab4a2f1e3059872e699dc396541"  # pragma: allowlist secret
-    ), (
-        "scripts/hooks/prepush_dispatch.sh has diverged from the pinned "
-        "upstream copy. If the change is intentional, update this digest in "
-        "the same commit and name the upstream revision it tracks; if it is "
-        "not, restore the file from omnibase_infra"
-    )
+    rows = _vendored_rows()
+    assert rows, f"expected at least one provenance row in {VENDORED}"
+    for row in rows:
+        assert len(row) == 7, f"malformed provenance row: {row!r}"
+        rel, _repo, _upath, commit, _branch, digest, _copied = row
+        target = REPO_ROOT / rel
+        assert target.is_file(), f"provenance names a missing file: {rel}"
+        actual = hashlib.sha256(target.read_bytes()).hexdigest()
+        assert actual == digest, (
+            f"{rel} has diverged from its recorded copy "
+            f"({_repo}@{commit}:{_upath}). If the change is intentional, update "
+            f"the sha256 in {VENDORED.name} in the same commit and say which "
+            "upstream revision it now tracks; if it is not, restore the file"
+        )
+        assert len(commit) == 40, (
+            f"upstream_commit for {rel} is not a full 40-char sha: {commit!r}"
+        )
+        assert all(c in "0123456789abcdef" for c in commit), (
+            f"upstream_commit for {rel} is not lowercase hex: {commit!r}"
+        )
+
+
+def test_the_picker_library_is_covered_by_the_provenance_record() -> None:
+    """The picker specifically -- not merely "some file" -- must be pinned.
+
+    A provenance file that happened to list only the two Python helpers would
+    leave the fail-closed placement logic itself unguarded, which is the one
+    file whose silent fork actually changes where a suite runs.
+    """
+    covered = {row[0] for row in _vendored_rows()}
+    assert "scripts/hooks/prepush_dispatch.sh" in covered
+    assert "scripts/hooks/prepush_override_grant.py" in covered
+    assert "scripts/hooks/pytest_full_suite_host_guard.py" in covered
 
 
 def test_the_picker_library_is_not_edited_into_a_repo_specific_fork() -> None:


### PR DESCRIPTION
Converges the THIRD vendored copy of the pre-push picker. `omnibase_infra` is upstream; `omnimarket` re-vendored under OMN-17753; this repo was the one copy still missing both a provenance record and the registry-root half of the picker.

Closes the `omnibase_core` half of OMN-17787's Required-shape bullet, *"Re-vendor into `omnibase_core` and `omnimarket` (`prepush_vendored.tsv` re-pin), one PR each."*

## What was actually missing here

Measured on `origin/dev` at `e0ea3492`, with `omnimarket` as the positive control:

| | omnibase_infra (upstream) | omnimarket | omnibase_core (before) |
|---|---|---|---|
| `scripts/hooks/prepush_vendored.tsv` | n/a (is upstream) | present | **absent** |
| vendored-drift test | n/a | present | **absent** — a bare sha256 literal inside a test docstring |
| `grep -c OMNI_HOME prepush_dispatch.sh` | 4 | 4 | **0** |

So two distinct gaps, not one. The digest literal detects a LOCAL edit but cannot say the copy is STALE — and that is not hypothetical here: on 2026-09-01 this repo's pin named `81955c0d0` while upstream `dev` had already shipped `3e1c975b0`, a full feature ahead, and nothing in the repo could say so.

## 1. Provenance record

New `scripts/hooks/prepush_vendored.tsv`, the same shape `omnimarket` adopted under OMN-17435: each row carries the upstream **commit** next to the sha256, so "has upstream moved?" is answerable by anyone with network access without this repo needing that access at push time.

Pinned to `omnibase_infra` `812d0b5451c1b157dd764cc26a83b9c7e12bcf71` — verified an ancestor of `omnibase_infra origin/dev` and still the newest commit touching that file.

**This repo's copy is NOT verbatim, and the header says exactly how** rather than letting the name of a test assert a parity that does not hold. It is a documented subset port: 1471 lines against upstream's 1917. What is deliberately absent (upstream's OMN-17392/OMN-17485 memory-aware admission) is absent for a mechanical reason — upstream reads `heavy_local` at host-table column 13, and this repo's `prepush_hosts.tsv` has thirteen columns with `note` at 13, so a verbatim take of upstream's reader would parse every row's free-text note as its heavy_local policy. Per the brief, the reader was **not** changed to match and the table was **not** re-shaped; the divergence is recorded in the pin header and the column port stays OMN-17756's ticket.

## 2. The registry-root half

`ssh` forwards no environment, so the transplanted tree previously ran with `OMNI_HOME` unset on every target host. The wrapper now constructs `$RUNDIR/omni_home/<repo>` on the target, symlinks it to the cloned tree, and exports `OMNI_HOME` to it. The value is **constructed, never forwarded** — the launcher's workspace path exists on every lab Mac and is TCC-denied to `sshd`, so forwarding converts a fail-fast into a `PermissionError` deep inside a test. The repo name travels as the tenth positional; it is passed rather than derived because `RUNDIR`'s basename is `<repo>-<sha12>-<pid>` and repo names contain both separators.

It lives under `$RUNDIR`, so `prepush_remote_gc` already sweeps it. Failure to build it exits 98 — no `MARKER`, which the dispatcher classifies as NO EVIDENCE and walks past. That is the right classification: a workspace that could not be created on the *target* says nothing about the tree under test.

## Convergence proof, mechanical

Comment lines and blank lines stripped from both sides, against upstream `812d0b545`:

- the **registry block diffs EMPTY** — the `REPO_NAME` guard, the `rm -rf`/`mkdir`/`ln -s`, the export and the `exit 98`s are byte-identical;
- the **OMN-17787 block diffs by exactly one thing**: this repo's `prepush_banner_stream` normalizer, which strips SGR colour codes and CR progress writes ahead of the two banner fallbacks. `tests/pytest.ini` addopts carries `--color=yes` and this leg's rootdir resolves into `tests/`, so the serial banner arrives SGR-prefixed and upstream's plain `^collected` anchor never matched here. Upstream ships no `tests/pytest.ini` and never sees the colorized form.
- `grep -c OMNI_HOME`: **0 → 4**, matching upstream's 4.

## Tests — red first

`cab0ae33` is the red commit, pinned against the shipped library before any fix: 7 failed, 4 passed in the `-k` subset on `e0ea3492`.

Added: the drift test (every row's sha256 must match the bytes it names, and every `upstream_commit` must be a full 40-char lowercase hex sha), a coverage test that the picker specifically is pinned, and five extract-and-execute tests driving the shipped wrapper text — the registry is built and writable, an inherited launcher value **loses**, the name comes from the dispatch rather than being hardcoded, the root sits under the GC-swept workroot, and a dispatch naming no repo exits 98 with no `MARKER` and still releases the slot.

The harness pops `OMNI_HOME` before invoking the wrapper. That is fidelity, not tidiness: `ssh` forwards no environment, so a wrapper that establishes nothing would otherwise pass the registry assertions on the launcher's inherited value.

**Positive control on the drift test**, because a passing digest test proves nothing on its own: appending one comment line to `prepush_dispatch.sh` made it fail with the expected `3731ca42` vs `08a98ec8` mismatch; restoring the file returned the tree to clean and the digest to `3731ca42`.

## Verification

- `tests/scripts/test_prepush_host_table.py` + `test_prepush_remote_leg_policy.py`: **134 passed**.
- `ruff format --check` and `ruff check`: clean. `mypy --strict` on the touched test file: clean. `pre-commit` on the three touched files: 0 failed.
- Governed pre-push, whole-suite-equivalent escalation, **44758 passed / 53 skipped / 3 xpassed / ZERO failed** in 2:06:05, then `impacted tests passed; allowing push`.

An earlier attempt on this same commit was refused by the gate with 2 failures in `tests/scripts/test_prepush_hook_host_identity_guard.py`. Those are OMN-17924, third recorded occurrence, and not this change: both tests shell out to `scripts/hooks/prepush_smart_tests.sh` — a file this PR does not touch — and both failed with all seven hosts reading `slot-unknown` under fleet saturation, so the picker refuses and returns 1 while the test asserts 0. No override grant was minted at any point.

Evidence-Ticket: OMN-17754
Evidence-Source: OCC#8260
