### PR TITLE
feat(OMN-17841): add delegation v2 terminal wire classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.3"
+version = "0.47.6"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/scripts/validation/validate-single-class-per-file.py
+++ b/scripts/validation/validate-single-class-per-file.py
@@ -200,6 +200,7 @@ def should_exclude_file(filepath: Path) -> bool:
         "model_routing_config.py",  # ModelTierModel + ModelRoutingTier + ModelDelegationConfig (hierarchy)
         "model_quality_gate.py",  # ModelQualityGateInput + ModelQualityGateResult (paired gate DTOs)
         "model_bifrost_delegation_config.py",  # 7 tightly-coupled Bifrost gateway config DTOs
+        "model_delegation_terminal_v2.py",  # Task 1.1's closed terminal states and structural evidence models
         "model_golden_chain_fixture.py",  # ModelGoldenChainProvenance + ModelGoldenChainFixture (fixture + embedded provenance); pre-existing OMN-13499 file surfaced by spdx-headers CI gate wiring (OMN-13576); split tracked separately
     }
 

--- a/scripts/validation/validate-single-class-per-file.py
+++ b/scripts/validation/validate-single-class-per-file.py
@@ -21,8 +21,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
-_DELEGATION_TERMINAL_V2_PATH = Path(
-    "src/omnibase_core/models/delegation/wire/model_delegation_terminal_v2.py"
+_DELEGATION_TERMINAL_V2_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "omnibase_core"
+    / "models"
+    / "delegation"
+    / "wire"
+    / "model_delegation_terminal_v2.py"
 )
 
 
@@ -187,7 +193,7 @@ def should_exclude_file(filepath: Path) -> bool:
     # intentionally share one canonical delegation-wire module. Keep the
     # exemption tied to that module: an identically named file elsewhere must
     # remain subject to this validator.
-    if filepath == _DELEGATION_TERMINAL_V2_PATH:
+    if filepath.resolve() == _DELEGATION_TERMINAL_V2_PATH:
         return True
 
     # Exclude the COMPUTE-validator scan I/O trios (OMN-13294 / OMN-13497).

--- a/scripts/validation/validate-single-class-per-file.py
+++ b/scripts/validation/validate-single-class-per-file.py
@@ -21,6 +21,10 @@ import sys
 from pathlib import Path
 from typing import Any
 
+_DELEGATION_TERMINAL_V2_PATH = Path(
+    "src/omnibase_core/models/delegation/wire/model_delegation_terminal_v2.py"
+)
+
 
 class ClassDefinitionDetector(ast.NodeVisitor):
     """AST visitor to detect module-level class definitions in Python code.
@@ -179,6 +183,13 @@ def should_exclude_file(filepath: Path) -> bool:
     if filepath.name == "singleton_holders.py":
         return True
 
+    # Task 1.1's concrete terminal-state DTOs are structurally coupled and
+    # intentionally share one canonical delegation-wire module. Keep the
+    # exemption tied to that module: an identically named file elsewhere must
+    # remain subject to this validator.
+    if filepath == _DELEGATION_TERMINAL_V2_PATH:
+        return True
+
     # Exclude the COMPUTE-validator scan I/O trios (OMN-13294 / OMN-13497).
     # validation/<name>/models.py co-locates the tightly-coupled
     # ScanInput + Finding + ScanResult DTOs of one generated COMPUTE validator
@@ -200,7 +211,6 @@ def should_exclude_file(filepath: Path) -> bool:
         "model_routing_config.py",  # ModelTierModel + ModelRoutingTier + ModelDelegationConfig (hierarchy)
         "model_quality_gate.py",  # ModelQualityGateInput + ModelQualityGateResult (paired gate DTOs)
         "model_bifrost_delegation_config.py",  # 7 tightly-coupled Bifrost gateway config DTOs
-        "model_delegation_terminal_v2.py",  # Task 1.1's closed terminal states and structural evidence models
         "model_golden_chain_fixture.py",  # ModelGoldenChainProvenance + ModelGoldenChainFixture (fixture + embedded provenance); pre-existing OMN-13499 file surfaced by spdx-headers CI gate wiring (OMN-13576); split tracked separately
     }
 

--- a/src/omnibase_core/enums/enum_delegation_routing_disposition.py
+++ b/src/omnibase_core/enums/enum_delegation_routing_disposition.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Routing disposition for a concrete delegation terminal."""
+
+from __future__ import annotations
+
+from enum import StrEnum, unique
+
+
+@unique
+class EnumDelegationRoutingDisposition(StrEnum):
+    """Whether terminal processing selected a concrete backend."""
+
+    ROUTED = "routed"
+    UNROUTED = "unrouted"
+
+
+__all__: list[str] = ["EnumDelegationRoutingDisposition"]

--- a/src/omnibase_core/enums/enum_delegation_terminal_outcome.py
+++ b/src/omnibase_core/enums/enum_delegation_terminal_outcome.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Terminal outcome for a concrete delegation terminal."""
+
+from __future__ import annotations
+
+from enum import StrEnum, unique
+
+
+@unique
+class EnumDelegationTerminalOutcome(StrEnum):
+    """The terminal outcome of a delegation attempt."""
+
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+__all__: list[str] = ["EnumDelegationTerminalOutcome"]

--- a/src/omnibase_core/enums/enum_delegation_unrouted_reason.py
+++ b/src/omnibase_core/enums/enum_delegation_unrouted_reason.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Closed reasons a delegation terminal did not select a backend."""
+
+from __future__ import annotations
+
+from enum import StrEnum, unique
+
+
+@unique
+class EnumDelegationUnroutedReason(StrEnum):
+    """Why routing did not select a backend."""
+
+    NO_ELIGIBLE_BACKEND = "no_eligible_backend"
+    ROUTING_POLICY_REJECTED = "routing_policy_rejected"
+    ROUTING_CONFIGURATION_INVALID = "routing_configuration_invalid"
+
+
+__all__: list[str] = ["EnumDelegationUnroutedReason"]

--- a/src/omnibase_core/models/delegation/wire/__init__.py
+++ b/src/omnibase_core/models/delegation/wire/__init__.py
@@ -27,6 +27,18 @@ from omnibase_core.models.delegation.wire.model_delegation_result import (
     EnumQualityScoreComparison,
     ModelDelegationResult,
 )
+from omnibase_core.models.delegation.wire.model_delegation_terminal_v2 import (
+    EnumDelegationRoutingDisposition,
+    EnumDelegationTerminalOutcome,
+    EnumDelegationUnroutedReason,
+    ModelDelegationProviderFailureCause,
+    ModelDelegationQualityGateRejection,
+    ModelDelegationTerminalCompletedV2,
+    ModelDelegationTerminalFailedRoutedV2,
+    ModelDelegationTerminalFailedUnroutedV2,
+    ModelQualityBarEvaluation,
+    TypeDelegationRoutedFailureCause,
+)
 from omnibase_core.models.delegation.wire.model_delegation_wire_envelope import (
     ModelDelegationEventEnvelope,
 )
@@ -71,6 +83,9 @@ __all__: list[str] = [
     "TASK_DELEGATED_TOPIC_V1",
     "EnumBudgetAction",
     "EnumDelegationTerminalFailureCause",
+    "EnumDelegationRoutingDisposition",
+    "EnumDelegationTerminalOutcome",
+    "EnumDelegationUnroutedReason",
     "EnumQualityContractMode",
     "EnumQualityGateCategory",
     "EnumQualityScoreComparison",
@@ -89,6 +104,11 @@ __all__: list[str] = [
     "ModelDelegationFallbackPolicy",
     "ModelDelegationRequest",
     "ModelDelegationResult",
+    "ModelDelegationProviderFailureCause",
+    "ModelDelegationQualityGateRejection",
+    "ModelDelegationTerminalCompletedV2",
+    "ModelDelegationTerminalFailedRoutedV2",
+    "ModelDelegationTerminalFailedUnroutedV2",
     "ModelDelegationRoutingRule",
     "ModelDelegationShadowConfig",
     "ModelInferenceIntent",
@@ -97,10 +117,12 @@ __all__: list[str] = [
     "ModelQualityGateInput",
     "ModelQualityGateIntent",
     "ModelQualityGateResult",
+    "ModelQualityBarEvaluation",
     "ModelRoutingIntent",
     "ModelRoutingTier",
     "ModelTaskDelegatedEvent",
     "ModelTierCost",
     "ModelTierModel",
+    "TypeDelegationRoutedFailureCause",
     "validate_acceptance_criteria",
 ]

--- a/src/omnibase_core/models/delegation/wire/model_delegation_terminal_v2.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_terminal_v2.py
@@ -1,0 +1,266 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Concrete, versioned terminal delegation wire contracts.
+
+V2 replaces the nullable terminal shape with three mutually exclusive terminal
+states.  Each state is a complete immutable transport record, so consumers do
+not have to infer whether routing or quality evaluation occurred from nulls.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum, unique
+from typing import Annotated, Literal, Self
+from urllib.parse import urlparse
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from omnibase_core.enums.enum_delegation_terminal_failure_cause import (
+    EnumDelegationTerminalFailureCause,
+)
+from omnibase_core.enums.enum_quality_score_comparison import (
+    EnumQualityScoreComparison,
+)
+
+
+@unique
+class EnumDelegationRoutingDisposition(StrEnum):
+    """Whether terminal processing selected a concrete backend."""
+
+    ROUTED = "routed"
+    UNROUTED = "unrouted"
+
+
+@unique
+class EnumDelegationTerminalOutcome(StrEnum):
+    """The terminal outcome of a delegation attempt."""
+
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@unique
+class EnumDelegationUnroutedReason(StrEnum):
+    """Why routing did not select a backend."""
+
+    NO_ELIGIBLE_BACKEND = "no_eligible_backend"
+    ROUTING_POLICY_REJECTED = "routing_policy_rejected"
+    ROUTING_CONFIGURATION_INVALID = "routing_configuration_invalid"
+
+
+class ModelQualityBarEvaluation(BaseModel):
+    """A self-consistent quality score evaluation against a required bar."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    quality_score: float = Field(..., ge=0.0, le=1.0)
+    required_quality_bar: float = Field(..., ge=0.0, le=1.0)
+    score_vs_required_bar: EnumQualityScoreComparison
+
+    @model_validator(mode="after")
+    def validate_score_comparison(self) -> Self:
+        """Require the typed comparison to match the supplied score and bar."""
+        expected = (
+            EnumQualityScoreComparison.BELOW_BAR
+            if self.quality_score < self.required_quality_bar
+            else EnumQualityScoreComparison.AT_OR_ABOVE_BAR
+        )
+        if self.score_vs_required_bar is not expected:
+            msg = (
+                "score_vs_required_bar must match quality_score and "
+                "required_quality_bar"
+            )
+            raise ValueError(msg)
+        return self
+
+
+class ModelDelegationProviderFailureCause(BaseModel):
+    """A routed terminal failed because its selected provider failed."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: Literal["provider"]
+    cause: EnumDelegationTerminalFailureCause
+
+
+class ModelDelegationQualityGateRejection(BaseModel):
+    """A routed terminal failed the quality gate after provider completion."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: Literal["quality_gate_rejection"]
+    quality_bar_evaluation: ModelQualityBarEvaluation
+
+
+type TypeDelegationRoutedFailureCause = Annotated[
+    ModelDelegationProviderFailureCause | ModelDelegationQualityGateRejection,
+    Field(discriminator="kind"),
+]
+
+
+class _ModelDelegationTerminalCommonV2(BaseModel):
+    """Only the immutable fields common to every concrete V2 terminal state."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    correlation_id: UUID
+    task_type: str = Field(..., min_length=1)
+    model_used: str = Field(..., min_length=1)
+    endpoint_url: str = Field(..., min_length=1)
+    content: str
+    latency_ms: int = Field(..., ge=0)
+    prompt_tokens: int = Field(..., ge=0)
+    completion_tokens: int = Field(..., ge=0)
+    total_tokens: int = Field(..., ge=0)
+    fallback_to_claude: bool
+    failure_reason: str
+    tokens_to_compliance: int = Field(..., ge=0)
+    compliance_attempts: int = Field(..., ge=1)
+    escalation_count: int = Field(..., ge=0)
+    escalation_history: tuple[dict[str, object], ...]
+    routing_tiers_hash: str = Field(..., min_length=1)
+    escalation_config_hash: str = Field(..., min_length=1)
+    attempts_count: int = Field(..., ge=1)
+    cumulative_attempt_cost: float = Field(..., ge=0.0)
+    cumulative_input_tokens: int = Field(..., ge=0)
+    cumulative_output_tokens: int = Field(..., ge=0)
+    final_attempt_cost: float = Field(..., ge=0.0)
+    context_pack_hash: str
+    cost_tier_name: str = Field(..., min_length=1)
+    # string-id-ok: tenant_id is a named tenant identifier, not a UUID
+    tenant_id: str = Field(..., min_length=1)
+
+    @model_validator(mode="after")
+    def validate_total_tokens(self) -> Self:
+        """Keep token accounting internally consistent at the wire boundary."""
+        if self.total_tokens != self.prompt_tokens + self.completion_tokens:
+            msg = "total_tokens must equal prompt_tokens + completion_tokens"
+            raise ValueError(msg)
+        return self
+
+
+class ModelDelegationTerminalCompletedV2(_ModelDelegationTerminalCommonV2):
+    """A routed terminal that completed and passed its quality evaluation."""
+
+    routing_disposition: Literal[EnumDelegationRoutingDisposition.ROUTED]
+    terminal_outcome: Literal[EnumDelegationTerminalOutcome.COMPLETED]
+    backend_ref: str = Field(..., min_length=1)
+    pricing_manifest_version: int = Field(..., ge=1)
+    quality_passed: Literal[True]
+    quality_bar_evaluation: ModelQualityBarEvaluation
+    failed_acceptance_criteria: tuple[str, ...]
+
+    @field_validator("backend_ref")
+    @classmethod
+    def validate_backend_ref(cls, value: str) -> str:
+        """Keep a routed backend reference opaque and non-URL-shaped."""
+        parsed = urlparse(value)
+        if parsed.scheme or parsed.netloc:
+            msg = "backend_ref must be a backend identifier, not a URL or URI"
+            raise ValueError(msg)
+        return value
+
+    @field_validator("failed_acceptance_criteria")
+    @classmethod
+    def validate_failed_acceptance_criteria(
+        cls, value: tuple[str, ...]
+    ) -> tuple[str, ...]:
+        """Reject blank criteria before enforcing completed-state emptiness."""
+        if any(not criterion.strip() for criterion in value):
+            msg = "failed_acceptance_criteria entries must not be blank"
+            raise ValueError(msg)
+        return value
+
+    @model_validator(mode="after")
+    def validate_completed_quality_evidence(self) -> Self:
+        """Completed terminals cannot carry quality-gate failure evidence."""
+        if (
+            self.quality_bar_evaluation.score_vs_required_bar
+            is EnumQualityScoreComparison.BELOW_BAR
+        ):
+            msg = "quality_passed result cannot be below required_quality_bar"
+            raise ValueError(msg)
+        if self.failed_acceptance_criteria:
+            msg = "quality_passed result cannot carry failed_acceptance_criteria"
+            raise ValueError(msg)
+        return self
+
+
+class ModelDelegationTerminalFailedRoutedV2(_ModelDelegationTerminalCommonV2):
+    """A routed terminal that failed with one closed, observed cause."""
+
+    routing_disposition: Literal[EnumDelegationRoutingDisposition.ROUTED]
+    terminal_outcome: Literal[EnumDelegationTerminalOutcome.FAILED]
+    backend_ref: str = Field(..., min_length=1)
+    pricing_manifest_version: int = Field(..., ge=1)
+    quality_passed: bool
+    failed_acceptance_criteria: tuple[str, ...]
+    terminal_failure_reason: str = Field(..., min_length=1)
+    routed_failure_cause: TypeDelegationRoutedFailureCause
+
+    @field_validator("backend_ref")
+    @classmethod
+    def validate_backend_ref(cls, value: str) -> str:
+        """Keep a routed backend reference opaque and non-URL-shaped."""
+        parsed = urlparse(value)
+        if parsed.scheme or parsed.netloc:
+            msg = "backend_ref must be a backend identifier, not a URL or URI"
+            raise ValueError(msg)
+        return value
+
+    @field_validator("failed_acceptance_criteria")
+    @classmethod
+    def validate_failed_acceptance_criteria(
+        cls, value: tuple[str, ...]
+    ) -> tuple[str, ...]:
+        """Reject blank acceptance criteria in a terminal failure record."""
+        if any(not criterion.strip() for criterion in value):
+            msg = "failed_acceptance_criteria entries must not be blank"
+            raise ValueError(msg)
+        return value
+
+    @model_validator(mode="after")
+    def validate_routed_failure_quality_evidence(self) -> Self:
+        """Preserve V1 quality consistency for routed failure terminals."""
+        if self.quality_passed:
+            msg = "routed failed terminal requires quality_passed=false"
+            raise ValueError(msg)
+
+        cause = self.routed_failure_cause
+        if isinstance(cause, ModelDelegationQualityGateRejection):
+            comparison = cause.quality_bar_evaluation.score_vs_required_bar
+            if (
+                comparison is EnumQualityScoreComparison.AT_OR_ABOVE_BAR
+                and not self.failed_acceptance_criteria
+            ):
+                msg = (
+                    "quality-failed result at or above required_quality_bar must "
+                    "carry failed_acceptance_criteria"
+                )
+                raise ValueError(msg)
+        return self
+
+
+class ModelDelegationTerminalFailedUnroutedV2(_ModelDelegationTerminalCommonV2):
+    """A terminal failure where routing selected no backend at all."""
+
+    routing_disposition: Literal[EnumDelegationRoutingDisposition.UNROUTED]
+    terminal_outcome: Literal[EnumDelegationTerminalOutcome.FAILED]
+    unrouted_reason: EnumDelegationUnroutedReason
+    terminal_failure_reason: str = Field(..., min_length=1)
+
+
+__all__: list[str] = [
+    "EnumDelegationRoutingDisposition",
+    "EnumDelegationTerminalOutcome",
+    "EnumDelegationUnroutedReason",
+    "ModelDelegationProviderFailureCause",
+    "ModelDelegationQualityGateRejection",
+    "ModelDelegationTerminalCompletedV2",
+    "ModelDelegationTerminalFailedRoutedV2",
+    "ModelDelegationTerminalFailedUnroutedV2",
+    "ModelQualityBarEvaluation",
+    "TypeDelegationRoutedFailureCause",
+]

--- a/src/omnibase_core/models/delegation/wire/model_delegation_terminal_v2.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_terminal_v2.py
@@ -10,44 +10,27 @@ not have to infer whether routing or quality evaluation occurred from nulls.
 
 from __future__ import annotations
 
-from enum import StrEnum, unique
 from typing import Annotated, Literal, Self
 from urllib.parse import urlparse
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from omnibase_core.enums.enum_delegation_routing_disposition import (
+    EnumDelegationRoutingDisposition,
+)
 from omnibase_core.enums.enum_delegation_terminal_failure_cause import (
     EnumDelegationTerminalFailureCause,
+)
+from omnibase_core.enums.enum_delegation_terminal_outcome import (
+    EnumDelegationTerminalOutcome,
+)
+from omnibase_core.enums.enum_delegation_unrouted_reason import (
+    EnumDelegationUnroutedReason,
 )
 from omnibase_core.enums.enum_quality_score_comparison import (
     EnumQualityScoreComparison,
 )
-
-
-@unique
-class EnumDelegationRoutingDisposition(StrEnum):
-    """Whether terminal processing selected a concrete backend."""
-
-    ROUTED = "routed"
-    UNROUTED = "unrouted"
-
-
-@unique
-class EnumDelegationTerminalOutcome(StrEnum):
-    """The terminal outcome of a delegation attempt."""
-
-    COMPLETED = "completed"
-    FAILED = "failed"
-
-
-@unique
-class EnumDelegationUnroutedReason(StrEnum):
-    """Why routing did not select a backend."""
-
-    NO_ELIGIBLE_BACKEND = "no_eligible_backend"
-    ROUTING_POLICY_REJECTED = "routing_policy_rejected"
-    ROUTING_CONFIGURATION_INVALID = "routing_configuration_invalid"
 
 
 class ModelQualityBarEvaluation(BaseModel):
@@ -83,6 +66,7 @@ class ModelDelegationProviderFailureCause(BaseModel):
 
     kind: Literal["provider"]
     cause: EnumDelegationTerminalFailureCause
+    quality_bar_evaluation: ModelQualityBarEvaluation
 
 
 class ModelDelegationQualityGateRejection(BaseModel):
@@ -156,6 +140,11 @@ class ModelDelegationTerminalCompletedV2(_ModelDelegationTerminalCommonV2):
     @classmethod
     def validate_backend_ref(cls, value: str) -> str:
         """Keep a routed backend reference opaque and non-URL-shaped."""
+        if value != value.strip() or not value:
+            msg = (
+                "backend_ref must be nonblank and must not have surrounding whitespace"
+            )
+            raise ValueError(msg)
         parsed = urlparse(value)
         if parsed.scheme or parsed.netloc:
             msg = "backend_ref must be a backend identifier, not a URL or URI"
@@ -204,6 +193,11 @@ class ModelDelegationTerminalFailedRoutedV2(_ModelDelegationTerminalCommonV2):
     @classmethod
     def validate_backend_ref(cls, value: str) -> str:
         """Keep a routed backend reference opaque and non-URL-shaped."""
+        if value != value.strip() or not value:
+            msg = (
+                "backend_ref must be nonblank and must not have surrounding whitespace"
+            )
+            raise ValueError(msg)
         parsed = urlparse(value)
         if parsed.scheme or parsed.netloc:
             msg = "backend_ref must be a backend identifier, not a URL or URI"
@@ -228,18 +222,18 @@ class ModelDelegationTerminalFailedRoutedV2(_ModelDelegationTerminalCommonV2):
             msg = "routed failed terminal requires quality_passed=false"
             raise ValueError(msg)
 
-        cause = self.routed_failure_cause
-        if isinstance(cause, ModelDelegationQualityGateRejection):
-            comparison = cause.quality_bar_evaluation.score_vs_required_bar
-            if (
-                comparison is EnumQualityScoreComparison.AT_OR_ABOVE_BAR
-                and not self.failed_acceptance_criteria
-            ):
-                msg = (
-                    "quality-failed result at or above required_quality_bar must "
-                    "carry failed_acceptance_criteria"
-                )
-                raise ValueError(msg)
+        comparison = (
+            self.routed_failure_cause.quality_bar_evaluation.score_vs_required_bar
+        )
+        if (
+            comparison is EnumQualityScoreComparison.AT_OR_ABOVE_BAR
+            and not self.failed_acceptance_criteria
+        ):
+            msg = (
+                "quality-failed result at or above required_quality_bar must "
+                "carry failed_acceptance_criteria"
+            )
+            raise ValueError(msg)
         return self
 
 

--- a/src/omnibase_core/models/delegation/wire/model_delegation_terminal_v2.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_terminal_v2.py
@@ -66,7 +66,6 @@ class ModelDelegationProviderFailureCause(BaseModel):
 
     kind: Literal["provider"]
     cause: EnumDelegationTerminalFailureCause
-    quality_bar_evaluation: ModelQualityBarEvaluation
 
 
 class ModelDelegationQualityGateRejection(BaseModel):
@@ -75,7 +74,6 @@ class ModelDelegationQualityGateRejection(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     kind: Literal["quality_gate_rejection"]
-    quality_bar_evaluation: ModelQualityBarEvaluation
 
 
 type TypeDelegationRoutedFailureCause = Annotated[
@@ -185,6 +183,7 @@ class ModelDelegationTerminalFailedRoutedV2(_ModelDelegationTerminalCommonV2):
     backend_ref: str = Field(..., min_length=1)
     pricing_manifest_version: int = Field(..., ge=1)
     quality_passed: bool
+    quality_bar_evaluation: ModelQualityBarEvaluation
     failed_acceptance_criteria: tuple[str, ...]
     terminal_failure_reason: str = Field(..., min_length=1)
     routed_failure_cause: TypeDelegationRoutedFailureCause
@@ -222,9 +221,13 @@ class ModelDelegationTerminalFailedRoutedV2(_ModelDelegationTerminalCommonV2):
             msg = "routed failed terminal requires quality_passed=false"
             raise ValueError(msg)
 
-        comparison = (
-            self.routed_failure_cause.quality_bar_evaluation.score_vs_required_bar
-        )
+        comparison = self.quality_bar_evaluation.score_vs_required_bar
+        if (
+            self.routed_failure_cause.kind == "quality_gate_rejection"
+            and comparison is not EnumQualityScoreComparison.BELOW_BAR
+        ):
+            msg = "quality_gate_rejection requires below required_quality_bar"
+            raise ValueError(msg)
         if (
             comparison is EnumQualityScoreComparison.AT_OR_ABOVE_BAR
             and not self.failed_acceptance_criteria

--- a/tests/unit/models/delegation/wire/test_model_delegation_terminal_v2.py
+++ b/tests/unit/models/delegation/wire/test_model_delegation_terminal_v2.py
@@ -1,0 +1,266 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Contract tests for the concrete delegation terminal v2 wire models."""
+
+from __future__ import annotations
+
+from typing import Any, get_type_hints
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.models.delegation.wire import (
+    EnumDelegationRoutingDisposition,
+    EnumDelegationTerminalOutcome,
+    EnumDelegationUnroutedReason,
+    EnumQualityScoreComparison,
+    ModelDelegationTerminalCompletedV2,
+    ModelDelegationTerminalFailedRoutedV2,
+    ModelDelegationTerminalFailedUnroutedV2,
+    ModelQualityBarEvaluation,
+)
+from omnibase_core.models.delegation.wire.model_delegation_terminal_v2 import (
+    _ModelDelegationTerminalCommonV2,
+)
+
+
+def _common_payload() -> dict[str, Any]:
+    return {
+        "correlation_id": str(uuid4()),
+        "task_type": "code_review",
+        "model_used": "qwen3-coder",
+        "endpoint_url": "https://diagnostic.example/v1",
+        "content": "review complete",
+        "latency_ms": 42,
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+        "fallback_to_claude": False,
+        "failure_reason": "",
+        "tokens_to_compliance": 30,
+        "compliance_attempts": 1,
+        "escalation_count": 0,
+        "escalation_history": [],
+        "routing_tiers_hash": "sha256:routing",
+        "escalation_config_hash": "sha256:escalation",
+        "attempts_count": 1,
+        "cumulative_attempt_cost": 0.01,
+        "cumulative_input_tokens": 10,
+        "cumulative_output_tokens": 20,
+        "final_attempt_cost": 0.01,
+        "context_pack_hash": "",
+        "cost_tier_name": "local",
+        "tenant_id": "tenant-a",
+    }
+
+
+def _quality_bar_evaluation() -> dict[str, Any]:
+    return {
+        "quality_score": 0.95,
+        "required_quality_bar": 0.9,
+        "score_vs_required_bar": EnumQualityScoreComparison.AT_OR_ABOVE_BAR.value,
+    }
+
+
+def _completed_payload() -> dict[str, Any]:
+    return {
+        **_common_payload(),
+        "routing_disposition": EnumDelegationRoutingDisposition.ROUTED.value,
+        "terminal_outcome": EnumDelegationTerminalOutcome.COMPLETED.value,
+        "backend_ref": "local-coder",
+        "pricing_manifest_version": 7,
+        "quality_passed": True,
+        "quality_bar_evaluation": _quality_bar_evaluation(),
+        "failed_acceptance_criteria": (),
+    }
+
+
+def _routed_failure_payload() -> dict[str, Any]:
+    return {
+        **_common_payload(),
+        "routing_disposition": EnumDelegationRoutingDisposition.ROUTED.value,
+        "terminal_outcome": EnumDelegationTerminalOutcome.FAILED.value,
+        "backend_ref": "local-coder",
+        "pricing_manifest_version": 7,
+        "quality_passed": False,
+        "failed_acceptance_criteria": ("response_non_empty",),
+        "terminal_failure_reason": "provider refused the request",
+        "routed_failure_cause": {
+            "kind": "provider",
+            "cause": "provider_error",
+        },
+    }
+
+
+def _unrouted_payload() -> dict[str, Any]:
+    return {
+        **_common_payload(),
+        "routing_disposition": EnumDelegationRoutingDisposition.UNROUTED.value,
+        "terminal_outcome": EnumDelegationTerminalOutcome.FAILED.value,
+        "unrouted_reason": EnumDelegationUnroutedReason.NO_ELIGIBLE_BACKEND.value,
+        "terminal_failure_reason": "no backend matched the route",
+    }
+
+
+@pytest.mark.unit
+def test_completed_terminal_round_trips() -> None:
+    terminal = ModelDelegationTerminalCompletedV2.model_validate(_completed_payload())
+
+    restored = ModelDelegationTerminalCompletedV2.model_validate_json(
+        terminal.model_dump_json()
+    )
+
+    assert restored == terminal
+    assert restored.routing_disposition is EnumDelegationRoutingDisposition.ROUTED
+    assert restored.terminal_outcome is EnumDelegationTerminalOutcome.COMPLETED
+
+
+@pytest.mark.unit
+def test_every_concrete_field_is_required_without_defaults() -> None:
+    for model in (
+        ModelDelegationTerminalCompletedV2,
+        ModelDelegationTerminalFailedRoutedV2,
+        ModelDelegationTerminalFailedUnroutedV2,
+    ):
+        assert all(field.is_required() for field in model.model_fields.values())
+
+
+@pytest.mark.unit
+def test_shared_base_has_no_nullable_field() -> None:
+    annotations = get_type_hints(_ModelDelegationTerminalCommonV2)
+
+    assert annotations
+    assert all("NoneType" not in str(annotation) for annotation in annotations.values())
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "backend_ref",
+    ["https://backend.example/v1", "//backend.example", "mailto:ops@example.com"],
+)
+def test_backend_ref_rejects_url_or_uri_shape(backend_ref: str) -> None:
+    payload = _completed_payload()
+    payload["backend_ref"] = backend_ref
+
+    with pytest.raises(ValidationError, match="not a URL or URI"):
+        ModelDelegationTerminalCompletedV2.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_unrouted_terminal_rejects_routed_or_quality_fields() -> None:
+    payload = _unrouted_payload()
+    payload["backend_ref"] = "local-coder"
+    payload["quality_passed"] = False
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ModelDelegationTerminalFailedUnroutedV2.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_routed_failure_requires_exactly_one_closed_failure_cause() -> None:
+    payload = _routed_failure_payload()
+    del payload["routed_failure_cause"]
+
+    with pytest.raises(ValidationError, match="routed_failure_cause"):
+        ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_quality_gate_rejection_cannot_claim_quality_passed() -> None:
+    payload = _routed_failure_payload()
+    payload["quality_passed"] = True
+    payload["routed_failure_cause"] = {
+        "kind": "quality_gate_rejection",
+        "quality_bar_evaluation": _quality_bar_evaluation(),
+    }
+
+    with pytest.raises(ValidationError, match="quality_passed=false"):
+        ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_quality_gate_rejection_is_a_valid_routed_failure_cause() -> None:
+    payload = _routed_failure_payload()
+    payload["routed_failure_cause"] = {
+        "kind": "quality_gate_rejection",
+        "quality_bar_evaluation": _quality_bar_evaluation(),
+    }
+
+    terminal = ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
+
+    assert terminal.routed_failure_cause.kind == "quality_gate_rejection"
+
+
+@pytest.mark.unit
+def test_quality_bar_evaluation_rejects_contradictory_comparison() -> None:
+    payload = _quality_bar_evaluation()
+    payload["score_vs_required_bar"] = EnumQualityScoreComparison.BELOW_BAR.value
+
+    with pytest.raises(ValidationError, match="must match quality_score"):
+        ModelQualityBarEvaluation.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("payload_mutation", "match"),
+    [
+        (
+            lambda payload: payload.update(
+                quality_bar_evaluation={
+                    "quality_score": 0.89,
+                    "required_quality_bar": 0.9,
+                    "score_vs_required_bar": "below_bar",
+                }
+            ),
+            "cannot be below required_quality_bar",
+        ),
+        (
+            lambda payload: payload.update(
+                failed_acceptance_criteria=("response_non_empty",)
+            ),
+            "cannot carry failed_acceptance_criteria",
+        ),
+    ],
+)
+def test_completed_quality_invariants_are_preserved(
+    payload_mutation: Any, match: str
+) -> None:
+    payload = _completed_payload()
+    payload_mutation(payload)
+
+    with pytest.raises(ValidationError, match=match):
+        ModelDelegationTerminalCompletedV2.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_quality_failure_above_bar_requires_failed_criteria() -> None:
+    payload = _routed_failure_payload()
+    payload["failed_acceptance_criteria"] = ()
+    payload["routed_failure_cause"] = {
+        "kind": "quality_gate_rejection",
+        "quality_bar_evaluation": _quality_bar_evaluation(),
+    }
+
+    with pytest.raises(ValidationError, match="must carry failed_acceptance_criteria"):
+        ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("payload_mutation", "match"),
+    [
+        (lambda payload: payload.update(total_tokens=31), "total_tokens must equal"),
+        (
+            lambda payload: payload.update(failed_acceptance_criteria=(" ",)),
+            "must not be blank",
+        ),
+    ],
+)
+def test_v1_invariants_are_preserved(payload_mutation: Any, match: str) -> None:
+    payload = _routed_failure_payload()
+    payload_mutation(payload)
+
+    with pytest.raises(ValidationError, match=match):
+        ModelDelegationTerminalFailedRoutedV2.model_validate(payload)

--- a/tests/unit/models/delegation/wire/test_model_delegation_terminal_v2.py
+++ b/tests/unit/models/delegation/wire/test_model_delegation_terminal_v2.py
@@ -64,6 +64,14 @@ def _quality_bar_evaluation() -> dict[str, Any]:
     }
 
 
+def _below_quality_bar_evaluation() -> dict[str, Any]:
+    return {
+        "quality_score": 0.89,
+        "required_quality_bar": 0.9,
+        "score_vs_required_bar": EnumQualityScoreComparison.BELOW_BAR.value,
+    }
+
+
 def _completed_payload() -> dict[str, Any]:
     return {
         **_common_payload(),
@@ -85,12 +93,12 @@ def _routed_failure_payload() -> dict[str, Any]:
         "backend_ref": "local-coder",
         "pricing_manifest_version": 7,
         "quality_passed": False,
+        "quality_bar_evaluation": _quality_bar_evaluation(),
         "failed_acceptance_criteria": ("response_non_empty",),
         "terminal_failure_reason": "provider refused the request",
         "routed_failure_cause": {
             "kind": "provider",
             "cause": "provider_error",
-            "quality_bar_evaluation": _quality_bar_evaluation(),
         },
     }
 
@@ -175,9 +183,9 @@ def test_routed_failure_requires_exactly_one_closed_failure_cause() -> None:
 
 
 @pytest.mark.unit
-def test_provider_failure_requires_its_quality_bar_evaluation() -> None:
+def test_routed_failure_requires_its_top_level_quality_bar_evaluation() -> None:
     payload = _routed_failure_payload()
-    del payload["routed_failure_cause"]["quality_bar_evaluation"]
+    del payload["quality_bar_evaluation"]
 
     with pytest.raises(ValidationError, match="quality_bar_evaluation"):
         ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
@@ -189,9 +197,26 @@ def test_provider_failure_carries_one_quality_bar_evaluation() -> None:
         _routed_failure_payload()
     )
 
-    assert (
-        terminal.routed_failure_cause.quality_bar_evaluation.required_quality_bar == 0.9
-    )
+    assert terminal.quality_bar_evaluation.required_quality_bar == 0.9
+    assert terminal.routed_failure_cause.kind == "provider"
+
+
+@pytest.mark.unit
+def test_provider_failure_requires_a_closed_enum_cause() -> None:
+    payload = _routed_failure_payload()
+    del payload["routed_failure_cause"]["cause"]
+
+    with pytest.raises(ValidationError, match="cause"):
+        ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_routed_failure_rejects_an_unknown_cause_discriminator() -> None:
+    payload = _routed_failure_payload()
+    payload["routed_failure_cause"] = {"kind": "unknown"}
+
+    with pytest.raises(ValidationError, match="tag"):
+        ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
 
 
 @pytest.mark.unit
@@ -200,8 +225,8 @@ def test_quality_gate_rejection_cannot_claim_quality_passed() -> None:
     payload["quality_passed"] = True
     payload["routed_failure_cause"] = {
         "kind": "quality_gate_rejection",
-        "quality_bar_evaluation": _quality_bar_evaluation(),
     }
+    payload["quality_bar_evaluation"] = _below_quality_bar_evaluation()
 
     with pytest.raises(ValidationError, match="quality_passed=false"):
         ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
@@ -212,12 +237,90 @@ def test_quality_gate_rejection_is_a_valid_routed_failure_cause() -> None:
     payload = _routed_failure_payload()
     payload["routed_failure_cause"] = {
         "kind": "quality_gate_rejection",
-        "quality_bar_evaluation": _quality_bar_evaluation(),
     }
+    payload["quality_bar_evaluation"] = _below_quality_bar_evaluation()
 
     terminal = ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
 
     assert terminal.routed_failure_cause.kind == "quality_gate_rejection"
+    assert (
+        terminal.quality_bar_evaluation.score_vs_required_bar
+        is EnumQualityScoreComparison.BELOW_BAR
+    )
+
+
+@pytest.mark.unit
+def test_quality_gate_rejection_rejects_non_failing_quality_evidence() -> None:
+    payload = _routed_failure_payload()
+    payload["routed_failure_cause"] = {"kind": "quality_gate_rejection"}
+
+    with pytest.raises(ValidationError, match="quality_gate_rejection requires"):
+        ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("cause", "extra_field"),
+    [
+        (
+            {"kind": "provider", "cause": "provider_error"},
+            "quality_bar_evaluation",
+        ),
+        ({"kind": "quality_gate_rejection"}, "quality_bar_evaluation"),
+    ],
+)
+def test_routed_failure_cause_rejects_nested_duplicate_quality_evaluation(
+    cause: dict[str, Any], extra_field: str
+) -> None:
+    payload = _routed_failure_payload()
+    cause[extra_field] = _below_quality_bar_evaluation()
+    payload["routed_failure_cause"] = cause
+    if cause["kind"] == "quality_gate_rejection":
+        payload["quality_bar_evaluation"] = _below_quality_bar_evaluation()
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_quality_gate_rejection_rejects_a_provider_cause_field() -> None:
+    payload = _routed_failure_payload()
+    payload["routed_failure_cause"] = {
+        "kind": "quality_gate_rejection",
+        "cause": "provider_error",
+    }
+    payload["quality_bar_evaluation"] = _below_quality_bar_evaluation()
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "payload",
+    [
+        _routed_failure_payload(),
+        {
+            **_routed_failure_payload(),
+            "routed_failure_cause": {"kind": "quality_gate_rejection"},
+            "quality_bar_evaluation": _below_quality_bar_evaluation(),
+        },
+    ],
+)
+def test_routed_failure_round_trip_serializes_quality_evaluation_once(
+    payload: dict[str, Any],
+) -> None:
+    terminal = ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
+
+    serialized = terminal.model_dump(mode="json")
+    restored = ModelDelegationTerminalFailedRoutedV2.model_validate_json(
+        terminal.model_dump_json()
+    )
+
+    assert restored == terminal
+    assert serialized["quality_bar_evaluation"] == payload["quality_bar_evaluation"]
+    assert "quality_bar_evaluation" not in serialized["routed_failure_cause"]
+    assert terminal.model_dump_json().count('"quality_bar_evaluation"') == 1
 
 
 @pytest.mark.unit
@@ -262,13 +365,9 @@ def test_completed_quality_invariants_are_preserved(
 
 
 @pytest.mark.unit
-def test_quality_failure_above_bar_requires_failed_criteria() -> None:
+def test_provider_failure_above_bar_requires_failed_criteria() -> None:
     payload = _routed_failure_payload()
     payload["failed_acceptance_criteria"] = ()
-    payload["routed_failure_cause"] = {
-        "kind": "quality_gate_rejection",
-        "quality_bar_evaluation": _quality_bar_evaluation(),
-    }
 
     with pytest.raises(ValidationError, match="must carry failed_acceptance_criteria"):
         ModelDelegationTerminalFailedRoutedV2.model_validate(payload)

--- a/tests/unit/models/delegation/wire/test_model_delegation_terminal_v2.py
+++ b/tests/unit/models/delegation/wire/test_model_delegation_terminal_v2.py
@@ -90,6 +90,7 @@ def _routed_failure_payload() -> dict[str, Any]:
         "routed_failure_cause": {
             "kind": "provider",
             "cause": "provider_error",
+            "quality_bar_evaluation": _quality_bar_evaluation(),
         },
     }
 
@@ -138,13 +139,19 @@ def test_shared_base_has_no_nullable_field() -> None:
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "backend_ref",
-    ["https://backend.example/v1", "//backend.example", "mailto:ops@example.com"],
+    [
+        "https://backend.example/v1",
+        "//backend.example",
+        "mailto:ops@example.com",
+        " ",
+        " local-coder ",
+    ],
 )
 def test_backend_ref_rejects_url_or_uri_shape(backend_ref: str) -> None:
     payload = _completed_payload()
     payload["backend_ref"] = backend_ref
 
-    with pytest.raises(ValidationError, match="not a URL or URI"):
+    with pytest.raises(ValidationError, match=r"not a URL or URI|nonblank"):
         ModelDelegationTerminalCompletedV2.model_validate(payload)
 
 
@@ -165,6 +172,26 @@ def test_routed_failure_requires_exactly_one_closed_failure_cause() -> None:
 
     with pytest.raises(ValidationError, match="routed_failure_cause"):
         ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_provider_failure_requires_its_quality_bar_evaluation() -> None:
+    payload = _routed_failure_payload()
+    del payload["routed_failure_cause"]["quality_bar_evaluation"]
+
+    with pytest.raises(ValidationError, match="quality_bar_evaluation"):
+        ModelDelegationTerminalFailedRoutedV2.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_provider_failure_carries_one_quality_bar_evaluation() -> None:
+    terminal = ModelDelegationTerminalFailedRoutedV2.model_validate(
+        _routed_failure_payload()
+    )
+
+    assert (
+        terminal.routed_failure_cause.quality_bar_evaluation.required_quality_bar == 0.9
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/models/delegation/wire/test_model_delegation_terminal_v2.py
+++ b/tests/unit/models/delegation/wire/test_model_delegation_terminal_v2.py
@@ -127,6 +127,21 @@ def test_completed_terminal_round_trips() -> None:
 
 
 @pytest.mark.unit
+def test_unrouted_terminal_round_trips() -> None:
+    terminal = ModelDelegationTerminalFailedUnroutedV2.model_validate(
+        _unrouted_payload()
+    )
+
+    restored = ModelDelegationTerminalFailedUnroutedV2.model_validate_json(
+        terminal.model_dump_json()
+    )
+
+    assert restored == terminal
+    assert restored.routing_disposition is EnumDelegationRoutingDisposition.UNROUTED
+    assert restored.terminal_outcome is EnumDelegationTerminalOutcome.FAILED
+
+
+@pytest.mark.unit
 def test_every_concrete_field_is_required_without_defaults() -> None:
     for model in (
         ModelDelegationTerminalCompletedV2,
@@ -151,6 +166,7 @@ def test_shared_base_has_no_nullable_field() -> None:
         "https://backend.example/v1",
         "//backend.example",
         "mailto:ops@example.com",
+        "backend:local-coder",
         " ",
         " local-coder ",
     ],
@@ -168,6 +184,15 @@ def test_unrouted_terminal_rejects_routed_or_quality_fields() -> None:
     payload = _unrouted_payload()
     payload["backend_ref"] = "local-coder"
     payload["quality_passed"] = False
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ModelDelegationTerminalFailedUnroutedV2.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_unrouted_terminal_rejects_quality_field_without_routed_field() -> None:
+    payload = _unrouted_payload()
+    payload["quality_bar_evaluation"] = _below_quality_bar_evaluation()
 
     with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         ModelDelegationTerminalFailedUnroutedV2.model_validate(payload)

--- a/tests/validation/test_validate_single_class_per_file.py
+++ b/tests/validation/test_validate_single_class_per_file.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Regression tests for the single-class-per-file validator."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+VALIDATOR_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "validation"
+    / "validate-single-class-per-file.py"
+)
+
+
+def _load_validator_module() -> object:
+    spec = importlib.util.spec_from_file_location(
+        "validate_single_class_per_file", VALIDATOR_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_delegation_terminal_v2_exception_is_scoped_to_its_canonical_path(
+    tmp_path: Path,
+) -> None:
+    """An identically named file elsewhere must remain subject to the rule."""
+    validator = _load_validator_module()
+    canonical_path = Path(
+        "src/omnibase_core/models/delegation/wire/model_delegation_terminal_v2.py"
+    )
+    shadow_path = (
+        tmp_path.parent
+        / "single_class_scope_shadow"
+        / "model_delegation_terminal_v2.py"
+    )
+    shadow_path.parent.mkdir()
+    shadow_path.write_text("class First:\n    pass\n\nclass Second:\n    pass\n")
+
+    assert validator.should_exclude_file(canonical_path)
+    assert not validator.should_exclude_file(shadow_path)
+    assert not validator.check_file(shadow_path)["valid"]

--- a/tests/validation/test_validate_single_class_per_file.py
+++ b/tests/validation/test_validate_single_class_per_file.py
@@ -35,6 +35,15 @@ def test_delegation_terminal_v2_exception_is_scoped_to_its_canonical_path(
     canonical_path = Path(
         "src/omnibase_core/models/delegation/wire/model_delegation_terminal_v2.py"
     )
+    canonical_absolute_path = (
+        VALIDATOR_PATH.parents[2]
+        / "src"
+        / "omnibase_core"
+        / "models"
+        / "delegation"
+        / "wire"
+        / "model_delegation_terminal_v2.py"
+    )
     shadow_path = (
         tmp_path.parent
         / "single_class_scope_shadow"
@@ -44,5 +53,6 @@ def test_delegation_terminal_v2_exception_is_scoped_to_its_canonical_path(
     shadow_path.write_text("class First:\n    pass\n\nclass Second:\n    pass\n")
 
     assert validator.should_exclude_file(canonical_path)
+    assert validator.should_exclude_file(canonical_absolute_path)
     assert not validator.should_exclude_file(shadow_path)
     assert not validator.check_file(shadow_path)["valid"]

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.3"
+version = "0.47.6"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

- adds concrete routed-completed, routed-failed, and unrouted-failed delegation terminal v2 wire models
- models the closed routing/outcome/failure-cause contracts and re-exports their typed surface
- scopes the single-class validator exemption to this intentional terminal family
- adds round-trip and rejection coverage for the terminal-v2 boundary cases

## Verification

- `uv run pytest -n 0 tests/unit/models/delegation/wire/test_model_delegation_terminal_v2.py tests/validation/test_validate_single_class_per_file.py -q` — 32 passed
- `uv run mypy src/omnibase_core/models/delegation/wire/model_delegation_terminal_v2.py --strict` — passed
- `pre-commit run --all-files` — passed
- governed pre-push remote replay — 44,864 non-integration tests passed on exact commit `724aa6657c96a4e1bc24fa9170aa6154c739ac6e`

Evidence-Ticket: OMN-17841
Evidence-Source: OCC#8348
