### PR TITLE
fix(OMN-17980): a def-B single-emit terminal is this run's own, not a foreign one (0.47.3 regression; cuts 0.47.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- onex-allow-file-todo-marker reason="historical changelog entries include literal TODO marker tokens" -->
 
+## v0.47.4 (2026-09-06)
+
+### Changes
+- fix a def-B single-emit terminal no longer reads as a foreign run's terminal (#PRNUM). v0.47.3 (#1645) armed the terminal correlation predicate in host mode as well as client mode, and the predicate required the terminal to declare this run's correlation id and nothing else. The canonical def-B terminal is the handler's bare domain model, published verbatim by `LocalRuntimeBusAdapter` on the single-emit path (`result.model_dump_json()`) — `handle(request: ModelX) -> ModelY` has no envelope and therefore no field in which to carry a correlation id. It declared nothing, so every def-B ORCHESTRATOR run through `RuntimeLocal._run_event_driven` recorded its own terminal as foreign, discarded it, and timed out. The predicate now judges a terminal that declares NO correlation on its shape: a bare domain payload is this run's own; an ENVELOPE that names nobody stays refused; and once anything is declared, every declared id must still be this run's, so the isolation boundary #1645 added is unchanged. Core's own event-driven coverage stamped a correlation id into a hand-built dict, which is why this repo stayed green while every downstream def-B node broke.
+
 ## v0.47.3 (2026-09-05)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.3"
+version = "0.47.4"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -365,8 +365,21 @@ class RuntimeLocal:
 
         Returns ``True`` unconditionally when no correlation predicate is armed
         — i.e. when no correlation id reached the wire, so there is nothing to
-        compare against. That is the only remaining unfiltered case; it is NOT
-        a host/client distinction (OMN-15660).
+        compare against. That is NOT a host/client distinction (OMN-15660).
+
+        A terminal that declares NO correlation id at either level is judged on
+        its SHAPE, not treated as unattributable outright (OMN-17980). The
+        canonical def-B terminal is the handler's bare domain model, published
+        verbatim by ``LocalRuntimeBusAdapter`` on the single-emit path
+        (``result.model_dump_json()``): ``handle(request: ModelX) -> ModelY``
+        has no envelope and therefore no field in which to carry a correlation
+        id. Refusing that shape does not isolate the run, it makes every def-B
+        ORCHESTRATOR unrunnable — the whole event-driven path records
+        ``(terminal) 1`` / ``(terminal:foreign) 1`` and then times out.
+
+        An ENVELOPE that names nobody is a different fact: it has the field and
+        left it empty, so it stays refused (OMN-17304 AC4). Once anything IS
+        declared, shape is irrelevant and every declared id must be this run's.
         """
         expected = self._expected_correlation_id
         if expected is None:
@@ -380,6 +393,8 @@ class RuntimeLocal:
             raw = container.get("correlation_id")
             if isinstance(raw, str) and raw:
                 declared.add(raw)
+        if not declared:
+            return not self._is_envelope_shaped(payload)
         return declared == {wanted}
 
     # ONEX_EXCLUDE: dict_str_any — event bus payload

--- a/tests/unit/runtime/test_runtime_local.py
+++ b/tests/unit/runtime/test_runtime_local.py
@@ -1337,3 +1337,145 @@ async def test_no_terminal_event_no_handler_spec_still_writes_state(
     assert workflow_data["run_id"] != str(stale_run_id)
     assert workflow_data["result"] == EnumWorkflowResult.FAILED.value
     assert "handler_result" not in workflow_data
+
+
+# ---------------------------------------------------------------------------
+# OMN-17980 regression: a canonical def-B single-emit terminal declares NO
+# correlation id at any level, and the OMN-15660 correlation predicate refused
+# it as foreign — so every def-B ORCHESTRATOR run through the event-driven
+# runtime timed out on 0.47.3.
+# ---------------------------------------------------------------------------
+
+_BARE_TERMINAL_TOPIC = "onex.evt.omn17962.completed.v1"
+
+
+class _ModelBareDomainTerminal(BaseModel):
+    """A canonical def-B response model: domain fields only, no run identity.
+
+    This is the shape ``LocalRuntimeBusAdapter`` publishes verbatim on the
+    single-emit path (``result.model_dump_json()``), and it is the shape every
+    ``NodeCompute``/``NodeOrchestrator`` def-B handler returns —
+    ``handle(request: ModelX) -> ModelY`` carries no envelope and therefore no
+    place to put a correlation id.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: str = Field(default="success")
+    artifact_written: bool = Field(default=True)
+
+
+class _BareDomainTerminalHandler:
+    """Returns the bare domain model — the def-B contract, no envelope."""
+
+    async def handle(
+        self, payload: _ModelRequiresOnlyCorrelationId
+    ) -> _ModelBareDomainTerminal:
+        return _ModelBareDomainTerminal()
+
+
+def _write_bare_terminal_contract(target: Path) -> None:
+    contract: dict[str, Any] = {
+        "workflow_id": "omn-17962-bare-domain-terminal",
+        "terminal_event": _BARE_TERMINAL_TOPIC,
+        "event_bus": {
+            "subscribe_topics": ["onex.cmd.omn17962.start.v1"],
+            "publish_topics": [_BARE_TERMINAL_TOPIC],
+        },
+        "handler_routing": {
+            "routing_strategy": "operation_match",
+            "handlers": [
+                {
+                    "operation": "start",
+                    "handler": {
+                        "module": _THIS_MODULE_FOR_IDENTITY,
+                        "name": "_BareDomainTerminalHandler",
+                    },
+                    "event_model": {
+                        "module": _THIS_MODULE_FOR_IDENTITY,
+                        "name": "_ModelRequiresOnlyCorrelationId",
+                    },
+                }
+            ],
+        },
+    }
+    target.write_text(yaml.safe_dump(contract), encoding="utf-8")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bare_domain_terminal_without_correlation_is_this_run(
+    tmp_path: Path,
+) -> None:
+    """A def-B single-emit terminal completes the run (OMN-17980).
+
+    OMN-15660 armed ``_expected_correlation_id`` in host mode, and
+    ``_terminal_correlation_matches`` demanded ``declared == {wanted}``. A bare
+    domain payload declares nothing, so ``set() != {wanted}`` classified the
+    run's OWN terminal as foreign: ``(terminal) 1`` / ``(terminal:foreign) 1``,
+    then TIMEOUT. The existing event-driven coverage
+    (``test_event_driven_runtime_waits_for_declared_terminal_event``) stamps
+    ``correlation_id`` into a hand-built dict, which is why core stayed green
+    while every def-B consumer node broke.
+
+    This asserts the run COMPLETES and the terminal payload is the handler's
+    own — never that an unattributable ENVELOPE is accepted, which is the
+    OMN-17304 AC4 refusal pinned by the counter-assertion below.
+    """
+    contract_path = tmp_path / "contract.yaml"
+    state_root = tmp_path / "state"
+    _write_bare_terminal_contract(contract_path)
+
+    runtime = RuntimeLocal(
+        workflow_path=contract_path,
+        state_root=state_root,
+        timeout=10,
+    )
+
+    result = await runtime.run_async()
+
+    assert result == EnumWorkflowResult.COMPLETED, (
+        "a def-B single-emit terminal is this run's own terminal; refusing it "
+        f"as foreign makes every def-B node unrunnable (got {result})"
+    )
+    workflow_data = json.loads((state_root / "workflow_result.json").read_text())
+    assert workflow_data["terminal_payload"]["artifact_written"] is True
+    assert workflow_data["handler_result"]["status"] == "success"
+
+
+@pytest.mark.unit
+def test_bare_terminal_with_foreign_correlation_is_still_refused() -> None:
+    """Counter-assertion: a bare payload that NAMES another run stays foreign.
+
+    The OMN-17980 fix widens the predicate only for payloads that declare no
+    correlation at all. A bare domain payload that carries a correlation id is
+    fully attributable, so the OMN-15660 isolation boundary is unchanged there.
+    """
+    runtime = RuntimeLocal(workflow_path=Path("unused.yaml"), timeout=1)
+    runtime._expected_correlation_id = _uuid_module.uuid4()
+
+    assert runtime._terminal_correlation_matches(
+        {"status": "success", "correlation_id": str(runtime._expected_correlation_id)}
+    )
+    assert not runtime._terminal_correlation_matches(
+        {"status": "success", "correlation_id": str(_uuid_module.uuid4())}
+    )
+
+
+@pytest.mark.unit
+def test_envelope_terminal_naming_nobody_is_still_refused() -> None:
+    """Counter-assertion: OMN-17304 AC4 survives the OMN-17980 widening.
+
+    An envelope-shaped terminal has a declared place for a correlation id at
+    both levels. One that names nobody is unattributable rather than
+    shapeless, and is still discarded.
+    """
+    runtime = RuntimeLocal(workflow_path=Path("unused.yaml"), timeout=1)
+    runtime._expected_correlation_id = _uuid_module.uuid4()
+
+    assert not runtime._terminal_correlation_matches(
+        {
+            "envelope_id": str(_uuid_module.uuid4()),
+            "payload": {"status": "success"},
+        }
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.3"
+version = "0.47.4"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Fixes OMN-17980. Release-blocking regression in omnibase_core 0.47.2 -> 0.47.3.

## Symptom

Every def-B ORCHESTRATOR driven through `RuntimeLocal._run_event_driven` times out. Measured on omnimarket `tests/test_integration_sweep_dispatch_path.py` (4 rows), with the worktree venv on core 0.47.3:

```
AssertionError: dispatch path did not complete: EnumWorkflowResult.TIMEOUT
WARNING  RuntimeLocal: timeout after 30s (correlation_id=c9c0eed8-...)
WARNING    handlers wired: ['HandlerIntegrationSweepOrchestrator']
WARNING    events on '(terminal)': 1
WARNING    events on '(terminal:foreign)': 1
```

Positive control: the same checkout on core 0.47.2 passes all 4. Three-way isolation had already narrowed it to core (infra 0.38.16 + core 0.47.2 passes; either infra + core 0.47.3 fails), so this PR only had to find which core change.

## Cause

`1bd884e5` (#1645) removed the host/client gate on the terminal correlation predicate:

```python
-        if not self.host_handlers:
-            self._expected_correlation_id = correlation_id
+        self._expected_correlation_id = correlation_id
```

`_terminal_correlation_matches` then requires `declared == {wanted}`: every correlation id the terminal declares must be this run's, **and it must declare at least one**.

The canonical def-B terminal declares none. `LocalRuntimeBusAdapter` publishes the single-emit result verbatim (`result.model_dump_json()`), and the def-B signature `handle(request: ModelX) -> ModelY` carries no envelope, so there is no field a correlation id could live in. Read live off the omnimarket node:

```
TERMINAL PAYLOAD KEYS: ['artifact_path', 'artifact_written', 'details', 'status', 'surfaces', 'ticket_count']
  top corr: None
  expected: 9367d866-798e-4d69-90e8-50803c0f5228
```

`set() != {wanted}` -> the run's own terminal is recorded as foreign and discarded -> the wait never satisfies -> TIMEOUT.

## Deliberate or accidental

Accidental. `_classify_terminal`, added in the same commit, already carves this exact shape out on the status axis — its docstring reads "A bare domain terminal with no status (e.g. `{"kind": "completed"}`) is the long-standing offline shape and keeps rule 3." The same commit recognises the shape when reading status and refuses it when reading correlation. The predicate's stated reasoning, "an envelope that names nobody is unattributable", is about envelopes; it was carried onto a shape that has no field to fill.

Because it is accidental, the fix belongs here, not in omnimarket. Nothing in #1645, its ticket, or the 0.47.3 changelog announces a new terminal-attribution contract for def-B handlers, and adopting one would mean every def-B node in every repo starts stamping run identity into its domain response model — the opposite of the def-B contract.

## Fix

A terminal that declares NO correlation id is judged on its SHAPE, using the discriminator already present in the class (`_is_envelope_shaped`: `envelope_id` plus a mapping `payload`):

- bare domain payload declaring nothing -> this run's own terminal, accepted
- ENVELOPE declaring nothing -> still refused; it has the field and left it empty (OMN-17304 AC4 intact)
- anything declared at either level -> every declared id must still be this run's (the #1645 isolation boundary, unchanged)

## Why core stayed green through 0.47.3

The only pre-existing end-to-end coverage of the event-driven path, `test_event_driven_runtime_waits_for_declared_terminal_event`, uses a handler returning a hand-built `dict` with `correlation_id` stamped in. The #1645 suite `test_runtime_local_terminal_isolation.py` drives envelope-shaped terminals against a broker double. Neither exercises the bare domain model, which is the shape the adapter actually publishes for every real def-B node.

## Tests

`tests/unit/runtime/test_runtime_local.py` gains three cases:

- `test_bare_domain_terminal_without_correlation_is_this_run` — RED-first, end-to-end through `run_async()`. TIMEOUT on dev (reproduced before the fix), COMPLETED after.
- `test_bare_terminal_with_foreign_correlation_is_still_refused` — counter-assertion; passes on dev and after.
- `test_envelope_terminal_naming_nobody_is_still_refused` — counter-assertion pinning OMN-17304 AC4; passes on dev and after.

Local: 95 passed across `test_runtime_local.py`, `test_runtime_local_terminal_isolation.py` (all 14 OMN-15660 isolation cases), `test_runtime_local_client_mode.py` (10), `test_runtime_local_adapter_fanout.py`.

Governed pre-push escalated to the full suite on lab host h105: **44805 passed, 57 skipped, 3 xpassed, 0 failed** in 2:25:08.

`mypy src/ --strict`: 14 errors, byte-identical to the origin/dev baseline measured in the same worktree (stash / unstash), none in `runtime_local.py`. `ruff format` + `ruff check`: clean. All staged-file pre-commit hooks green, including the release-identity gate (OMN-13411).

## Release

`[project].version` 0.47.3 -> 0.47.4 in this PR, per the release-identity gate; the tag is cut on this PR's squash commit once it lands on dev.

## Residual, explicitly not closed

On a durable broker a retained BARE-domain terminal from an earlier run becomes adoptable again, because a bare payload has nowhere to carry attribution and the run-scoped consumer group reads the retained log from the beginning. The delegate path is envelope-shaped, so the defect actually observed live in OMN-15660 (a 12-minute-old terminal from a different correlation) stays closed. Closing the bare case properly means carrying attribution out of band — the bus message key or a header — which requires widening `ProtocolLocalRuntimeMessage` (it exposes only `value` today) and having every transport propagate it. That is a cross-repo protocol change, not a hotfix, and is recorded on OMN-17980.

Evidence-Ticket: OMN-17980
Evidence-Source: OCC#8370
