### PR TITLE
chore(OMN-17556): describe the real contents of the v0.47.3 release in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,23 @@
 <!-- onex-allow-file-todo-marker reason="historical changelog entries include literal TODO marker tokens" -->
 
-## v0.47.3 (2026-09-02)
+## v0.47.3 (2026-09-05)
+
+### Features
+- feat typed store-resolved credential carrier on the deployment topology database binding, plus the `tenant-projection` runtime profile (#1648). `ModelDeploymentTopologyDatabaseBinding` now declares exactly ONE credential carrier per binding: `dsn_env` (legacy — a process env var holding the DSN) or `secret_ref` (a dotted logical secret name the runtime resolves through `SecretResolver` at the binding boundary). Both-set and neither-set are rejected by a model validator that names the offending principal either way; neither field is defaulted. `tenant-projection` is registered in `REGISTERED_RUNTIME_PROFILES` and in `CONSUMER_ATTACHED_RUNTIME_PROFILES` — it is one consolidated writer process owning every TENANT-domain projection contract, because it is the only process holding that binding's store-resolved credential. Additive: existing `dsn_env` bindings are unchanged.
+- feat give omnibase_core a lab host table so heavy pre-push escalations can leave the launching host (#1635), and add the hcloud EC2 overflow row while making the host-identity refusal proofs host-independent (#1640).
 
 ### Changes
-- chore move this repository's prose documentation to the OmniNode knowledge base and flip the KB doc gate to `mode: strict`. 199 markdown files outside the gate's allowed set are gone: 113 to the public knowledge base, 37 to the internal one, 47 deleted as stubs or dated artifacts, and `CONTRIBUTING.md`/`CODE_OF_CONDUCT.md` moved under `.github/`. No public API changes; the packaged tree changes only in that the eight generated validators no longer ship a `GENERATION_PROVENANCE.md` beside them, and their docstrings now cite that record in the knowledge base instead.
+- fix `backend_secret_discipline` no longer accepts `api_key_env` as a logical secret reference (#1649). An env-var name is a carrier, not a logical secret name; accepting it let a raw env credential pass a check that exists to force store resolution.
+- fix let a non-owner actor push through the governed pre-push dispatcher (#1642).
+- fix core vendored provenance record + the registry-root half of the picker (#1650), and port the zero-collected-tests refusal — a remote pre-push run that collected zero tests is no evidence, not a pass (#1647). A remote selector run that collected nothing now fails closed instead of reporting a green it never earned.
+- fix carry the pytest execution policy across the pre-push remote dispatch seam (#1643) — 3:36:06 to 1:32:51 on h105.
+- fix arm the terminal correlation predicate in host mode and stop reading a missing status as success (#1645).
+- fix arm omnibase_core auto-merge with the org PAT so dev push workflows fire (#1646).
+- fix scope the core release App token for workflows (#1638); the release main-sync pushes as `onexbot-occ-writer`, not `github-actions[bot]` (#1637).
+- fix remove a dead async autouse fixture that errors on pytest 9.1 + wire an async-fixture-decorator gate (#1636).
+- chore move this repository's prose documentation to the OmniNode knowledge base and flip the KB doc gate to `mode: strict` (#1644). 199 markdown files outside the gate's allowed set are gone: 113 to the public knowledge base, 37 to the internal one, 47 deleted as stubs or dated artifacts, and `CONTRIBUTING.md`/`CODE_OF_CONDUCT.md` moved under `.github/`. No public API changes; the packaged tree changes only in that the eight generated validators no longer ship a `GENERATION_PROVENANCE.md` beside them, and their docstrings now cite that record in the knowledge base instead.
+- ci require the KB doc gate on omnibase_core PRs (#1639).
+- chore(deps) bump the actions group with 2 updates.
 
 ## v0.47.0 (2026-08-29)
 


### PR DESCRIPTION
OMN-17556 — the release-identity step of the four-repo store-resolved-DSN chain. This PR changes one file, `CHANGELOG.md`, so that tagging `v0.47.3` ships a wheel whose changelog describes it.

## Why this exists

`pyproject.toml` on dev already declares `0.47.3` (set by #1645). The latest published tag and the latest PyPI release are both `0.47.2`. Sixteen commits have landed on dev since `v0.47.2`, but the `v0.47.3` changelog section carried exactly one bullet — the documentation migration (#1644) — and omitted everything else, including #1648, the typed store-resolved credential carrier that the omnibase_infra half of OMN-17556 pins `omnibase-core==0.47.3` to resolve.

Two consequences of tagging without this PR, both avoided by it:

1. The published wheel's changelog would describe a documentation move and nothing else.
2. `release.yml`'s `Resolve release ticket + evidence` step reads the merged PR at the tagged commit and re-threads its evidence trailers into every downstream cascade PR. dev HEAD `f6a7a1bc` resolves to #1642, whose trailers name OMN-17280 — the pre-push dispatcher fix, unrelated to this release. Tagging this PR's own squash commit instead makes OMN-17556 the cascade evidence, which is what the release actually proves.

## What changed

`CHANGELOG.md` only, +16/-2. The `v0.47.3` section is rewritten to cover all sixteen commits since `v0.47.2` (#1635, #1636, #1637, #1638, #1639, #1640, #1642, #1643, #1644, #1645, #1646, #1647, #1648, #1649, #1650, and the grouped actions bump), split into Features and Changes. The date moves from 2026-09-02 to 2026-09-05, the day of the cut. No version file is touched — `pyproject.toml` already declares `0.47.3`, and `scripts/check_release_identity.py` compares `project.version` against the latest PUBLISHED tag, which is satisfied.

## What lands next, and why it is blocked until this releases

- omnibase_infra's OMN-17556 leg pins `omnibase-core==0.47.3` in both `[project].dependencies` and `[tool.uv].override-dependencies`. Installed `0.47.2` declares `extra="forbid"` on `ModelDeploymentTopologyDatabaseBinding` and rejects `secret_ref`, so `uv sync` cannot resolve that branch until this wheel is on PyPI.
- omnimarket's leg floats `omnibase-core>=0.47.2,<0.48.0` and picks `0.47.3` up on its next lock. Once `tenant-projection` is a registered runtime profile in the resolved core, the OMN-17641 interim allowlist block becomes a stale exemption and is deleted in a follow-up PR.
- The chain closes on onex-dev with the tenant_projection binding resolving from the store instead of a process env var, per the operator ruling of 2026-09-03 that forbids a tenant DSN env var on any pod. OMN-17809 tracks the store-resolution seam this release unblocks.

## Release identity

Verified immediately before opening this PR:

- `curl -sS https://pypi.org/pypi/omnibase-core/json` — `info.version = 0.47.2`, `'0.47.3' in releases = False`. Positive control: `'0.47.2' in releases = True`, so the zero is a real absence and not a failed query.
- `git ls-remote --tags origin` — highest tag is `v0.47.2` (`a3c3184e`); no `v0.47.3`. The same command returns 22 real tag refs, so the zero is positive-controlled.
- CI on `f6a7a1bc`, the base of this branch: 12 success, 1 skipped, 0 failure (`gh run list --branch dev --limit 200`, filtered to that headSha and grouped by conclusion).

- `git diff --stat` — `CHANGELOG.md | 18 ++++++++++++++++--`, one file.
- Pre-commit ran on commit, full hook set, exit 0. The first attempt failed one hook — the doc-content scan gate rejected a bare ticket reference in a changelog bullet — and the bullet was reworded to name the behaviour instead. The hook was not suppressed and no annotation was added to pass it.
- Governed pre-push selector (`scripts/hooks/prepush_smart_tests.sh`) ran and allowed the push: `selection: is_full_suite=False reason=None paths=[ ]`, `no impacted unit tests mapped for this push`, `impacted tests passed; allowing push`. A documentation-only diff maps to no test target, which is the selector working, not a narrowing. Push exit 0.
- No bypass of any kind: no `--no-verify`, no `PREPUSH_*` variable, no `ENABLE_SMART_TESTS=off`, no `core.hooksPath` override, no override grant.

## Authorization

The 0.47.3 release identity was previously reserved for another lane by a rolling-ledger note of 2026-09-04. That reservation is superseded by the operator ruling of 2026-09-05, recorded durably at `docs/tracking/ROLLING_WORK_LEDGER.md:3346` with its approved and out-of-scope lists, and cited by this lane's claim row at `:3347`. Before proceeding, `.github/workflows/release.yml` was checked for a mechanical dependency on the three tickets named as blockers by the other lane: zero matches across the 428-line file, against a positive control of 9 matches for a ticket known to be in it. None of them gates the release workflow.

Evidence-Ticket: OMN-17556
Evidence-Source: OCC#8307
