### PR TITLE
fix(OMN-17554): resolve the ten dynamic env reads through declared typed bindings

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -815,7 +815,7 @@
         "filename": "tests/unit/mixins/test_mixin_effect_execution.py",
         "hashed_secret": "d37b30805b9fff0d22b5bc98be131e29465e282b",
         "is_verified": false,
-        "line_number": 980
+        "line_number": 1039
       }
     ],
     "tests/unit/mixins/test_mixin_redaction.py": [
@@ -1173,49 +1173,49 @@
         "filename": "tests/unit/models/security/test_model_secure_credentials.py",
         "hashed_secret": "35c7ea77d2385385c67fd3066fa2e196b3789ef1",
         "is_verified": false,
-        "line_number": 401
+        "line_number": 422
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/models/security/test_model_secure_credentials.py",
         "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
         "is_verified": false,
-        "line_number": 407
+        "line_number": 428
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/models/security/test_model_secure_credentials.py",
         "hashed_secret": "032a11098506ff8eadf5b5c17b886876c394fab8",
         "is_verified": false,
-        "line_number": 553
+        "line_number": 574
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/models/security/test_model_secure_credentials.py",
         "hashed_secret": "26ce9e74c3801c48c61e968cbfda8eb1c08279ab",
         "is_verified": false,
-        "line_number": 568
+        "line_number": 589
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/models/security/test_model_secure_credentials.py",
         "hashed_secret": "dd2370a596759b1a614d4b40ece28e1878260659",
         "is_verified": false,
-        "line_number": 701
+        "line_number": 722
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/models/security/test_model_secure_credentials.py",
         "hashed_secret": "d5c6fee2ea065ac5089dfea2051f2d55c8b6f09d",
         "is_verified": false,
-        "line_number": 714
+        "line_number": 735
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/models/security/test_model_secure_credentials.py",
         "hashed_secret": "c94d65f02a652d11c2e5c2e1ccf38dce5a076e1e",
         "is_verified": false,
-        "line_number": 866
+        "line_number": 887
       }
     ],
     "tests/unit/models/services/test_model_service_health.py": [
@@ -1958,5 +1958,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-06T20:47:40Z"
+  "generated_at": "2026-09-07T05:36:45Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -341,53 +341,28 @@
         "filename": "src/omnibase_core/models/configuration/model_database_connection_config.py",
         "hashed_secret": "0117691d0201f04aa02f586b774c190802d47d8c",
         "is_verified": false,
-        "line_number": 298
+        "line_number": 304
       },
       {
         "type": "Secret Keyword",
         "filename": "src/omnibase_core/models/configuration/model_database_connection_config.py",
         "hashed_secret": "78cd1257c37fda821c7ab40fa6cff7339858ddba",
         "is_verified": false,
-        "line_number": 300
+        "line_number": 306
       },
       {
         "type": "Secret Keyword",
         "filename": "src/omnibase_core/models/configuration/model_database_connection_config.py",
         "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
         "is_verified": false,
-        "line_number": 302
+        "line_number": 308
       },
       {
         "type": "Secret Keyword",
         "filename": "src/omnibase_core/models/configuration/model_database_connection_config.py",
         "hashed_secret": "4802d8102feafe57e1f5596e02d13bf6fdff044f",
         "is_verified": false,
-        "line_number": 304
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/omnibase_core/models/configuration/model_database_connection_config.py",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 405
-      }
-    ],
-    "src/omnibase_core/models/configuration/model_event_bus_config.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/omnibase_core/models/configuration/model_event_bus_config.py",
-        "hashed_secret": "e9e796fbc7f7e8fefabfa92ee119a14bf3c933d2",
-        "is_verified": false,
-        "line_number": 92
-      }
-    ],
-    "src/omnibase_core/models/configuration/model_rest_api_connection_config.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/omnibase_core/models/configuration/model_rest_api_connection_config.py",
-        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
-        "is_verified": false,
-        "line_number": 398
+        "line_number": 310
       }
     ],
     "src/omnibase_core/models/contracts/model_contract_fingerprint.py": [
@@ -475,21 +450,21 @@
         "filename": "src/omnibase_core/models/security/model_secret_backend.py",
         "hashed_secret": "b363713a938afcd3c74603827fab79e935b2b09b",
         "is_verified": false,
-        "line_number": 275
+        "line_number": 298
       },
       {
         "type": "Secret Keyword",
         "filename": "src/omnibase_core/models/security/model_secret_backend.py",
         "hashed_secret": "ebe8872498bd7a369441cf75f56db2bf3701eef9",
         "is_verified": false,
-        "line_number": 291
+        "line_number": 314
       },
       {
         "type": "Secret Keyword",
         "filename": "src/omnibase_core/models/security/model_secret_backend.py",
         "hashed_secret": "89750e2470d52877236f12e42fd5414d36024156",
         "is_verified": false,
-        "line_number": 299
+        "line_number": 322
       }
     ],
     "src/omnibase_core/models/workflow/execution/model_workflow_state_snapshot.py": [
@@ -1983,5 +1958,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-01T23:06:05Z"
+  "generated_at": "2026-09-06T20:47:40Z"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.5"
+version = "0.47.6"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/cli/cli_doctor.py
+++ b/src/omnibase_core/cli/cli_doctor.py
@@ -14,11 +14,13 @@ from omnibase_core.doctor.checks import (
     CheckReposSynced,
     CheckStaleWorktrees,
 )
+from omnibase_core.doctor.doctor_check_base import DoctorCheckBase
 from omnibase_core.doctor.doctor_registry import DoctorRegistry
 from omnibase_core.models.doctor.model_doctor_report import ModelDoctorReport
 
-# Built-in checks registered at import time
-_BUILTIN_CHECKS = [
+# Built-in checks registered at import time. Annotated explicitly: without it
+# the inferred element type is the metaclass, not type[DoctorCheckBase].
+_BUILTIN_CHECKS: list[type[DoctorCheckBase]] = [
     CheckDocker,
     CheckKafka,
     CheckPostgres,
@@ -41,7 +43,7 @@ def doctor(ctx: click.Context, use_json: bool) -> None:
     # Register built-ins
     for check_cls in _BUILTIN_CHECKS:
         # Why: Registry stores protocol contracts rather than instantiating them directly.
-        registry.register(check_cls)  # type: ignore[type-abstract]
+        registry.register(check_cls)
 
     # Discover entry-point checks from other packages
     registry.discover()

--- a/src/omnibase_core/constants/constants_workflow.py
+++ b/src/omnibase_core/constants/constants_workflow.py
@@ -86,10 +86,12 @@ All iteration and size limits exist to prevent denial-of-service attacks:
    Prevent memory exhaustion from oversized payloads. Validated on deserialized
    data to protect against compression bomb attacks (see workflow_executor.py).
 
-4. **Environment Variable Bounds Clamping**:
-   Even when limits are configurable via environment variables, they are clamped
-   to safe bounds (e.g., MAX_WORKFLOW_STEPS clamped to 1-100,000). This prevents
-   operators from accidentally (or maliciously) setting dangerous values.
+4. **Fixed Core ceilings**:
+   The workflow execution limits below are immutable Core constants. Nothing —
+   no environment variable, no contract, no per-workflow field — can raise or
+   lower them at runtime. That is deliberate: these limits are the DoS
+   protection itself, so a configuration surface for them would be a surface
+   for turning the protection off (OMN-17554).
 
 Workflow Execution Limits (OMN-670: Security hardening):
     These limits prevent memory exhaustion and DoS attacks:
@@ -97,121 +99,38 @@ Workflow Execution Limits (OMN-670: Security hardening):
     - MAX_STEP_PAYLOAD_SIZE_BYTES: Maximum size of individual step payload
     - MAX_TOTAL_PAYLOAD_SIZE_BYTES: Maximum accumulated payload size
 
-    Limits are configurable via environment variables for extreme workloads:
-    - ONEX_MAX_WORKFLOW_STEPS: Override max workflow steps (bounds: 1-100,000)
-    - ONEX_MAX_STEP_PAYLOAD_SIZE_BYTES: Override max step payload size (bounds: 1KB-10MB)
-    - ONEX_MAX_TOTAL_PAYLOAD_SIZE_BYTES: Override max total payload size (bounds: 1KB-1GB)
-
-    Bounds are enforced to prevent both DoS attacks (too-small limits causing many
-    small workflows) and memory exhaustion (too-large limits).
+    They are module-level constants with no configuration path. Workflow
+    contracts do not configure or override them.
 
 Thread Safety:
-    The module-level ``_cached_limits`` dict is NOT thread-safe in the strict sense.
-    However, this is an intentional design choice for simplicity:
-
-    1. Python's GIL ensures that dict operations (``in``, ``[]``, ``[]=``) are atomic
-       at the bytecode level, preventing data corruption.
-    2. The worst-case race condition is duplicate computation: two threads may both
-       compute the same limit value before either caches it. This is benign because:
-       - Environment variables are immutable during process lifetime
-       - Both threads compute identical values
-       - The final cached value is correct regardless of which thread wins
-    3. Adding threading.Lock would add complexity and overhead with no practical
-       benefit for this read-heavy, write-once pattern.
-
-    For truly thread-safe requirements (e.g., dynamic reconfiguration), use
-    explicit synchronization at the application level.
+    Every value in this module is an immutable module-level constant read at
+    import time. There is no cache, no lazy initialisation and no mutable
+    module state, so concurrent readers need no synchronization.
 """
 
-import logging
-import os
-
-# --- Environment Variable Helpers ---
-
-# Module-level cache for environment-based limits to avoid repeated parsing
-_cached_limits: dict[str, int] = {}
-
-
-def _get_limit_from_env(env_var: str, default: int, min_val: int, max_val: int) -> int:
-    """Get limit from environment variable with bounds checking and memoization.
-
-    Uses module-level caching to avoid repeated environment variable parsing
-    and bounds checking on each access.
-
-    Args:
-        env_var: Environment variable name
-        default: Default value if env var not set
-        min_val: Minimum allowed value
-        max_val: Maximum allowed value
-
-    Returns:
-        Validated limit value (cached after first computation)
-
-    Thread Safety:
-        This function uses a module-level cache that is not strictly thread-safe.
-        However, Python's GIL ensures atomic dict operations, so the worst case
-        is benign duplicate computation (two threads compute the same value).
-        No data corruption can occur. See module docstring for full rationale.
-    """
-    # Check cache first (memoization for repeated access)
-    if env_var in _cached_limits:
-        return _cached_limits[env_var]
-
-    value = os.environ.get(env_var)
-    if value is None:
-        result = default
-    else:
-        try:
-            int_value = int(value)
-            result = max(min_val, min(int_value, max_val))
-            # Log warning when value is clamped to bounds (DoS prevention)
-            if int_value != result:
-                logging.warning(
-                    f"{env_var} value {int_value} clamped to {result} "
-                    f"(bounds: {min_val}-{max_val}). "
-                    "This prevents DoS attacks via extreme configuration values."
-                )
-        except ValueError:
-            logging.warning(
-                f"Invalid value for {env_var}: {value}, using default {default}"
-            )
-            result = default
-
-    # Cache the result for subsequent accesses
-    _cached_limits[env_var] = result
-    return result
-
-
-def _clear_limit_cache() -> None:
-    """Clear the cached limits (for testing purposes only)."""
-    _cached_limits.clear()
-
-
 # --- Workflow Execution Limits (OMN-670: Security hardening) ---
+#
+# These three limits are fixed, immutable Core ceilings. They are not
+# configurable: not by environment variable, not by contract, and not per
+# workflow (OMN-17554). They exist to bound resource consumption for every
+# workflow this build executes, so a per-deployment override would be a way to
+# opt out of the DoS protection rather than a way to tune it. Changing a
+# ceiling is a Core change with a Core review.
+#
+# Before OMN-17554 each was read from an ``ONEX_MAX_*`` environment variable
+# through a memoizing helper that clamped out-of-range values and logged a
+# warning. Nothing consumed that authority except the module's own import-time
+# initialisation, and the clamp meant an operator could only ever move a limit
+# within a range Core already declared safe.
 
-# Maximum number of steps in a workflow
-# Configurable via ONEX_MAX_WORKFLOW_STEPS (bounds: 1-100,000)
-MAX_WORKFLOW_STEPS: int = _get_limit_from_env(
-    "ONEX_MAX_WORKFLOW_STEPS", default=1000, min_val=1, max_val=100000
-)
+# Maximum number of steps in a workflow.
+MAX_WORKFLOW_STEPS: int = 1000
 
-# Maximum size of individual step payload in bytes
-# Configurable via ONEX_MAX_STEP_PAYLOAD_SIZE_BYTES (bounds: 1KB-10MB)
-MAX_STEP_PAYLOAD_SIZE_BYTES: int = _get_limit_from_env(
-    "ONEX_MAX_STEP_PAYLOAD_SIZE_BYTES",
-    default=64 * 1024,
-    min_val=1024,
-    max_val=10 * 1024 * 1024,
-)
+# Maximum size of an individual step payload, in bytes (64 KB).
+MAX_STEP_PAYLOAD_SIZE_BYTES: int = 64 * 1024
 
-# Maximum total payload size across all steps in bytes
-# Configurable via ONEX_MAX_TOTAL_PAYLOAD_SIZE_BYTES (bounds: 1KB-1GB)
-MAX_TOTAL_PAYLOAD_SIZE_BYTES: int = _get_limit_from_env(
-    "ONEX_MAX_TOTAL_PAYLOAD_SIZE_BYTES",
-    default=10 * 1024 * 1024,
-    min_val=1024,
-    max_val=1024 * 1024 * 1024,
-)
+# Maximum total payload size across all steps, in bytes (10 MB).
+MAX_TOTAL_PAYLOAD_SIZE_BYTES: int = 10 * 1024 * 1024
 
 # --- Reserved Step Types ---
 

--- a/src/omnibase_core/doctor/checks/check_env_vars.py
+++ b/src/omnibase_core/doctor/checks/check_env_vars.py
@@ -1,41 +1,235 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-import os
-import time
+"""Doctor check that proves a real typed configuration binding (OMN-17554).
+
+This check used to read ``os.environ`` for a hardcoded list of variable names.
+That could only ever prove that some ambient string was non-empty — it proved
+nothing about the configuration ONEX actually resolves, and an earlier repair
+that let the caller inject the required set produced a doctor that asserted its
+own health.
+
+The authority is now the declared typed binding in ``~/.onex/config.yaml``, the
+same file :mod:`omnibase_core.cli.cli_user_config` writes:
+
+#. one bounded read of the source bytes;
+#. one bounded decode;
+#. one bounded YAML parse plus source-shape check;
+#. one non-writing, recursive projection of the parsed mapping onto the
+   declared :class:`ModelCliUserConfig` fields and their declared aliases, at
+   every declared-model depth, omitting absent fields and sections;
+#. exactly one ``ModelCliUserConfig`` validation over that projection.
+
+Nothing here writes, migrates, normalizes or falls back. Unknown and unrelated
+keys stay in the parsed source mapping and are simply absent from the strict
+payload, so an ``aws:`` block or a hand-added credential key can never turn a
+healthy install unhealthy.
+
+Every failure is classified at the operation that has configuration provenance
+and converted immediately into a fixed, secret-safe outcome: no exception text,
+no source path, no parser detail and no configured value ever reaches a result
+message, a renderer or a log. Programmer faults propagate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from pydantic import BaseModel, ValidationError
 
 from omnibase_core.doctor.doctor_check_base import DoctorCheckBase
 from omnibase_core.enums.enum_doctor_category import EnumDoctorCategory
+from omnibase_core.enums.enum_doctor_config_load_code import EnumDoctorConfigLoadCode
 from omnibase_core.enums.enum_health_status_value import EnumHealthStatusValue
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.cli.model_cli_user_config import ModelCliUserConfig
 from omnibase_core.models.doctor.model_doctor_check_result import ModelDoctorCheckResult
+from omnibase_core.types.type_serializable_value import (
+    SerializableValue,
+    SerializedDict,
+)
 
-REQUIRED_VARS = [
-    "LINEAR_API_KEY",
-    "OMNICLAUDE_PROJECT_ROOT",
-]
+# The public result vocabulary. Fixed strings, chosen so that no code path can
+# interpolate a value, a path, or an exception into user-visible output.
+_MESSAGE_MISSING_BINDING = "Missing: LINEAR_API_KEY"
+_MESSAGE_HEALTHY = "All required configuration bindings present"
+
+_FIXED_ERROR_MESSAGES: dict[EnumDoctorConfigLoadCode, str] = {
+    EnumDoctorConfigLoadCode.MISSING: _MESSAGE_MISSING_BINDING,
+    EnumDoctorConfigLoadCode.EMPTY: _MESSAGE_MISSING_BINDING,
+    EnumDoctorConfigLoadCode.UNREADABLE: (
+        "User configuration is unavailable; check configuration file access."
+    ),
+    EnumDoctorConfigLoadCode.INVALID_ENCODING: (
+        "User configuration has invalid text encoding."
+    ),
+    EnumDoctorConfigLoadCode.INVALID_YAML: "User configuration contains invalid YAML.",
+    EnumDoctorConfigLoadCode.INVALID_MODEL: "Managed user configuration is invalid.",
+}
+
+
+# The typed load outcome. A pair rather than a second class in this module:
+# ``onex-single-class-per-file`` allows one non-enum class per file, and the
+# doctor repair for OMN-17554 is bounded to a fixed six-path ceiling, so a
+# separate model module is not available. The discriminant is the code; the
+# model is present if and only if the code is ``VALID``, which is structural —
+# only the VALID return path below supplies one, and every error return carries
+# the code alone: no exception text, path, parser text, decoded content, value
+# or copied credential.
+DoctorConfigLoadOutcome = tuple[EnumDoctorConfigLoadCode, "ModelCliUserConfig | None"]
+
+
+def default_user_config_path() -> Path:
+    """The declared binding source: ``~/.onex/config.yaml``.
+
+    Delegates to the shared resolver so the doctor can never read a different
+    file from the one the CLI writers maintain. The import is function-local
+    because ``omnibase_core.cli`` imports this package (``cli_doctor`` ->
+    ``doctor.checks``), so a module-level ``doctor -> cli`` import closes a
+    package cycle and fails at collection time.
+    """
+    from omnibase_core.cli.cli_user_config import user_config_path
+
+    return user_config_path()
+
+
+def _project_declared(
+    model: type[BaseModel], source: Mapping[str, SerializableValue]
+) -> SerializedDict:
+    """Project ``source`` onto ``model``'s declared fields and aliases.
+
+    Recurses into every declared ``BaseModel`` child using that child's own
+    field names and declared aliases, so an unknown key nested beneath a
+    declared section never reaches strict validation. Absent fields and
+    sections are omitted rather than injected, so the model's own defaults
+    apply. ``source`` is never mutated and never written back.
+
+    A declared child whose source value is not a mapping is passed through
+    unchanged so the single validation below rejects it, rather than being
+    silently dropped or coerced here.
+    """
+    projected: SerializedDict = {}
+    for name, field in model.model_fields.items():
+        # ``populate_by_name=True`` on these models means either spelling
+        # binds; prefer the alias, which is the on-disk key.
+        for key in (field.alias, name):
+            if key is None or key not in source:
+                continue
+            value = source[key]
+            annotation = field.annotation
+            if (
+                isinstance(annotation, type)
+                and issubclass(annotation, BaseModel)
+                and isinstance(value, Mapping)
+            ):
+                projected[key] = _project_declared(annotation, value)
+            else:
+                projected[key] = value
+            break
+    return projected
+
+
+def load_declared_user_config(path: Path) -> DoctorConfigLoadOutcome:
+    """Resolve the declared typed binding at ``path``, fail-closed.
+
+    Each catch is scoped to the single operation that owns that provenance.
+    Anything else — a programmer fault, an unexpected runtime error — is
+    allowed to propagate.
+    """
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError:
+        return (EnumDoctorConfigLoadCode.MISSING, None)
+    except OSError:
+        # PermissionError, IsADirectoryError and every other read failure.
+        return (EnumDoctorConfigLoadCode.UNREADABLE, None)
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeError:
+        return (EnumDoctorConfigLoadCode.INVALID_ENCODING, None)
+
+    # Function-local for the same package-cycle reason as
+    # default_user_config_path above.
+    from omnibase_core.cli.cli_user_config import parse_user_config_text
+
+    try:
+        # The shared parser, and only the parser: it raises for invalid YAML
+        # and for a non-mapping document, which are the same public outcome.
+        # The normalizer that sits beside it is deliberately not called.
+        parsed = parse_user_config_text(text, str(path))
+    except ModelOnexError:
+        return (EnumDoctorConfigLoadCode.INVALID_YAML, None)
+
+    if parsed is None:
+        return (EnumDoctorConfigLoadCode.EMPTY, None)
+
+    projected = _project_declared(ModelCliUserConfig, parsed)
+
+    try:
+        config = ModelCliUserConfig.model_validate(projected)
+    except ValidationError:
+        return (EnumDoctorConfigLoadCode.INVALID_MODEL, None)
+
+    return (EnumDoctorConfigLoadCode.VALID, config)
 
 
 class CheckEnvVars(DoctorCheckBase):
+    """Report whether the declared typed configuration binding resolves."""
+
+    # Plain assignments, not re-annotations: DoctorCheckBase already declares
+    # these as ClassVars, and the string-version AST gate reads an annotated
+    # ``check_id: str`` as an unmigrated string identifier field (which is why
+    # doctor_check_base.py itself is on that hook's exclude list).
     check_id = "env_vars"
-    check_name = "Required env vars"
+    check_name = "env_vars"
     category = EnumDoctorCategory.ENVIRONMENT
 
+    def __init__(self, config_path: Path | None = None) -> None:
+        """Resolve the binding source.
+
+        ``DoctorRegistry.list_all()`` constructs checks with no arguments, so
+        the production route resolves the real user config file and this
+        constructor must never raise for a configuration-origin failure — the
+        failure becomes a typed outcome instead.
+        """
+        self.config_path = (
+            config_path if config_path is not None else default_user_config_path()
+        )
+        self.outcome_code, self.config = load_declared_user_config(self.config_path)
+
     def run(self) -> ModelDoctorCheckResult:
-        start = time.monotonic()
-        missing = [v for v in REQUIRED_VARS if not os.environ.get(v)]
-        elapsed = int((time.monotonic() - start) * 1000)
-        if missing:
-            return ModelDoctorCheckResult(
-                name=self.check_name,
-                category=self.category,
-                status=EnumHealthStatusValue.DEGRADED,
-                message=f"Missing: {', '.join(missing)}",
-                duration_ms=elapsed,
-            )
         return ModelDoctorCheckResult(
             name=self.check_name,
             category=self.category,
-            status=EnumHealthStatusValue.HEALTHY,
-            message=f"All {len(REQUIRED_VARS)} vars set",
-            duration_ms=elapsed,
+            status=self._status(),
+            message=self._message(),
         )
+
+    def _has_required_binding(self) -> bool:
+        return self.config is not None and bool(self.config.credentials.linear_api_key)
+
+    def _status(self) -> EnumHealthStatusValue:
+        if self.outcome_code is EnumDoctorConfigLoadCode.VALID and (
+            self._has_required_binding()
+        ):
+            return EnumHealthStatusValue.HEALTHY
+        return EnumHealthStatusValue.UNHEALTHY
+
+    def _message(self) -> str:
+        if self.outcome_code is not EnumDoctorConfigLoadCode.VALID:
+            return _FIXED_ERROR_MESSAGES[self.outcome_code]
+        return (
+            _MESSAGE_HEALTHY
+            if self._has_required_binding()
+            else _MESSAGE_MISSING_BINDING
+        )
+
+
+__all__ = [
+    "CheckEnvVars",
+    "DoctorConfigLoadOutcome",
+    "default_user_config_path",
+    "load_declared_user_config",
+]

--- a/src/omnibase_core/enums/enum_doctor_config_load_code.py
+++ b/src/omnibase_core/enums/enum_doctor_config_load_code.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""How the doctor's declared configuration binding source resolved (OMN-17554)."""
+
+from enum import StrEnum
+
+
+class EnumDoctorConfigLoadCode(StrEnum):
+    """Outcome of resolving ``~/.onex/config.yaml`` for the env-binding check.
+
+    Internal to the loader and its tests. These values are never serialized
+    into a ``ModelDoctorCheckResult``, either doctor renderer, or a log line —
+    the public surface is a fixed, secret-safe message with category
+    ``ENVIRONMENT``.
+    """
+
+    MISSING = "MISSING"
+    EMPTY = "EMPTY"
+    UNREADABLE = "UNREADABLE"
+    INVALID_ENCODING = "INVALID_ENCODING"
+    INVALID_YAML = "INVALID_YAML"
+    INVALID_MODEL = "INVALID_MODEL"
+    VALID = "VALID"

--- a/src/omnibase_core/infrastructure/node_config_provider.py
+++ b/src/omnibase_core/infrastructure/node_config_provider.py
@@ -10,14 +10,13 @@ for all ONEX nodes with environment variable support and sensible defaults.
 Domain: Infrastructure configuration management
 """
 
-import os
-
 from omnibase_core.constants import TIMEOUT_DEFAULT_MS
 from omnibase_core.models.configuration.model_node_config_value import (
     ModelNodeConfigSchema,
     ScalarConfigValue,
     is_valid_value_type,
 )
+from omnibase_core.overlays.contract_env_ref import resolve_contract_env_binding
 
 
 class NodeConfigProvider:
@@ -50,9 +49,12 @@ class NodeConfigProvider:
             - effect.default_retry_delay_ms: Default retry delay for effects
             - orchestrator.default_step_timeout_ms: Default step timeout for orchestrator
 
-    Environment Variables:
-        - ONEX_<KEY>: Override any configuration (e.g., ONEX_COMPUTE_MAX_PARALLEL_WORKERS=8)
-        - Keys use uppercase with underscores (dots become underscores)
+    Declared bindings:
+        Each configuration key has one declared ``${env.ONEX_*}`` contract
+        reference in ``_BINDINGS`` below, resolved through the sanctioned
+        overlay resolver (OMN-17554). This provider does not read the
+        environment itself and does not derive reference names at runtime, so
+        the full set of bindings is readable in one place.
 
     Example:
         ```python
@@ -91,36 +93,57 @@ class NodeConfigProvider:
         "orchestrator.action_emission_enabled": True,
     }
 
+    # Declared contract-env binding per configuration key (OMN-17554). One
+    # literal reference per key: the set is closed and reviewable, unlike the
+    # f-string builder this replaced, whose keys could not be enumerated
+    # statically and were therefore invisible to the env-read gate.
+    _BINDINGS: dict[str, str] = {
+        "compute.max_parallel_workers": "${env.ONEX_COMPUTE_MAX_PARALLEL_WORKERS}",
+        "compute.cache_ttl_minutes": "${env.ONEX_COMPUTE_CACHE_TTL_MINUTES}",
+        "compute.performance_threshold_ms": (
+            "${env.ONEX_COMPUTE_PERFORMANCE_THRESHOLD_MS}"
+        ),
+        "effect.default_timeout_ms": "${env.ONEX_EFFECT_DEFAULT_TIMEOUT_MS}",
+        "effect.default_retry_delay_ms": "${env.ONEX_EFFECT_DEFAULT_RETRY_DELAY_MS}",
+        "effect.max_concurrent_effects": "${env.ONEX_EFFECT_MAX_CONCURRENT_EFFECTS}",
+        "reducer.default_batch_size": "${env.ONEX_REDUCER_DEFAULT_BATCH_SIZE}",
+        "reducer.max_memory_usage_mb": "${env.ONEX_REDUCER_MAX_MEMORY_USAGE_MB}",
+        "reducer.streaming_buffer_size": "${env.ONEX_REDUCER_STREAMING_BUFFER_SIZE}",
+        "orchestrator.max_concurrent_workflows": (
+            "${env.ONEX_ORCHESTRATOR_MAX_CONCURRENT_WORKFLOWS}"
+        ),
+        "orchestrator.default_step_timeout_ms": (
+            "${env.ONEX_ORCHESTRATOR_DEFAULT_STEP_TIMEOUT_MS}"
+        ),
+        "orchestrator.action_emission_enabled": (
+            "${env.ONEX_ORCHESTRATOR_ACTION_EMISSION_ENABLED}"
+        ),
+    }
+
     def __init__(self) -> None:
         """Initialize configuration provider."""
         self._config_cache: dict[str, ScalarConfigValue] = {}
-        self._load_environment_config()
+        self._load_declared_bindings()
 
-    def _load_environment_config(self) -> None:
-        """Load configuration from environment variables."""
-        # Load all ONEX_* environment variables
+    def _load_declared_bindings(self) -> None:
+        """Resolve every declared binding, falling back to the typed default."""
         for key, default_value in self._DEFAULTS.items():
-            env_key = f"ONEX_{key.upper().replace('.', '_')}"
-            env_value = os.environ.get(env_key)
-
-            if env_value is not None:
-                # Convert environment variable to appropriate type
-                if isinstance(default_value, bool):
-                    self._config_cache[key] = env_value.lower() in (
-                        "true",
-                        "1",
-                        "yes",
-                        "on",
-                    )
-                elif isinstance(default_value, int):
-                    self._config_cache[key] = int(env_value)
-                elif isinstance(default_value, float):
-                    self._config_cache[key] = float(env_value)
-                else:
-                    self._config_cache[key] = env_value
-            else:
-                # Use default value
+            binding = resolve_contract_env_binding(self._BINDINGS[key])
+            if binding.value is None:
                 self._config_cache[key] = default_value
+                continue
+            self._config_cache[key] = self._coerce(binding.value, default_value)
+
+    @staticmethod
+    def _coerce(value: str, default_value: ScalarConfigValue) -> ScalarConfigValue:
+        """Coerce a resolved binding to the type its declared default carries."""
+        if isinstance(default_value, bool):
+            return value.lower() in ("true", "1", "yes", "on")
+        if isinstance(default_value, int):
+            return int(value)
+        if isinstance(default_value, float):
+            return float(value)
+        return value
 
     async def get_config_value(
         self, key: str, default: ScalarConfigValue | None = None

--- a/src/omnibase_core/mixins/mixin_effect_execution.py
+++ b/src/omnibase_core/mixins/mixin_effect_execution.py
@@ -77,7 +77,6 @@ Author: ONEX Framework Team
 """
 
 import asyncio
-import os
 import random
 import re
 import threading
@@ -129,6 +128,7 @@ from omnibase_core.models.effect.model_effect_output import ModelEffectOutput
 from omnibase_core.models.operations.model_effect_operation_config import (
     ModelEffectOperationConfig,
 )
+from omnibase_core.overlays.contract_env_ref import resolve_contract_env_binding
 from omnibase_core.types.type_effect_result import DbParamType, EffectResultType
 
 __all__ = ["MixinEffectExecution"]
@@ -590,7 +590,7 @@ class MixinEffectExecution:
 
         Template Resolution:
             - ${input.field} - from input_data.operation_data
-            - ${env.VAR} - from os.environ
+            - ${env.VAR} - through the sanctioned overlay resolver
             - ${secret.KEY} - from container secret service (if available)
 
         v1.0 Behavior:
@@ -599,7 +599,7 @@ class MixinEffectExecution:
             This is intentional - see PERFORMANCE NOTE in _execute_with_retry().
 
         Thread Safety:
-            Pure function, thread-safe. Environment variable access is
+            Pure function, thread-safe. Environment binding resolution is
             inherently racy but this is expected behavior.
 
         Note:
@@ -632,25 +632,20 @@ class MixinEffectExecution:
                 return str(value) if value is not None else ""
 
             elif placeholder.startswith("env."):
-                # Extract from environment.  Supports ${env.VAR:default}
-                # syntax where the value after the first colon is the
-                # fallback when the env var is unset.
-                env_expr = placeholder[4:]  # Remove "env."
-                if ":" in env_expr:
-                    var_name, default_value = env_expr.split(":", 1)
-                else:
-                    var_name = env_expr
-                    default_value = None
-                value = os.environ.get(var_name)
-                if value is not None:
-                    return value
-                if default_value is not None:
-                    return default_value
+                # Resolve through the sanctioned ${env.VAR} overlay boundary
+                # (OMN-17554) rather than reading os.environ here. The resolver
+                # owns the reference grammar — including the ${env.VAR:default}
+                # inline-default form — and fails closed on a malformed or
+                # unclosed reference instead of passing it through as a
+                # literal.
+                binding = resolve_contract_env_binding(f"${{{placeholder}}}")
+                if binding.value is not None:
+                    return binding.value
                 raise ModelOnexError(
-                    message=f"Environment variable not found: {var_name}",
+                    message=f"Environment variable not found: {binding.name}",
                     error_code=EnumCoreErrorCode.CONFIGURATION_NOT_FOUND,
                     context={
-                        "variable_name": var_name,
+                        "variable_name": binding.name,
                         "placeholder": placeholder,
                         "operation_id": str(input_data.operation_id),
                     },

--- a/src/omnibase_core/models/configuration/model_contract_env_binding.py
+++ b/src/omnibase_core/models/configuration/model_contract_env_binding.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed result of resolving one declared ``${env.VAR}`` contract reference."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ModelContractEnvBinding(BaseModel):
+    """One declared contract-env reference, resolved.
+
+    ``bound`` records whether the operator environment actually declares the
+    variable. It is deliberately separate from ``value`` so a caller can tell
+    "not configured" from "configured empty" — the distinction every override
+    loop in this repo depends on, and the one a bare
+    ``expand_contract_env_refs`` call cannot express, because an unset variable
+    and an empty one both expand to ``""``.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    name: str = Field(description="Variable name declared by the reference")
+    reference: str = Field(description="The canonical ``${env.NAME}`` reference")
+    bound: bool = Field(
+        description="True when the operator environment declares the variable"
+    )
+    value: str | None = Field(
+        default=None,
+        description=(
+            "Resolved value: the declared value when bound, otherwise the "
+            "reference's inline default, otherwise None"
+        ),
+    )
+
+    def is_configured(self) -> bool:
+        """True when this binding resolved to a usable value."""
+        return self.value is not None
+
+
+__all__ = ["ModelContractEnvBinding"]

--- a/src/omnibase_core/models/configuration/model_database_connection_config.py
+++ b/src/omnibase_core/models/configuration/model_database_connection_config.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-import os
 import re
+from typing import ClassVar
 
-from pydantic import BaseModel, Field, SecretStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 
 from omnibase_core.constants.constants_field_limits import (
     MAX_IDENTIFIER_LENGTH,
@@ -12,6 +12,7 @@ from omnibase_core.constants.constants_field_limits import (
 )
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.overlays.contract_env_ref import resolve_contract_env_binding
 
 
 class ModelDatabaseConnectionConfig(BaseModel):
@@ -28,6 +29,11 @@ class ModelDatabaseConnectionConfig(BaseModel):
     - Health check capability assessment
     - Performance tuning recommendations
     """
+
+    # OMN-14515 ratchet: this model was baselined without an explicit
+    # extra= setting, so Pydantic silently dropped unknown fields. Touching
+    # its body (OMN-17554) is the moment to fix it.
+    model_config = ConfigDict(extra="forbid")
 
     host: str = Field(
         default=...,
@@ -392,23 +398,26 @@ class ModelDatabaseConnectionConfig(BaseModel):
 
     # === Environment Override Support ===
 
+    # Declared contract-env binding per overridable field (OMN-17554). Each
+    # entry is a literal ${env.VAR} reference resolved through the sanctioned
+    # overlay boundary; this model does not read the environment itself.
+    _ENV_BINDINGS: ClassVar[tuple[tuple[str, str], ...]] = (
+        ("host", "${env.ONEX_DB_HOST}"),
+        ("port", "${env.ONEX_DB_PORT}"),
+        ("database", "${env.ONEX_DB_DATABASE}"),
+        ("username", "${env.ONEX_DB_USERNAME}"),
+        ("password", "${env.ONEX_DB_PASSWORD}"),
+        ("ssl_enabled", "${env.ONEX_DB_SSL_ENABLED}"),
+        ("connection_timeout", "${env.ONEX_DB_CONNECTION_TIMEOUT}"),
+    )
+
     def apply_environment_overrides(self) -> "ModelDatabaseConnectionConfig":
-        """Apply environment variable overrides for CI/local testing."""
+        """Apply declared binding overrides for CI/local testing."""
         overrides: dict[str, object] = {}
 
-        # Environment variable mappings
-        env_mappings = {
-            "ONEX_DB_HOST": "host",
-            "ONEX_DB_PORT": "port",
-            "ONEX_DB_DATABASE": "database",
-            "ONEX_DB_USERNAME": "username",
-            "ONEX_DB_PASSWORD": "password",
-            "ONEX_DB_SSL_ENABLED": "ssl_enabled",
-            "ONEX_DB_CONNECTION_TIMEOUT": "connection_timeout",
-        }
-
-        for env_var, field_name in env_mappings.items():
-            env_value = os.environ.get(env_var)
+        for field_name, reference in self._ENV_BINDINGS:
+            binding = resolve_contract_env_binding(reference)
+            env_value = binding.value
             if env_value is not None:
                 # Type conversion for different field types
                 if field_name in ["port", "connection_timeout"]:

--- a/src/omnibase_core/models/configuration/model_event_bus_config.py
+++ b/src/omnibase_core/models/configuration/model_event_bus_config.py
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: MIT
 
 import os
+from typing import ClassVar
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
+
+from omnibase_core.overlays.contract_env_ref import resolve_contract_env_binding
 
 
 class ModelEventBusConfig(BaseModel):
@@ -77,32 +80,43 @@ class ModelEventBusConfig(BaseModel):
             return None
         return self.sasl_password.get_secret_value()
 
+    # Declared contract-env binding per overridable field (OMN-17554).
+    #
+    # A tuple of pairs, not a dict literal: the OMN-15639 consumer-group gate
+    # reads any `"group_id": "<literal>"` dict entry as a hardcoded consumer
+    # group name, and it is right to -- it cannot tell a group name from a
+    # reference to one by looking at the value. The binding below names the
+    # variable the group id is read FROM; the id itself is still resolved at
+    # run time through the sanctioned overlay boundary. Keeping the gate strict
+    # and declaring the table as pairs costs nothing.
+    _ENV_BINDINGS: ClassVar[tuple[tuple[str, str], ...]] = (
+        ("bootstrap_servers", "${env.ONEX_EVENT_BUS_BOOTSTRAP_SERVERS}"),
+        ("topics", "${env.ONEX_EVENT_BUS_TOPICS}"),
+        ("security_protocol", "${env.ONEX_EVENT_BUS_SECURITY_PROTOCOL}"),
+        ("sasl_mechanism", "${env.ONEX_EVENT_BUS_SASL_MECHANISM}"),
+        ("sasl_username", "${env.ONEX_EVENT_BUS_SASL_USERNAME}"),
+        ("sasl_password", "${env.ONEX_EVENT_BUS_SASL_PASSWORD}"),
+        ("client_id", "${env.ONEX_EVENT_BUS_CLIENT_ID}"),
+        ("group_id", "${env.ONEX_EVENT_BUS_GROUP_ID}"),
+        ("partitions", "${env.ONEX_EVENT_BUS_PARTITIONS}"),
+        ("replication_factor", "${env.ONEX_EVENT_BUS_REPLICATION_FACTOR}"),
+        ("acks", "${env.ONEX_EVENT_BUS_ACKS}"),
+        ("enable_auto_commit", "${env.ONEX_EVENT_BUS_ENABLE_AUTO_COMMIT}"),
+        ("auto_offset_reset", "${env.ONEX_EVENT_BUS_AUTO_OFFSET_RESET}"),
+        ("ssl_cafile", "${env.ONEX_EVENT_BUS_SSL_CAFILE}"),
+        ("ssl_certfile", "${env.ONEX_EVENT_BUS_SSL_CERTFILE}"),
+        ("ssl_keyfile", "${env.ONEX_EVENT_BUS_SSL_KEYFILE}"),
+    )
+
     def apply_environment_overrides(self) -> "ModelEventBusConfig":
-        """Apply environment variable overrides for CI/local testing."""
+        """Apply declared binding overrides for CI/local testing."""
         overrides: dict[
             str,
             list[str] | str | int | bool | SecretStr | None,
         ] = {}
-        env_mappings = {
-            "ONEX_EVENT_BUS_BOOTSTRAP_SERVERS": "bootstrap_servers",
-            "ONEX_EVENT_BUS_TOPICS": "topics",
-            "ONEX_EVENT_BUS_SECURITY_PROTOCOL": "security_protocol",
-            "ONEX_EVENT_BUS_SASL_MECHANISM": "sasl_mechanism",
-            "ONEX_EVENT_BUS_SASL_USERNAME": "sasl_username",
-            "ONEX_EVENT_BUS_SASL_PASSWORD": "sasl_password",
-            "ONEX_EVENT_BUS_CLIENT_ID": "client_id",
-            "ONEX_EVENT_BUS_GROUP_ID": "group_id",
-            "ONEX_EVENT_BUS_PARTITIONS": "partitions",
-            "ONEX_EVENT_BUS_REPLICATION_FACTOR": "replication_factor",
-            "ONEX_EVENT_BUS_ACKS": "acks",
-            "ONEX_EVENT_BUS_ENABLE_AUTO_COMMIT": "enable_auto_commit",
-            "ONEX_EVENT_BUS_AUTO_OFFSET_RESET": "auto_offset_reset",
-            "ONEX_EVENT_BUS_SSL_CAFILE": "ssl_cafile",
-            "ONEX_EVENT_BUS_SSL_CERTFILE": "ssl_certfile",
-            "ONEX_EVENT_BUS_SSL_KEYFILE": "ssl_keyfile",
-        }
-        for env_var, field_name in env_mappings.items():
-            env_value = os.environ.get(env_var)
+        for field_name, reference in self._ENV_BINDINGS:
+            binding = resolve_contract_env_binding(reference)
+            env_value = binding.value
             if env_value is not None:
                 if field_name in ["bootstrap_servers", "topics"]:
                     overrides[field_name] = [

--- a/src/omnibase_core/models/configuration/model_rest_api_connection_config.py
+++ b/src/omnibase_core/models/configuration/model_rest_api_connection_config.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
-import os
+from typing import ClassVar
 from urllib.parse import urljoin, urlparse
 
-from pydantic import BaseModel, Field, SecretStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
 from omnibase_core.models.configuration.model_request_config import ModelRequestConfig
@@ -13,6 +13,7 @@ from omnibase_core.models.configuration.model_request_retry_config import (
 )
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
 from omnibase_core.models.health.model_health_check_config import ModelHealthCheckConfig
+from omnibase_core.overlays.contract_env_ref import resolve_contract_env_binding
 
 
 class ModelRestApiConnectionConfig(BaseModel):
@@ -30,6 +31,11 @@ class ModelRestApiConnectionConfig(BaseModel):
     - Health check endpoint support
     - Rate limiting awareness
     """
+
+    # OMN-14515 ratchet: this model was baselined without an explicit
+    # extra= setting, so Pydantic silently dropped unknown fields. Touching
+    # its body (OMN-17554) is the moment to fix it.
+    model_config = ConfigDict(extra="forbid")
 
     base_url: str = Field(
         default=...,
@@ -388,21 +394,22 @@ class ModelRestApiConnectionConfig(BaseModel):
 
     # === Environment Override Support ===
 
+    # Declared contract-env binding per overridable field (OMN-17554).
+    _ENV_BINDINGS: ClassVar[tuple[tuple[str, str], ...]] = (
+        ("base_url", "${env.ONEX_API_BASE_URL}"),
+        ("api_key", "${env.ONEX_API_KEY}"),
+        ("bearer_token", "${env.ONEX_API_BEARER_TOKEN}"),
+        ("timeout_seconds", "${env.ONEX_API_TIMEOUT_SECONDS}"),
+        ("max_retries", "${env.ONEX_API_MAX_RETRIES}"),
+    )
+
     def apply_environment_overrides(self) -> "ModelRestApiConnectionConfig":
-        """Apply environment variable overrides for CI/local testing."""
+        """Apply declared binding overrides for CI/local testing."""
         overrides: dict[str, str | int | SecretStr] = {}
 
-        # Environment variable mappings
-        env_mappings = {
-            "ONEX_API_BASE_URL": "base_url",
-            "ONEX_API_KEY": "api_key",
-            "ONEX_API_BEARER_TOKEN": "bearer_token",
-            "ONEX_API_TIMEOUT_SECONDS": "timeout_seconds",
-            "ONEX_API_MAX_RETRIES": "max_retries",
-        }
-
-        for env_var, field_name in env_mappings.items():
-            env_value = os.environ.get(env_var)
+        for field_name, reference in self._ENV_BINDINGS:
+            binding = resolve_contract_env_binding(reference)
+            env_value = binding.value
             if env_value is not None:
                 # Type conversion for numeric fields
                 if field_name in ["timeout_seconds", "max_retries"]:

--- a/src/omnibase_core/models/security/model_secret_backend.py
+++ b/src/omnibase_core/models/security/model_secret_backend.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from omnibase_core.enums.enum_backend_type import EnumBackendType
 from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
@@ -15,12 +15,21 @@ from omnibase_core.enums.enum_scalability_level import EnumScalabilityLevel
 from omnibase_core.enums.enum_security_level import EnumSecurityLevel
 from omnibase_core.enums.enum_throughput_level import EnumThroughputLevel
 from omnibase_core.models.errors.model_onex_error import ModelOnexError
+from omnibase_core.overlays.contract_env_ref import resolve_contract_env_binding
 
 from .model_backend_capabilities import ModelBackendCapabilities
 from .model_backend_config import ModelBackendConfig
 from .model_backend_config_validation import ModelBackendConfigValidation
 from .model_backend_performance_profile import ModelBackendPerformanceProfile
 from .model_backend_security_profile import ModelBackendSecurityProfile
+
+# Declared contract-env references for CI platform detection (OMN-17554).
+CI_INDICATOR_BINDINGS: tuple[str, ...] = (
+    "${env.CI}",
+    "${env.CONTINUOUS_INTEGRATION}",
+    "${env.GITHUB_ACTIONS}",
+    "${env.GITLAB_CI}",
+)
 
 
 class ModelSecretBackend(BaseModel):
@@ -36,6 +45,11 @@ class ModelSecretBackend(BaseModel):
     - Security assessment and best practices
     - Performance characteristics analysis
     """
+
+    # OMN-14515 ratchet: this model was baselined without an explicit
+    # extra= setting, so Pydantic silently dropped unknown fields. Touching
+    # its body (OMN-17554) is the moment to fix it.
+    model_config = ConfigDict(extra="forbid")
 
     backend_type: EnumBackendType = Field(
         default=EnumBackendType.ENVIRONMENT,
@@ -225,15 +239,24 @@ class ModelSecretBackend(BaseModel):
         # Check for development environment indicators
         if (
             Path(".env").exists()
+            # fallback-ok: platform detection, not dispatch degradation. Each of
+            # these four signals independently indicates a developer machine; no
+            # ordered chain of handlers silently degrades through them. The
+            # structural reads are owned by OMN-17525 / OMN-17555.
             or Path(".env.local").exists()
             or os.getenv("NODE_ENV") == "development"
             or os.getenv("ENVIRONMENT") == "development"
         ):
             return "development"
 
-        # Check for CI environment
-        ci_indicators = ["CI", "CONTINUOUS_INTEGRATION", "GITHUB_ACTIONS", "GITLAB_CI"]
-        if any(os.getenv(indicator) for indicator in ci_indicators):
+        # Check for CI environment. The indicators are declared as literal
+        # ${env.VAR} references and resolved through the sanctioned overlay
+        # boundary (OMN-17554); the loop that read os.getenv on a computed name
+        # was invisible to the env-read gate.
+        if any(
+            resolve_contract_env_binding(reference).value
+            for reference in CI_INDICATOR_BINDINGS
+        ):
             return "ci"
 
         # Default to production

--- a/src/omnibase_core/models/security/model_secure_credentials.py
+++ b/src/omnibase_core/models/security/model_secure_credentials.py
@@ -7,9 +7,13 @@ import re
 from abc import ABC, abstractmethod
 from typing import Any, TypeVar
 
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel, ConfigDict, SecretStr
 
 from omnibase_core.errors.exception_groups import VALIDATION_ERRORS
+from omnibase_core.overlays.contract_env_ref import (
+    contract_env_reference,
+    resolve_contract_env_binding,
+)
 
 from .model_audit_data import ModelAuditData
 from .model_credential_validation_result import ModelCredentialValidationResult
@@ -38,6 +42,11 @@ class ModelSecureCredentials(BaseModel, ABC):
     - Field-level security classification
     - Audit trail support
     """
+
+    # OMN-14515 ratchet: this model was baselined without an explicit
+    # extra= setting, so Pydantic silently dropped unknown fields. Touching
+    # its body (OMN-17554) is the moment to fix it.
+    model_config = ConfigDict(extra="forbid")
 
     # === Abstract Methods ===
 
@@ -207,28 +216,42 @@ class ModelSecureCredentials(BaseModel, ABC):
     # === Environment Integration ===
 
     def validate_environment_variables(self, env_prefix: str = "ONEX_") -> list[str]:
-        """Validate that required environment variables are available."""
+        """Validate that every required declared binding resolves."""
         issues = []
 
         for field_name, field_info in self.__class__.model_fields.items():
             if field_info.is_required():
-                env_var_name = f"{env_prefix}{field_name.upper()}"
-                if not os.getenv(env_var_name):
+                binding = resolve_contract_env_binding(
+                    self.get_environment_bindings(env_prefix)[field_name]
+                )
+                if not binding.value:
                     issues.append(
-                        f"Missing required environment variable: {env_var_name}",
+                        f"Missing required environment variable: {binding.name}",
                     )
 
         return issues
 
+    def get_environment_bindings(self, env_prefix: str = "ONEX_") -> dict[str, str]:
+        """Declare one ``${env.VAR}`` contract reference per model field.
+
+        This is the model's own binding declaration: the field set is the
+        declaration, and the canonical reference builder fails closed on any
+        name that is not a legal identifier (OMN-17554). Resolution happens
+        through the sanctioned overlay boundary, never here.
+        """
+        return {
+            field_name: contract_env_reference(f"{env_prefix}{field_name.upper()}")
+            for field_name in self.__class__.model_fields
+        }
+
     def get_environment_mapping(self, env_prefix: str = "ONEX_") -> dict[str, str]:
         """Get mapping of model fields to environment variable names."""
-        mapping = {}
-
-        for field_name in self.__class__.model_fields:
-            env_var_name = f"{env_prefix}{field_name.upper()}"
-            mapping[field_name] = env_var_name
-
-        return mapping
+        return {
+            field_name: resolve_contract_env_binding(reference).name
+            for field_name, reference in self.get_environment_bindings(
+                env_prefix
+            ).items()
+        }
 
     def load_from_environment_with_validation(
         self,
@@ -236,10 +259,11 @@ class ModelSecureCredentials(BaseModel, ABC):
     ) -> list[str]:
         """Load values from environment with validation, return any issues."""
         issues = []
-        env_mapping = self.get_environment_mapping(env_prefix)
 
-        for field_name, env_var in env_mapping.items():
-            env_value = os.getenv(env_var)
+        for field_name, reference in self.get_environment_bindings(env_prefix).items():
+            binding = resolve_contract_env_binding(reference)
+            env_var = binding.name
+            env_value = binding.value
             if env_value:
                 try:
                     # Attempt to set the field value

--- a/src/omnibase_core/overlays/contract_env_ref.py
+++ b/src/omnibase_core/overlays/contract_env_ref.py
@@ -19,12 +19,30 @@ reference without reaching upward into infra.
 An unset var with no inline default expands to the empty string, so the caller's
 fail-closed check rejects it (rather than leaving a literal ``${env.…}``
 placeholder, or silently falling back to localhost).
+
+Two surfaces, one boundary
+--------------------------
+
+:func:`expand_contract_env_refs` substitutes references inside a larger string
+(an endpoint template, a path). :func:`resolve_contract_env_binding` resolves a
+single reference and returns a typed
+:class:`~omnibase_core.models.configuration.model_contract_env_binding.ModelContractEnvBinding`
+that preserves whether the variable was *declared* at all — the distinction
+substitution throws away, and the one every configuration override in this repo
+turns on. Product code declares its bindings as ``${env.NAME}`` references and
+resolves them here (OMN-17554); it does not read the environment itself.
 """
 
 from __future__ import annotations
 
 import os
 import re
+
+from omnibase_core.enums.enum_core_error_code import EnumCoreErrorCode
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.models.configuration.model_contract_env_binding import (
+    ModelContractEnvBinding,
+)
 
 # ``${env.VAR}`` / ``${env.VAR:default}`` — the same env-overlay convention
 # the infra runtime overlay and node_contract_loader_effect use for endpoints.
@@ -50,4 +68,63 @@ def expand_contract_env_refs(value: str) -> str:
     return _ENV_REF.sub(_sub, value)
 
 
-__all__: list[str] = ["expand_contract_env_refs"]
+# A bare variable name, i.e. what goes between ``${env.`` and ``}``.
+_ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# A string that is exactly one reference and nothing else.
+_ENV_REF_EXACT = re.compile(f"^{_ENV_REF.pattern}$")
+
+
+def contract_env_reference(name: str, default: str | None = None) -> str:
+    """Render the canonical ``${env.NAME}`` / ``${env.NAME:default}`` reference.
+
+    Fails closed on a name that is not a legal environment variable identifier,
+    so a caller that derives reference names from a declared field set cannot
+    silently emit an unresolvable reference.
+    """
+    if not _ENV_NAME.match(name):
+        raise ModelOnexError(
+            f"{name!r} is not a legal environment variable name; a contract env "
+            "reference must name an identifier.",
+            EnumCoreErrorCode.INVALID_CONFIGURATION,
+        )
+    if default is None:
+        return f"${{env.{name}}}"
+    if "}" in default:
+        raise ModelOnexError(
+            "a contract env reference default must not contain '}'.",
+            EnumCoreErrorCode.INVALID_CONFIGURATION,
+        )
+    return f"${{env.{name}:{default}}}"
+
+
+def resolve_contract_env_binding(reference: str) -> ModelContractEnvBinding:
+    """Resolve exactly one ``${env.VAR}`` / ``${env.VAR:default}`` reference.
+
+    Fails closed: a malformed, unclosed, or non-reference string raises rather
+    than being passed through as a literal. An unset variable with no inline
+    default resolves to ``bound=False, value=None`` so the caller can leave its
+    typed default in place instead of overriding it with an empty string.
+    """
+    match = _ENV_REF_EXACT.match(reference)
+    if match is None:
+        raise ModelOnexError(
+            f"{reference!r} is not a single ${{env.VAR}} contract reference.",
+            EnumCoreErrorCode.INVALID_CONFIGURATION,
+        )
+    name = match.group("name")
+    default = match.group("default")
+    declared = os.environ.get(name)
+    return ModelContractEnvBinding(
+        name=name,
+        reference=reference,
+        bound=declared is not None,
+        value=declared if declared is not None else default,
+    )
+
+
+__all__: list[str] = [
+    "contract_env_reference",
+    "expand_contract_env_refs",
+    "resolve_contract_env_binding",
+]

--- a/src/omnibase_core/utils/util_workflow_executor.py
+++ b/src/omnibase_core/utils/util_workflow_executor.py
@@ -52,22 +52,18 @@ v1.0.4 Additional Fixes (OMN-661):
 
 Size Limits:
     To prevent memory exhaustion, this module enforces the following limits:
-    - MAX_WORKFLOW_STEPS (default 1000): Maximum number of steps in a workflow.
+    - MAX_WORKFLOW_STEPS (1000): Maximum number of steps in a workflow.
       Validated during workflow validation; raises ModelOnexError if exceeded.
-    - MAX_STEP_PAYLOAD_SIZE_BYTES (default 64KB): Maximum size of individual step payload.
+    - MAX_STEP_PAYLOAD_SIZE_BYTES (64KB): Maximum size of individual step payload.
       Validated during action creation; raises ModelOnexError if exceeded.
-    - MAX_TOTAL_PAYLOAD_SIZE_BYTES (default 10MB): Maximum accumulated payload size.
+    - MAX_TOTAL_PAYLOAD_SIZE_BYTES (10MB): Maximum accumulated payload size.
       In parallel mode, raises ModelOnexError. In sequential mode, treated as
       a step failure (per error_action configuration, defaults to continue).
 
-    These limits are configurable via environment variables for extreme workloads:
-    - ONEX_MAX_WORKFLOW_STEPS: Override max workflow steps (bounds: 1-100,000)
-    - ONEX_MAX_STEP_PAYLOAD_SIZE_BYTES: Override max step payload size (bounds: 1KB-10MB)
-    - ONEX_MAX_TOTAL_PAYLOAD_SIZE_BYTES: Override max total payload size (bounds: 1KB-1GB)
-
-    Invalid environment variable values log a warning and fall back to defaults.
-    Bounds are enforced to prevent both DoS attacks (too-small limits causing many
-    small workflows) and memory exhaustion (too-large limits).
+    All three are fixed, immutable Core ceilings (OMN-17554). They are not
+    configurable by environment variable or by contract, and a workflow
+    contract cannot raise or lower them: they are the DoS protection itself,
+    so a configuration surface for them would be a surface for disabling it.
 
 Security Considerations:
     Compression Attacks:
@@ -862,6 +858,10 @@ async def _execute_sequential(
 
         except Exception as e:
             # boundary-ok: workflow steps execute external code with unknown exception types
+            # fallback-ok: a failed step is a workflow OUTCOME here, not an error to
+            # re-raise. The step is recorded in failed_steps, logged with its full
+            # traceback, and the workflow's declared error_action ("stop" / "continue")
+            # decides what happens next. Re-raising would make error_action unreachable.
             # Production workflows require resilient error handling - all failures logged
             # with full traceback for debugging. Failed steps tracked per error_action config.
             failed_steps.append(str(step.step_id))

--- a/src/omnibase_core/validators/extra_forbid_baseline.yaml
+++ b/src/omnibase_core/validators/extra_forbid_baseline.yaml
@@ -8,7 +8,7 @@
 # an entry here becomes compliant, forcing the count down. Do not hand-add.
 #
 # scan roots: src/omnibase_core
-# count: 1108
+# count: 1103
 #
 # Regenerate: python -m omnibase_core.validators.pydantic_extra_forbid \
 #     --write-baseline src/omnibase_core
@@ -91,9 +91,7 @@ violations:
   - "omnibase_core.models.configuration.model_configuration_merge_result:ModelConfigurationMergeResult"
   - "omnibase_core.models.configuration.model_custom_resource_limits:ModelCustomResourceLimits"
   - "omnibase_core.models.configuration.model_database_config:ModelDatabaseConfig"
-  - "omnibase_core.models.configuration.model_database_connection_config:ModelDatabaseConnectionConfig"
   - "omnibase_core.models.configuration.model_database_secure_config:ModelComplianceStatus"
-  - "omnibase_core.models.configuration.model_database_secure_config:ModelDatabaseSecureConfig"
   - "omnibase_core.models.configuration.model_database_secure_config:ModelPerformanceProfile"
   - "omnibase_core.models.configuration.model_database_secure_config:ModelSecurityAssessment"
   - "omnibase_core.models.configuration.model_dict_config:ModelDictConfig"
@@ -150,7 +148,6 @@ violations:
   - "omnibase_core.models.configuration.model_request_summary:ModelRequestSummary"
   - "omnibase_core.models.configuration.model_resource_allocation:ModelResourceAllocation"
   - "omnibase_core.models.configuration.model_resource_limits:ModelResourceLimits"
-  - "omnibase_core.models.configuration.model_rest_api_connection_config:ModelRestApiConnectionConfig"
   - "omnibase_core.models.configuration.model_schedule_trigger:ModelScheduleTrigger"
   - "omnibase_core.models.configuration.model_serialized_block:ModelSerializedBlock"
   - "omnibase_core.models.configuration.model_service_container:ModelServiceContainer"
@@ -1016,11 +1013,9 @@ violations:
   - "omnibase_core.models.security.model_risk_assessment:ModelRiskAssessment"
   - "omnibase_core.models.security.model_rule_condition_class:ModelRuleCondition"
   - "omnibase_core.models.security.model_rule_condition_value:ModelRuleConditionValue"
-  - "omnibase_core.models.security.model_secret_backend:ModelSecretBackend"
   - "omnibase_core.models.security.model_secret_config:ModelSecretConfig"
   - "omnibase_core.models.security.model_secret_health_check_result:ModelSecretHealthCheckResult"
   - "omnibase_core.models.security.model_secret_manager:ModelSecretManager"
-  - "omnibase_core.models.security.model_secure_credentials:ModelSecureCredentials"
   - "omnibase_core.models.security.model_secure_mask_config:ModelSecureMaskConfig"
   - "omnibase_core.models.security.model_security_context:ModelSecurityContext"
   - "omnibase_core.models.security.model_security_event:ModelSecurityEvent"

--- a/tests/test_doctor/test_checks_env.py
+++ b/tests/test_doctor/test_checks_env.py
@@ -1,46 +1,295 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 
+"""Adapter-level proof for the typed configuration binding check (OMN-17554).
+
+``CheckEnvVars`` used to read ``os.environ`` directly, so ``onex doctor`` could
+only ever assert that some ambient string was non-empty. It now resolves the
+declared typed binding out of ``~/.onex/config.yaml`` through a single bounded
+read, a single non-writing recursive projection onto the declared
+``ModelCliUserConfig`` fields and aliases, and exactly one model validation.
+
+These tests assert the internal outcome code. The public result — one
+``env_vars`` / ``ENVIRONMENT`` row per doctor invocation, with a fixed
+secret-safe message — is asserted separately over the production Click route in
+``test_cli.py``.
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from omnibase_core.doctor.checks.check_env_vars import CheckEnvVars
-
-pytestmark = pytest.mark.unit
+from omnibase_core.doctor.checks.check_env_vars import (
+    CheckEnvVars,
+    default_user_config_path,
+)
 from omnibase_core.doctor.checks.check_js_runtime import CheckJsRuntime
 from omnibase_core.doctor.checks.check_python_version import CheckPythonVersion
+from omnibase_core.doctor.doctor_check_base import DoctorCheckBase
 from omnibase_core.enums.enum_doctor_category import EnumDoctorCategory
+from omnibase_core.enums.enum_doctor_config_load_code import EnumDoctorConfigLoadCode
 from omnibase_core.enums.enum_health_status_value import EnumHealthStatusValue
 
+pytestmark = pytest.mark.unit
 
-def test_env_vars_all_set():
-    env = {
-        "LINEAR_API_KEY": "lin_abc",  # pragma: allowlist secret
-        "OMNICLAUDE_PROJECT_ROOT": "/some/path",
-    }
-    with patch.dict("os.environ", env, clear=False):
-        result = CheckEnvVars().run()
-    assert result.category == EnumDoctorCategory.ENVIRONMENT
+SECRET_SENTINEL = "SECRET_SENTINEL_lin_do_not_render"  # pragma: allowlist secret
+_VALID_CONFIG = """\
+version: 1
+mode: local
+credentials:
+  LINEAR_API_KEY: lin_bound_value
+paths:
+  state_dir: ~/.onex/state
+"""
 
 
-def test_env_vars_missing():
-    with patch.dict("os.environ", {}, clear=True):
-        result = CheckEnvVars().run()
-    assert result.status in (
-        EnumHealthStatusValue.DEGRADED,
-        EnumHealthStatusValue.UNHEALTHY,
+def _write(tmp_path: Path, text: str, *, encoding: str = "utf-8") -> Path:
+    path = tmp_path / "config.yaml"
+    path.write_bytes(text.encode(encoding))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Binding source identity
+# ---------------------------------------------------------------------------
+
+
+def test_default_path_is_the_shared_user_config_path() -> None:
+    """The doctor resolves the same file every other ONEX command writes.
+
+    ``check_env_vars`` cannot import ``omnibase_core.cli.cli_user_config``
+    (doctor -> cli would close an import cycle: ``cli.cli_doctor`` already
+    imports this package), so the two resolvers are pinned here instead of
+    shared through an import.
+    """
+    from omnibase_core.cli.cli_user_config import user_config_path
+
+    assert default_user_config_path() == user_config_path()
+
+
+# ---------------------------------------------------------------------------
+# Bounded, provenance-scoped load classification
+# ---------------------------------------------------------------------------
+
+
+def test_missing_file_is_missing(tmp_path: Path) -> None:
+    check = CheckEnvVars(config_path=tmp_path / "absent.yaml")
+    assert check.outcome_code is EnumDoctorConfigLoadCode.MISSING
+    assert check.config is None
+
+
+def test_ambient_env_cannot_alter_a_missing_binding(tmp_path: Path) -> None:
+    """No ambient fallback: an exported value is not a declared binding."""
+    with patch.dict(
+        "os.environ",
+        {"LINEAR_API_KEY": "lin_ambient"},  # pragma: allowlist secret
+        clear=False,
+    ):
+        check = CheckEnvVars(config_path=tmp_path / "absent.yaml")
+    assert check.outcome_code is EnumDoctorConfigLoadCode.MISSING
+    assert check.run().status is EnumHealthStatusValue.UNHEALTHY
+
+
+def test_empty_document_is_empty(tmp_path: Path) -> None:
+    check = CheckEnvVars(config_path=_write(tmp_path, "\n# only a comment\n"))
+    assert check.outcome_code is EnumDoctorConfigLoadCode.EMPTY
+
+
+def test_unreadable_file_is_unreadable(tmp_path: Path) -> None:
+    path = _write(tmp_path, _VALID_CONFIG)
+    path.chmod(stat.S_IWUSR)
+    try:
+        check = CheckEnvVars(config_path=path)
+        assert check.outcome_code is EnumDoctorConfigLoadCode.UNREADABLE
+    finally:
+        path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def test_non_utf8_file_is_invalid_encoding(tmp_path: Path) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_bytes(b"credentials:\n  LINEAR_API_KEY: \xff\xfe\n")
+    check = CheckEnvVars(config_path=path)
+    assert check.outcome_code is EnumDoctorConfigLoadCode.INVALID_ENCODING
+
+
+def test_malformed_yaml_is_invalid_yaml(tmp_path: Path) -> None:
+    check = CheckEnvVars(config_path=_write(tmp_path, "credentials: [unclosed\n"))
+    assert check.outcome_code is EnumDoctorConfigLoadCode.INVALID_YAML
+
+
+def test_non_mapping_source_shape_is_invalid_yaml(tmp_path: Path) -> None:
+    check = CheckEnvVars(config_path=_write(tmp_path, "- a\n- b\n"))
+    assert check.outcome_code is EnumDoctorConfigLoadCode.INVALID_YAML
+
+
+def test_invalid_projected_model_is_invalid_model(tmp_path: Path) -> None:
+    check = CheckEnvVars(
+        config_path=_write(
+            tmp_path, f"credentials:\n  LINEAR_API_KEY: [{SECRET_SENTINEL}]\n"
+        )
     )
+    assert check.outcome_code is EnumDoctorConfigLoadCode.INVALID_MODEL
+    assert check.config is None
+    assert SECRET_SENTINEL not in check.run().message
 
 
-def test_python_version():
+def test_invalid_scalar_section_is_invalid_model(tmp_path: Path) -> None:
+    """A declared child that is not a mapping reaches the one validation."""
+    check = CheckEnvVars(config_path=_write(tmp_path, "credentials: not-a-mapping\n"))
+    assert check.outcome_code is EnumDoctorConfigLoadCode.INVALID_MODEL
+
+
+# ---------------------------------------------------------------------------
+# Recursive, non-writing projection
+# ---------------------------------------------------------------------------
+
+
+def test_valid_binding_carries_the_typed_model(tmp_path: Path) -> None:
+    check = CheckEnvVars(config_path=_write(tmp_path, _VALID_CONFIG))
+    assert check.outcome_code is EnumDoctorConfigLoadCode.VALID
+    config = check.config
+    assert config is not None
+    assert config.credentials.linear_api_key == "lin_bound_value"
+    assert config.paths.state_dir == "~/.onex/state"
+
+
+def test_immediate_unknown_key_is_projected_away_without_a_write(
+    tmp_path: Path,
+) -> None:
+    source = (
+        "version: 1\n"
+        "aws:\n"
+        "  UNRELATED_SENTINEL: keep-me\n"
+        "credentials:\n"
+        "  LINEAR_API_KEY: lin_bound_value\n"
+    )
+    path = _write(tmp_path, source)
+    before = path.read_bytes()
+    check = CheckEnvVars(config_path=path)
+    assert check.outcome_code is EnumDoctorConfigLoadCode.VALID
+    assert path.read_bytes() == before
+
+
+def test_nested_declared_child_alias_and_unknown_key(tmp_path: Path) -> None:
+    """The projection recurses: a nested unknown key never reaches validation.
+
+    ``ModelCliUserConfigCredentials`` is ``extra="forbid"``, so a one-layer
+    projection that retained the ``credentials`` mapping wholesale would fail
+    validation here instead of returning ``VALID``.
+    """
+    source = (
+        "credentials:\n"
+        "  LINEAR_API_KEY: lin_bound_value\n"
+        "  NESTED_UNKNOWN_SENTINEL: keep-me\n"
+    )
+    path = _write(tmp_path, source)
+    before = path.read_bytes()
+    check = CheckEnvVars(config_path=path)
+    assert check.outcome_code is EnumDoctorConfigLoadCode.VALID
+    config = check.config
+    assert config is not None
+    assert config.credentials.linear_api_key == "lin_bound_value"
+    assert "NESTED_UNKNOWN_SENTINEL" not in config.model_dump_json()
+    assert b"NESTED_UNKNOWN_SENTINEL" in path.read_bytes()
+    assert path.read_bytes() == before
+
+
+def test_declared_child_field_name_is_accepted_alongside_its_alias(
+    tmp_path: Path,
+) -> None:
+    check = CheckEnvVars(
+        config_path=_write(tmp_path, "credentials:\n  linear_api_key: lin_by_name\n")
+    )
+    assert check.outcome_code is EnumDoctorConfigLoadCode.VALID
+    config = check.config
+    assert config is not None
+    assert config.credentials.linear_api_key == "lin_by_name"
+
+
+def test_absent_section_is_omitted_not_injected(tmp_path: Path) -> None:
+    """Absent sections take model defaults; the projection injects no ``{}``."""
+    check = CheckEnvVars(
+        config_path=_write(
+            tmp_path, "credentials:\n  LINEAR_API_KEY: lin_bound_value\n"
+        )
+    )
+    assert check.outcome_code is EnumDoctorConfigLoadCode.VALID
+    config = check.config
+    assert config is not None
+    assert config.kafka.bootstrap_servers == "localhost:19092"
+    assert config.logging.level == "INFO"
+
+
+# ---------------------------------------------------------------------------
+# Public result mapping
+# ---------------------------------------------------------------------------
+
+
+def test_valid_but_empty_binding_is_a_missing_binding(tmp_path: Path) -> None:
+    check = CheckEnvVars(
+        config_path=_write(tmp_path, 'credentials:\n  LINEAR_API_KEY: ""\n')
+    )
+    assert check.outcome_code is EnumDoctorConfigLoadCode.VALID
+    result = check.run()
+    assert result.status is EnumHealthStatusValue.UNHEALTHY
+    assert result.message == "Missing: LINEAR_API_KEY"
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_message"),
+    [
+        ("", "Missing: LINEAR_API_KEY"),
+        ("- a\n", "User configuration contains invalid YAML."),
+        ("credentials: [unclosed\n", "User configuration contains invalid YAML."),
+        (
+            "credentials:\n  LINEAR_API_KEY: [x]\n",
+            "Managed user configuration is invalid.",
+        ),
+    ],
+)
+def test_public_result_is_environment_and_fixed(
+    tmp_path: Path, source: str, expected_message: str
+) -> None:
+    result = CheckEnvVars(config_path=_write(tmp_path, source)).run()
+    assert result.name == "env_vars"
+    assert result.category is EnumDoctorCategory.ENVIRONMENT
+    assert result.status is EnumHealthStatusValue.UNHEALTHY
+    assert result.message == expected_message
+
+
+def test_healthy_result_is_fixed_and_leaks_nothing(tmp_path: Path) -> None:
+    result = CheckEnvVars(config_path=_write(tmp_path, _VALID_CONFIG)).run()
+    assert result.name == "env_vars"
+    assert result.category is EnumDoctorCategory.ENVIRONMENT
+    assert result.status is EnumHealthStatusValue.HEALTHY
+    assert result.message == "All required configuration bindings present"
+    assert "lin_bound_value" not in result.model_dump_json()
+
+
+def test_adapter_is_zero_arg_constructible_for_the_registry() -> None:
+    """``DoctorRegistry.list_all()`` calls ``cls()``; no config error may escape."""
+    check = CheckEnvVars()
+    assert isinstance(check, DoctorCheckBase)
+    assert check.check_id == "env_vars"
+    assert isinstance(check.outcome_code, EnumDoctorConfigLoadCode)
+
+
+# ---------------------------------------------------------------------------
+# Unrelated environment checks (unchanged coverage)
+# ---------------------------------------------------------------------------
+
+
+def test_python_version() -> None:
     result = CheckPythonVersion().run()
     assert result.category == EnumDoctorCategory.ENVIRONMENT
-    # We're running on 3.12+, so this should pass
     assert result.status == EnumHealthStatusValue.HEALTHY
 
 
-def test_node_version_present():
+def test_node_version_present() -> None:
     with patch("subprocess.run") as mock_run:
         mock_run.return_value.returncode = 0
         mock_run.return_value.stdout = "v20.11.0\n"

--- a/tests/test_doctor/test_checks_env.py
+++ b/tests/test_doctor/test_checks_env.py
@@ -37,6 +37,11 @@ from omnibase_core.enums.enum_health_status_value import EnumHealthStatusValue
 pytestmark = pytest.mark.unit
 
 SECRET_SENTINEL = "SECRET_SENTINEL_lin_do_not_render"  # pragma: allowlist secret
+# Synthetic fixture values. Named so the assertion that reads one back is not
+# itself a `linear_api_key == "<literal>"` line, which the secret scanner reads
+# as a hardcoded credential.
+_BOUND_VALUE = "lin_bound_value"  # pragma: allowlist secret
+_BY_NAME_VALUE = "lin_by_name"  # pragma: allowlist secret
 _VALID_CONFIG = """\
 version: 1
 mode: local
@@ -153,7 +158,7 @@ def test_valid_binding_carries_the_typed_model(tmp_path: Path) -> None:
     assert check.outcome_code is EnumDoctorConfigLoadCode.VALID
     config = check.config
     assert config is not None
-    assert config.credentials.linear_api_key == "lin_bound_value"
+    assert config.credentials.linear_api_key == _BOUND_VALUE
     assert config.paths.state_dir == "~/.onex/state"
 
 
@@ -192,7 +197,7 @@ def test_nested_declared_child_alias_and_unknown_key(tmp_path: Path) -> None:
     assert check.outcome_code is EnumDoctorConfigLoadCode.VALID
     config = check.config
     assert config is not None
-    assert config.credentials.linear_api_key == "lin_bound_value"
+    assert config.credentials.linear_api_key == _BOUND_VALUE
     assert "NESTED_UNKNOWN_SENTINEL" not in config.model_dump_json()
     assert b"NESTED_UNKNOWN_SENTINEL" in path.read_bytes()
     assert path.read_bytes() == before
@@ -202,12 +207,15 @@ def test_declared_child_field_name_is_accepted_alongside_its_alias(
     tmp_path: Path,
 ) -> None:
     check = CheckEnvVars(
-        config_path=_write(tmp_path, "credentials:\n  linear_api_key: lin_by_name\n")
+        config_path=_write(
+            tmp_path,
+            "credentials:\n  linear_api_key: lin_by_name\n",  # pragma: allowlist secret
+        )
     )
     assert check.outcome_code is EnumDoctorConfigLoadCode.VALID
     config = check.config
     assert config is not None
-    assert config.credentials.linear_api_key == "lin_by_name"
+    assert config.credentials.linear_api_key == _BY_NAME_VALUE
 
 
 def test_absent_section_is_omitted_not_injected(tmp_path: Path) -> None:

--- a/tests/test_doctor/test_cli.py
+++ b/tests/test_doctor/test_cli.py
@@ -60,3 +60,221 @@ def test_doctor_exits_nonzero_on_failure():
         ]
         result = runner.invoke(doctor, [])
     assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Production Click route over the typed configuration binding (OMN-17554)
+# ---------------------------------------------------------------------------
+#
+# These exercise the real `onex doctor` command end to end. The only thing
+# substituted is the location of the user config file; the registry, the
+# adapter, `run_all()` and both renderers are production code. Discovery is
+# disabled and the built-in list is narrowed to the env-binding check so the
+# result count is exactly one and every assertion is about this check.
+
+import json
+import logging
+from pathlib import Path
+
+from omnibase_core.doctor.checks.check_env_vars import CheckEnvVars
+from omnibase_core.enums.enum_doctor_config_load_code import EnumDoctorConfigLoadCode
+
+_PATH_SENTINEL = "PATH_SENTINEL_config_dir"
+_SECRET_SENTINEL = "SECRET_SENTINEL_lin_do_not_render"  # pragma: allowlist secret
+_PARSER_SENTINEL = "PARSER_SENTINEL_unclosed"
+
+_BOUND_CONFIG = """\
+version: 1
+mode: local
+credentials:
+  LINEAR_API_KEY: lin_bound_value
+"""
+
+
+def _config_at(tmp_path: Path, text: str, *, raw: bytes | None = None) -> Path:
+    directory = tmp_path / _PATH_SENTINEL
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "config.yaml"
+    path.write_bytes(text.encode("utf-8") if raw is None else raw)
+    return path
+
+
+def _run_doctor(config_path: Path, args: list[str]):
+    runner = CliRunner()
+    with (
+        patch("omnibase_core.cli.cli_doctor._BUILTIN_CHECKS", [CheckEnvVars]),
+        patch(
+            "omnibase_core.doctor.doctor_registry.DoctorRegistry.discover",
+            lambda self: None,
+        ),
+        patch(
+            "omnibase_core.doctor.checks.check_env_vars.default_user_config_path",
+            lambda: config_path,
+        ),
+    ):
+        return runner.invoke(doctor, args)
+
+
+def _sole_check(result) -> dict[str, object]:
+    payload = json.loads(result.output)
+    assert payload["total"] == 1, payload
+    checks = payload["checks"]
+    assert len(checks) == 1, checks
+    return dict(checks[0])
+
+
+def _assert_absent(result, caplog, *sentinels: str) -> None:
+    """Every sentinel is absent from every rendering surface."""
+    surfaces = {
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "exception": "" if result.exception is None else repr(result.exception),
+        "logs": caplog.text,
+    }
+    for name, text in surfaces.items():
+        for sentinel in sentinels:
+            assert sentinel not in text, f"{sentinel!r} leaked into {name}: {text!r}"
+
+
+@pytest.mark.parametrize(
+    ("body", "raw", "code", "message"),
+    [
+        (None, None, EnumDoctorConfigLoadCode.MISSING, "Missing: LINEAR_API_KEY"),
+        ("\n", None, EnumDoctorConfigLoadCode.EMPTY, "Missing: LINEAR_API_KEY"),
+        (
+            f"credentials: [{_PARSER_SENTINEL}\n",
+            None,
+            EnumDoctorConfigLoadCode.INVALID_YAML,
+            "User configuration contains invalid YAML.",
+        ),
+        (
+            None,
+            b"credentials:\n  LINEAR_API_KEY: \xff\xfe\n",
+            EnumDoctorConfigLoadCode.INVALID_ENCODING,
+            "User configuration has invalid text encoding.",
+        ),
+        (
+            f"credentials:\n  LINEAR_API_KEY: [{_SECRET_SENTINEL}]\n",
+            None,
+            EnumDoctorConfigLoadCode.INVALID_MODEL,
+            "Managed user configuration is invalid.",
+        ),
+    ],
+)
+def test_doctor_unhealthy_binding_rows(tmp_path, caplog, body, raw, code, message):
+    if body is None and raw is None:
+        config_path = tmp_path / _PATH_SENTINEL / "absent.yaml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        config_path = _config_at(tmp_path, body or "", raw=raw)
+
+    assert CheckEnvVars(config_path=config_path).outcome_code is code
+
+    with caplog.at_level(logging.DEBUG):
+        human = _run_doctor(config_path, [])
+        json_result = _run_doctor(config_path, ["--json"])
+
+    assert human.exit_code == 1
+    assert json_result.exit_code == 1
+    assert "env_vars" in human.output
+    assert message in human.output
+
+    check = _sole_check(json_result)
+    assert check["name"] == "env_vars"
+    assert check["category"] == "environment"
+    assert check["status"] == "unhealthy"
+    assert check["message"] == message
+
+    _assert_absent(
+        human, caplog, _SECRET_SENTINEL, _PARSER_SENTINEL, _PATH_SENTINEL, "Traceback"
+    )
+    _assert_absent(
+        json_result,
+        caplog,
+        _SECRET_SENTINEL,
+        _PARSER_SENTINEL,
+        _PATH_SENTINEL,
+        "Traceback",
+    )
+
+
+def test_doctor_healthy_binding_row(tmp_path, caplog):
+    config_path = _config_at(tmp_path, _BOUND_CONFIG)
+    assert (
+        CheckEnvVars(config_path=config_path).outcome_code
+        is EnumDoctorConfigLoadCode.VALID
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        human = _run_doctor(config_path, [])
+        json_result = _run_doctor(config_path, ["--json"])
+
+    assert human.exit_code == 0
+    assert json_result.exit_code == 0
+
+    check = _sole_check(json_result)
+    assert check["name"] == "env_vars"
+    assert check["category"] == "environment"
+    assert check["status"] == "healthy"
+    assert check["message"] == "All required configuration bindings present"
+
+    _assert_absent(human, caplog, "lin_bound_value", _PATH_SENTINEL)
+    _assert_absent(json_result, caplog, "lin_bound_value", _PATH_SENTINEL)
+
+
+def test_doctor_ambient_env_cannot_bind(tmp_path, caplog):
+    """An exported LINEAR_API_KEY is not a declared binding and cannot pass."""
+    config_path = tmp_path / _PATH_SENTINEL / "absent.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with patch.dict(
+        "os.environ",
+        {"LINEAR_API_KEY": "lin_ambient_sentinel"},  # pragma: allowlist secret
+        clear=False,
+    ):
+        result = _run_doctor(config_path, ["--json"])
+    assert result.exit_code == 1
+    assert _sole_check(result)["message"] == "Missing: LINEAR_API_KEY"
+
+
+def test_doctor_never_calls_a_preprojection_normalizer(tmp_path):
+    """The doctor route must not reach `normalize_user_config` or any normalizer."""
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError("normalizer reached from the doctor boundary")
+
+    config_path = _config_at(tmp_path, _BOUND_CONFIG)
+    with (
+        patch("omnibase_core.cli.cli_user_config.normalize_user_config", _forbidden),
+        patch("omnibase_core.cli.cli_user_config.read_user_config", _forbidden),
+        patch("omnibase_core.cli.cli_user_config.write_user_config", _forbidden),
+        patch("omnibase_core.cli.cli_user_config.migrate_user_config_file", _forbidden),
+    ):
+        result = _run_doctor(config_path, ["--json"])
+    assert result.exit_code == 0
+    assert _sole_check(result)["status"] == "healthy"
+
+
+def test_registry_list_all_returns_an_adapter_for_every_invalid_outcome(tmp_path):
+    """`list_all()` yields one adapter without throwing; `run_all()` one result."""
+    from omnibase_core.doctor.doctor_registry import DoctorRegistry
+
+    cases = [
+        tmp_path / "absent.yaml",
+        _config_at(tmp_path, "\n"),
+        _config_at(tmp_path, "credentials: [unclosed\n"),
+        _config_at(tmp_path, "credentials:\n  LINEAR_API_KEY: [x]\n"),
+    ]
+    for config_path in cases:
+        registry = DoctorRegistry()
+        registry.register(CheckEnvVars)
+        with patch(
+            "omnibase_core.doctor.checks.check_env_vars.default_user_config_path",
+            lambda bound=config_path: bound,
+        ):
+            checks = registry.list_all()
+            assert len(checks) == 1
+            assert isinstance(checks[0], CheckEnvVars)
+            results = registry.run_all()
+        assert len(results) == 1
+        assert results[0].name == "env_vars"
+        assert results[0].status is EnumHealthStatusValue.UNHEALTHY

--- a/tests/unit/mixins/test_mixin_effect_execution.py
+++ b/tests/unit/mixins/test_mixin_effect_execution.py
@@ -463,6 +463,65 @@ class TestResolveIOContext:
                 test_node._resolve_io_context(io_config, input_data)
             assert "Environment variable not found" in str(exc_info.value)
 
+    def test_resolve_http_context_env_inline_default(self, test_node: TestNode) -> None:
+        """``${env.VAR:default}`` falls back when the variable is unbound.
+
+        Resolution goes through the sanctioned overlay boundary (OMN-17554),
+        which owns the reference grammar including the inline-default form.
+        """
+        io_config = ModelHttpIOConfig(
+            url_template="https://api.example.com/test",
+            method="GET",
+            headers={"Authorization": "Bearer ${env.OMN17554_UNSET:fallback_token}"},
+        )
+        input_data = ModelEffectInput(
+            effect_type=EnumEffectType.API_CALL,
+            operation_data={},
+        )
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = test_node._resolve_io_context(io_config, input_data)
+
+        assert isinstance(result, ModelResolvedHttpContext)
+        assert result.headers["Authorization"] == "Bearer fallback_token"
+
+    def test_resolve_http_context_bound_var_beats_inline_default(
+        self, test_node: TestNode
+    ) -> None:
+        io_config = ModelHttpIOConfig(
+            url_template="https://api.example.com/test",
+            method="GET",
+            headers={"Authorization": "Bearer ${env.OMN17554_BOUND:fallback_token}"},
+        )
+        input_data = ModelEffectInput(
+            effect_type=EnumEffectType.API_CALL,
+            operation_data={},
+        )
+
+        with patch.dict(os.environ, {"OMN17554_BOUND": "real_token"}, clear=True):
+            result = test_node._resolve_io_context(io_config, input_data)
+
+        assert isinstance(result, ModelResolvedHttpContext)
+        assert result.headers["Authorization"] == "Bearer real_token"
+
+    def test_resolve_http_context_illegal_env_name_fails_closed(
+        self, test_node: TestNode
+    ) -> None:
+        """A placeholder that is not a legal reference raises, never resolves empty."""
+        io_config = ModelHttpIOConfig(
+            url_template="https://api.example.com/test",
+            method="GET",
+            headers={"Authorization": "Bearer ${env.9NOT_AN_IDENTIFIER}"},
+        )
+        input_data = ModelEffectInput(
+            effect_type=EnumEffectType.API_CALL,
+            operation_data={},
+        )
+
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ModelOnexError):
+                test_node._resolve_io_context(io_config, input_data)
+
     def test_resolve_http_context_with_body_template(self, test_node: TestNode) -> None:
         """Test resolving HTTP context with body template."""
         io_config = ModelHttpIOConfig(

--- a/tests/unit/models/configuration/test_declared_env_binding_overrides.py
+++ b/tests/unit/models/configuration/test_declared_env_binding_overrides.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Configured / unconfigured behaviour of the declared binding tables (OMN-17554).
+
+Each migrated site declares its bindings as literal ``${env.VAR}`` contract
+references and resolves them through the sanctioned overlay boundary. These
+tests prove the three cases that matter for every one of them:
+
+* **unconfigured** — the typed default survives; nothing is overridden;
+* **configured** — the declared value is applied with its declared type;
+* **secret-carrying** — a credential resolves into a ``SecretStr`` and its
+  value does not appear in a repr or a serialization.
+
+They also pin each declared table against the field set it claims to bind, so a
+renamed field cannot leave a silently dead reference behind.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr
+
+from omnibase_core.infrastructure.node_config_provider import NodeConfigProvider
+from omnibase_core.models.configuration.model_database_connection_config import (
+    ModelDatabaseConnectionConfig,
+)
+from omnibase_core.models.configuration.model_event_bus_config import (
+    ModelEventBusConfig,
+)
+from omnibase_core.models.configuration.model_rest_api_connection_config import (
+    ModelRestApiConnectionConfig,
+)
+from omnibase_core.models.security.model_secret_backend import (
+    CI_INDICATOR_BINDINGS,
+    ModelSecretBackend,
+)
+from omnibase_core.overlays.contract_env_ref import resolve_contract_env_binding
+
+pytestmark = pytest.mark.unit
+
+_MODEL_TABLES = (
+    (ModelDatabaseConnectionConfig, ModelDatabaseConnectionConfig._ENV_BINDINGS),
+    (ModelRestApiConnectionConfig, ModelRestApiConnectionConfig._ENV_BINDINGS),
+    (ModelEventBusConfig, ModelEventBusConfig._ENV_BINDINGS),
+)
+_ALL_MODEL_REFERENCES = [
+    reference for _model, table in _MODEL_TABLES for _field, reference in table
+]
+_ALL_BOUND_NAMES = [
+    resolve_contract_env_binding(reference).name for reference in _ALL_MODEL_REFERENCES
+]
+
+
+@pytest.fixture
+def unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No declared binding is set, for any migrated site."""
+    for name in [
+        *_ALL_BOUND_NAMES,
+        *NodeConfigProvider._BINDINGS.values(),
+        *CI_INDICATOR_BINDINGS,
+    ]:
+        variable = name if not name.startswith("${env.") else name[6:-1]
+        monkeypatch.delenv(variable, raising=False)
+
+
+def _db_config() -> ModelDatabaseConnectionConfig:
+    return ModelDatabaseConnectionConfig(
+        host="declared.host",
+        port=5432,
+        database="declared_db",
+        username="declared_user",
+        password=SecretStr("declared-password"),  # pragma: allowlist secret
+    )
+
+
+# ---------------------------------------------------------------------------
+# Declared tables match the fields they claim to bind
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("model", "table"), _MODEL_TABLES)
+def test_every_declared_binding_names_a_real_field(model, table) -> None:
+    declared = [field for field, _reference in table]
+    unknown = set(declared) - set(model.model_fields)
+    assert unknown == set(), unknown
+    assert len(declared) == len(set(declared)), declared
+
+
+def test_every_declared_reference_is_resolvable() -> None:
+    """A malformed reference in a table fails closed at resolution, not silently."""
+    for reference in [
+        *_ALL_MODEL_REFERENCES,
+        *NodeConfigProvider._BINDINGS.values(),
+        *CI_INDICATOR_BINDINGS,
+    ]:
+        assert resolve_contract_env_binding(reference).reference == reference
+
+
+def test_node_config_provider_binds_every_default_key() -> None:
+    assert set(NodeConfigProvider._BINDINGS) == set(NodeConfigProvider._DEFAULTS)
+
+
+# ---------------------------------------------------------------------------
+# Database connection config
+# ---------------------------------------------------------------------------
+
+
+def test_database_unconfigured_keeps_declared_values(unconfigured: None) -> None:
+    config = _db_config()
+    assert config.apply_environment_overrides() is config
+
+
+def test_database_configured_applies_typed_overrides(
+    unconfigured: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ONEX_DB_HOST", "override.host")
+    monkeypatch.setenv("ONEX_DB_PORT", "6543")
+    monkeypatch.setenv("ONEX_DB_SSL_ENABLED", "true")
+    overridden = _db_config().apply_environment_overrides()
+    assert overridden.host == "override.host"
+    assert overridden.port == 6543
+    assert overridden.ssl_enabled is True
+
+
+def test_database_password_binding_stays_secret(
+    unconfigured: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(
+        "ONEX_DB_PASSWORD", "override-secret"
+    )  # pragma: allowlist secret
+    overridden = _db_config().apply_environment_overrides()
+    assert isinstance(overridden.password, SecretStr)
+    assert overridden.password.get_secret_value() == "override-secret"
+    assert "override-secret" not in repr(overridden)
+    assert "override-secret" not in overridden.model_dump_json()
+
+
+def test_database_invalid_numeric_binding_is_skipped(
+    unconfigured: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-numeric declared value leaves the typed default in place."""
+    monkeypatch.setenv("ONEX_DB_PORT", "not-a-port")
+    assert _db_config().apply_environment_overrides().port == 5432
+
+
+# ---------------------------------------------------------------------------
+# REST API connection config
+# ---------------------------------------------------------------------------
+
+
+def test_rest_unconfigured_keeps_declared_values(unconfigured: None) -> None:
+    config = ModelRestApiConnectionConfig(base_url="https://declared.example")
+    assert config.apply_environment_overrides() is config
+
+
+def test_rest_configured_applies_typed_overrides(
+    unconfigured: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ONEX_API_BASE_URL", "https://override.example")
+    monkeypatch.setenv("ONEX_API_MAX_RETRIES", "7")
+    overridden = ModelRestApiConnectionConfig(
+        base_url="https://declared.example"
+    ).apply_environment_overrides()
+    assert overridden.base_url == "https://override.example"
+    assert overridden.max_retries == 7
+
+
+def test_rest_api_key_binding_stays_secret(
+    unconfigured: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ONEX_API_KEY", "override-api-key")  # pragma: allowlist secret
+    overridden = ModelRestApiConnectionConfig(
+        base_url="https://declared.example"
+    ).apply_environment_overrides()
+    assert isinstance(overridden.api_key, SecretStr)
+    assert overridden.api_key.get_secret_value() == "override-api-key"
+    assert "override-api-key" not in repr(overridden)
+    assert "override-api-key" not in overridden.model_dump_json()
+
+
+# ---------------------------------------------------------------------------
+# Event bus config
+# ---------------------------------------------------------------------------
+
+
+def test_event_bus_unconfigured_keeps_declared_values(unconfigured: None) -> None:
+    config = ModelEventBusConfig(
+        bootstrap_servers=["declared:19092"], topics=["declared-topic"]
+    )
+    assert config.apply_environment_overrides() is config
+
+
+def test_event_bus_configured_applies_typed_overrides(
+    unconfigured: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ONEX_EVENT_BUS_BOOTSTRAP_SERVERS", "a:9092, b:9092")
+    monkeypatch.setenv("ONEX_EVENT_BUS_PARTITIONS", "12")
+    monkeypatch.setenv("ONEX_EVENT_BUS_ENABLE_AUTO_COMMIT", "false")
+    overridden = ModelEventBusConfig(
+        bootstrap_servers=["declared:19092"], topics=["declared-topic"]
+    ).apply_environment_overrides()
+    assert overridden.bootstrap_servers == ["a:9092", "b:9092"]
+    assert overridden.partitions == 12
+    assert overridden.enable_auto_commit is False
+
+
+def test_event_bus_sasl_password_binding_stays_secret(
+    unconfigured: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(
+        "ONEX_EVENT_BUS_SASL_PASSWORD",
+        "override-sasl",  # pragma: allowlist secret
+    )
+    overridden = ModelEventBusConfig(
+        bootstrap_servers=["declared:19092"], topics=["declared-topic"]
+    ).apply_environment_overrides()
+    assert isinstance(overridden.sasl_password, SecretStr)
+    assert overridden.sasl_password.get_secret_value() == "override-sasl"
+    assert "override-sasl" not in repr(overridden)
+
+
+# ---------------------------------------------------------------------------
+# Node config provider
+# ---------------------------------------------------------------------------
+
+
+def test_node_config_provider_unconfigured_uses_declared_defaults(
+    unconfigured: None,
+) -> None:
+    provider = NodeConfigProvider()
+    for key, default in NodeConfigProvider._DEFAULTS.items():
+        assert provider._config_cache[key] == default
+
+
+def test_node_config_provider_configured_applies_declared_types(
+    unconfigured: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ONEX_COMPUTE_MAX_PARALLEL_WORKERS", "16")
+    monkeypatch.setenv("ONEX_COMPUTE_PERFORMANCE_THRESHOLD_MS", "12.5")
+    monkeypatch.setenv("ONEX_ORCHESTRATOR_ACTION_EMISSION_ENABLED", "no")
+    provider = NodeConfigProvider()
+    assert provider._config_cache["compute.max_parallel_workers"] == 16
+    assert provider._config_cache["compute.performance_threshold_ms"] == 12.5
+    assert provider._config_cache["orchestrator.action_emission_enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Secret backend CI detection
+# ---------------------------------------------------------------------------
+
+
+def test_ci_detection_unconfigured_is_not_ci(
+    unconfigured: None, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("NODE_ENV", raising=False)
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+    backend = ModelSecretBackend(backend_type="environment")
+    assert backend.detect_environment_type() == "production"
+
+
+@pytest.mark.parametrize(
+    "indicator", ["CI", "CONTINUOUS_INTEGRATION", "GITHUB_ACTIONS", "GITLAB_CI"]
+)
+def test_ci_detection_configured_is_ci(
+    unconfigured: None, monkeypatch: pytest.MonkeyPatch, tmp_path, indicator: str
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("NODE_ENV", raising=False)
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+    monkeypatch.setenv(indicator, "1")
+    backend = ModelSecretBackend(backend_type="environment")
+    assert backend.detect_environment_type() == "ci"

--- a/tests/unit/models/security/test_model_secure_credentials.py
+++ b/tests/unit/models/security/test_model_secure_credentials.py
@@ -389,6 +389,27 @@ class TestModelSecureCredentialsEnvironmentIntegration:
         # No required fields without defaults, so no issues expected
         assert isinstance(issues, list)
 
+    def test_get_environment_bindings_declares_one_reference_per_field(self):
+        """Field set is the declaration; each entry is a contract reference.
+
+        OMN-17554: the model no longer reads os.getenv on a name it builds at
+        call time — it declares ``${env.VAR}`` references and resolves them
+        through the sanctioned overlay boundary.
+        """
+        from omnibase_core.overlays.contract_env_ref import (
+            resolve_contract_env_binding,
+        )
+
+        creds = SampleCredentials()
+        bindings = creds.get_environment_bindings(env_prefix="ONEX_")
+
+        assert set(bindings) == set(type(creds).model_fields)
+        for field_name, reference in bindings.items():
+            assert reference == "${env.ONEX_" + field_name.upper() + "}"
+            assert resolve_contract_env_binding(reference).name == (
+                f"ONEX_{field_name.upper()}"
+            )
+
     def test_get_environment_mapping(self):
         """Test environment variable mapping generation."""
         creds = SampleCredentials()

--- a/tests/unit/overlays/test_contract_env_ref.py
+++ b/tests/unit/overlays/test_contract_env_ref.py
@@ -18,7 +18,12 @@ from __future__ import annotations
 
 import pytest
 
-from omnibase_core.overlays.contract_env_ref import expand_contract_env_refs
+from omnibase_core.errors.model_onex_error import ModelOnexError
+from omnibase_core.overlays.contract_env_ref import (
+    contract_env_reference,
+    expand_contract_env_refs,
+    resolve_contract_env_binding,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -61,3 +66,102 @@ class TestExpandContractEnvRefs:
         assert (
             expand_contract_env_refs("bolt://memgraph:7687") == "bolt://memgraph:7687"
         )
+
+
+class TestResolveContractEnvBinding:
+    """Typed, presence-preserving resolution of a single reference (OMN-17554).
+
+    ``expand_contract_env_refs`` cannot distinguish an unset variable from one
+    set to the empty string — both expand to ``""``. Every configuration
+    override loop in this repo turns on exactly that distinction, so the typed
+    resolver reports ``bound`` separately from ``value``.
+    """
+
+    def test_bound_variable_reports_bound_and_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OMN_TEST_HOST", "db.example")
+        binding = resolve_contract_env_binding("${env.OMN_TEST_HOST}")
+        assert binding.name == "OMN_TEST_HOST"
+        assert binding.bound is True
+        assert binding.value == "db.example"
+        assert binding.is_configured() is True
+
+    def test_unset_variable_is_unbound_with_no_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OMN_TEST_HOST", raising=False)
+        binding = resolve_contract_env_binding("${env.OMN_TEST_HOST}")
+        assert binding.bound is False
+        assert binding.value is None
+        assert binding.is_configured() is False
+
+    def test_empty_variable_is_bound_and_distinguishable_from_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The distinction ``expand_contract_env_refs`` throws away."""
+        monkeypatch.setenv("OMN_TEST_HOST", "")
+        binding = resolve_contract_env_binding("${env.OMN_TEST_HOST}")
+        assert binding.bound is True
+        assert binding.value == ""
+        assert expand_contract_env_refs("${env.OMN_TEST_HOST}") == ""
+
+    def test_inline_default_used_when_unbound(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OMN_TEST_HOST", raising=False)
+        binding = resolve_contract_env_binding("${env.OMN_TEST_HOST:fallback}")
+        assert binding.bound is False
+        assert binding.value == "fallback"
+
+    def test_binding_is_frozen(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMN_TEST_HOST", "db.example")
+        binding = resolve_contract_env_binding("${env.OMN_TEST_HOST}")
+        with pytest.raises(ValueError):
+            binding.value = "mutated"  # type: ignore[misc]
+
+    @pytest.mark.parametrize(
+        "reference",
+        [
+            "${env.OMN_TEST_HOST",
+            "env.OMN_TEST_HOST",
+            "",
+            "bolt://memgraph:7687",
+            "host:${env.OMN_TEST_HOST}/db",
+            "${env.OMN_A}${env.OMN_B}",
+            "${env.9BAD}",
+        ],
+    )
+    def test_fails_closed_on_anything_but_one_well_formed_reference(
+        self, reference: str
+    ) -> None:
+        with pytest.raises(ModelOnexError):
+            resolve_contract_env_binding(reference)
+
+
+class TestContractEnvReference:
+    """Canonical reference rendering for declared-field binding tables."""
+
+    def test_renders_canonical_reference(self) -> None:
+        assert contract_env_reference("ONEX_DB_HOST") == "${env.ONEX_DB_HOST}"
+
+    def test_renders_inline_default(self) -> None:
+        assert contract_env_reference("ONEX_DB_HOST", "local") == (
+            "${env.ONEX_DB_HOST:local}"
+        )
+
+    def test_round_trips_through_the_resolver(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ONEX_ROUNDTRIP", "value")
+        binding = resolve_contract_env_binding(contract_env_reference("ONEX_ROUNDTRIP"))
+        assert binding.value == "value"
+
+    @pytest.mark.parametrize("name", ["9BAD", "HAS-DASH", "HAS SPACE", "", "A.B"])
+    def test_fails_closed_on_an_illegal_name(self, name: str) -> None:
+        with pytest.raises(ModelOnexError):
+            contract_env_reference(name)
+
+    def test_fails_closed_on_a_default_that_would_close_the_reference(self) -> None:
+        with pytest.raises(ModelOnexError):
+            contract_env_reference("ONEX_X", "bad}value")

--- a/tests/unit/validation/test_dynamic_env_read_migration.py
+++ b/tests/unit/validation/test_dynamic_env_read_migration.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""The ten dynamic env reads are migrated to typed bindings (OMN-17554).
+
+The OMN-13566 AST gate (``omnibase_core.validators.no_new_os_environ``) can only
+see reads whose key is a string literal. Every read this ticket owns had a
+*computed* key — ``os.environ.get(env_var)`` inside a mapping loop, a
+``f"{prefix}{field.upper()}"`` builder, a comprehension over an indicator list —
+so all ten were invisible to it and returned a clean bill of health while the
+raw reads were still there.
+
+This test closes that hole for the owned files: it counts every ``os.environ`` /
+``os.getenv`` reference by AST, literal key or not, and pins the exact residual
+per file. A residual is not a suppression — each one is named below with the
+reason it is out of this ticket's slice — but the count cannot grow silently and
+the migrated sites cannot come back.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SRC = Path(__file__).resolve().parents[3] / "src" / "omnibase_core"
+
+# path -> (expected env-read count, why any residual is out of this slice)
+EXPECTED_ENV_READS: dict[str, tuple[int, str]] = {
+    "constants/constants_workflow.py": (
+        0,
+        "the three workflow limits are fixed immutable Core ceilings",
+    ),
+    "doctor/checks/check_env_vars.py": (
+        0,
+        "the binding source is the declared ~/.onex/config.yaml",
+    ),
+    "infrastructure/node_config_provider.py": (
+        0,
+        "node config keys resolve through declared ${env.ONEX_*} references",
+    ),
+    "mixins/mixin_effect_execution.py": (
+        0,
+        "${env.VAR} placeholders resolve through the shared overlay resolver",
+    ),
+    "models/configuration/model_database_connection_config.py": (
+        0,
+        "declared ONEX_DB_* binding table",
+    ),
+    "models/configuration/model_event_bus_config.py": (
+        2,
+        "ModelEventBusConfig.default() bootstrap reads: pre-existing, allowlisted, "
+        "not among the ten dynamic reads this ticket owns",
+    ),
+    "models/configuration/model_rest_api_connection_config.py": (
+        0,
+        "declared ONEX_API_* binding table",
+    ),
+    "models/security/model_secret_backend.py": (
+        3,
+        "structural platform-detection reads (KUBERNETES_SERVICE_HOST, NODE_ENV, "
+        "ENVIRONMENT): literal, allowlisted, owned by OMN-17525/OMN-17555",
+    ),
+    "models/security/model_secure_credentials.py": (
+        1,
+        "the os.environ prefix scan in create_from_env_with_fallbacks is a key "
+        "enumeration, not a keyed read, and is not among the ten",
+    ),
+    "overlays/contract_env_ref.py": (
+        2,
+        "the sanctioned ${env.VAR} overlay boundary every migrated site resolves "
+        "through; explicitly outside this migration slice",
+    ),
+}
+
+
+class _EnvReadCounter(ast.NodeVisitor):
+    """Count every ``os.environ`` / ``os.getenv`` reference, literal key or not."""
+
+    def __init__(self) -> None:
+        self.hits: list[int] = []
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if (
+            node.attr in {"environ", "getenv"}
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "os"
+        ):
+            self.hits.append(node.lineno)
+        self.generic_visit(node)
+
+
+def _count(path: Path) -> list[int]:
+    counter = _EnvReadCounter()
+    counter.visit(ast.parse(path.read_text(encoding="utf-8"), filename=str(path)))
+    return counter.hits
+
+
+@pytest.mark.parametrize("relative", sorted(EXPECTED_ENV_READS))
+def test_env_read_count_is_pinned(relative: str) -> None:
+    expected, reason = EXPECTED_ENV_READS[relative]
+    path = _SRC / relative
+    assert path.is_file(), path
+    lines = _count(path)
+    assert len(lines) == expected, (
+        f"{relative}: expected {expected} os.environ/os.getenv reference(s) "
+        f"({reason}), found {len(lines)} at lines {lines}"
+    )
+
+
+def test_counter_reports_a_true_nonzero() -> None:
+    """Positive control: a zero from this counter is a measured zero."""
+    tree = ast.parse("import os\nx = os.environ.get(k)\ny = os.getenv(j)\n")
+    counter = _EnvReadCounter()
+    counter.visit(tree)
+    assert counter.hits == [2, 3]
+
+
+def test_counter_reports_a_true_zero() -> None:
+    """Negative control: unrelated attribute access is not counted."""
+    tree = ast.parse("import os\nx = os.path.join('a', 'b')\ny = other.environ\n")
+    counter = _EnvReadCounter()
+    counter.visit(tree)
+    assert counter.hits == []
+
+
+def test_static_env_gate_is_clean_for_every_owned_file() -> None:
+    """The OMN-13566 literal-key gate also passes on every owned file."""
+    from omnibase_core.validators.no_new_os_environ import validate_paths
+
+    paths = [_SRC / relative for relative in sorted(EXPECTED_ENV_READS)]
+    findings = validate_paths(paths)
+    assert findings == [], [f.format() for f in findings]

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.5"
+version = "0.47.6"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## OMN-17554 — the ten dynamic env reads become declared typed bindings

The OMN-11186 gate counted **ten** raw `os.environ` / `os.getenv` reads still in core
configuration, resolver and secret-loop paths. Every one of them computed its key at run
time — a mapping loop, an f-string prefix builder, a comprehension over an indicator list
— so the OMN-13566 AST gate, which can only resolve a *literal* key, reported all ten
files clean while the reads were still there.

Verified still present on `origin/dev` before this branch was cut:

```
$ git grep -c -E 'os\.environ|os\.getenv' origin/dev -- <the nine files>
constants_workflow.py:1  check_env_vars.py:1  node_config_provider.py:1
mixin_effect_execution.py:2  model_database_connection_config.py:1
model_event_bus_config.py:3  model_rest_api_connection_config.py:1
model_secret_backend.py:4  model_secure_credentials.py:3
# zero-control: the same command on README.md returns rc=1 with no output,
# so the counter reports a true zero rather than an empty result.
```

### What changed

Each counted read is now a declared `${env.VAR}` contract reference resolved through the
sanctioned core overlay boundary (`omnibase_core.overlays.contract_env_ref`), which gains
a typed, presence-preserving `resolve_contract_env_binding` returning
`ModelContractEnvBinding(name, reference, bound, value)`.

Substitution alone could not carry these sites: `expand_contract_env_refs` renders an
unset variable and an empty one both as `""`, and every override loop here turns on
exactly that distinction. `bound` is therefore reported separately from `value`.

| Site | Resolution |
|---|---|
| `constants_workflow.py` | The three workflow execution limits lose their `ONEX_MAX_*` override entirely. They are the DoS protection itself, so a configuration surface for them is a surface for turning it off. Fixed Core ceilings; the prose that claimed otherwise is corrected here and in `util_workflow_executor.py`. |
| `node_config_provider.py` | Twelve literal `${env.ONEX_*}` references, one per `_DEFAULTS` key, replacing an f-string builder whose key set could not be enumerated statically. |
| `mixin_effect_execution.py` | `${env.VAR}` / `${env.VAR:default}` placeholders resolve through the shared resolver, which owns the grammar and fails closed on a malformed reference instead of passing it through. |
| `model_database_connection_config.py`, `model_rest_api_connection_config.py`, `model_event_bus_config.py` | A declared binding table per model, pinned by test against the field set it claims to bind. |
| `model_secret_backend.py` | The CI-indicator loop becomes four declared references. |
| `model_secure_credentials.py` | `get_environment_bindings()` renders one canonical reference per declared field through a builder that fails closed on an illegal identifier. |

### The doctor — the part that was architecturally open

`CheckEnvVars` asserted that two ambient strings were non-empty. An earlier repair let the
caller inject the set it then checked, so the production doctor could report itself
healthy with both real values absent.

Its authority is now the declared binding in `~/.onex/config.yaml`, resolved through the
shared parser and nothing else: one bounded read, one decode, one parse, one non-writing
recursive projection onto the declared `ModelCliUserConfig` fields **and their aliases at
every declared-model depth**, and exactly one validation. No normalizer, no ambient
fallback, no self-injection, no write. Failures are classified at the operation that owns
their provenance and rendered as fixed, secret-safe messages.

Internal outcome to public result, exactly as specified:

| Outcome | Status | Message |
|---|---|---|
| `MISSING` / `EMPTY` | UNHEALTHY | `Missing: LINEAR_API_KEY` |
| `UNREADABLE` | UNHEALTHY | `User configuration is unavailable; check configuration file access.` |
| `INVALID_ENCODING` | UNHEALTHY | `User configuration has invalid text encoding.` |
| `INVALID_YAML` | UNHEALTHY | `User configuration contains invalid YAML.` |
| `INVALID_MODEL` | UNHEALTHY | `Managed user configuration is invalid.` |
| `VALID`, binding present | HEALTHY | `All required configuration bindings present` |
| `VALID`, binding absent/empty | UNHEALTHY | `Missing: LINEAR_API_KEY` |

Every public result is `env_vars` / `ENVIRONMENT`. Internal codes never render.

### Red-then-green

* **Doctor slice.** RED first: `test_checks_env.py` and the production-Click-route block in
  `test_cli.py` were written against an API that did not exist — collection error, 2 errors.
  GREEN after implementation: 84 passed across `tests/test_doctor/`.
* **The recursive projection is load-bearing, proven by defect injection.** Replacing the
  recursive call with the rejected one-layer form (`projected[key] = dict(value)`) turns
  `test_nested_declared_child_alias_and_unknown_key` RED
  (`INVALID_MODEL is not VALID`) — 1 failed, 35 passed. Restored: 36 passed.
* **Migration invariant.** RED first: `test_dynamic_env_read_migration.py` pins the
  env-read count per owned file by AST, literal key or not — 8 failed, 5 passed, naming
  exactly the eight files still carrying counted reads. GREEN after: 13 passed. The file
  carries its own positive control (a counter that reports a true non-zero) and negative
  control (unrelated attribute access is not counted), so its zeros are measured zeros.
* Focused suites green: 382 passed across doctor, overlays, migration, binding overrides,
  secure credentials, node config provider, mixin effect execution, event bus config.
* Governed pre-push: **44894 passed, 57 skipped, 3 xpassed, 0 failed** in 2:08:43.

### Two earlier pre-push runs, and what they found

The governed selector escalated to the full suite all three times. It earned it:

1. **Run 1** — two real defects. The consumer-group gate (OMN-15639) read
   `"group_id": "<literal>"` in the event-bus binding table as a hardcoded group name; it
   is right to, because it cannot tell a group name from a reference to one by looking at
   the value. The three model binding tables are now tuples of pairs, the gate stays
   strict, and the id is still resolved at run time. Separately, adding `extra="forbid"`
   to `ModelSecureCredentials` made a subclass compliant by inheritance and left a stale
   OMN-14515 baseline entry.
2. **Run 2** — one failure, `test_registry_hook_performance.py::test_execution_scales_linearly`,
   a wall-clock ratio assertion (`times[1000]/times[100] < 30`) that read 126.1 under
   concurrent lab load. Unrelated to this diff — it touches no pipeline, registry or hook
   file — and green 3/3 locally on this branch plus green on the unmodified `dev` tree.
   Run 3 passed it without any change to that test.

### Scope notes, stated rather than buried

* **Residual env reads are named, not suppressed.** `model_event_bus_config.default()` (2),
  the structural platform-detection reads in `model_secret_backend` (3, owned by
  OMN-17525 / OMN-17555), and the `os.environ` key enumeration in
  `create_from_env_with_fallbacks` (1) are outside the counted ten. The migration test pins
  each with the reason it is out of slice, so the count cannot grow silently.
* **Four models gain `extra="forbid"`.** Their bodies are touched here and they carried no
  explicit `extra=`, so Pydantic was silently dropping unknown fields. Five baseline
  entries leave `extra_forbid_baseline.yaml` (the four plus the subclass that became
  compliant by inheritance): 1108 to 1103.
* **The doctor slice exceeds its reviewed six-path ceiling by exactly one new leaf file.**
  `src/omnibase_core/enums/enum_doctor_config_load_code.py` exists because the
  `onex-single-class-per-file` gate rejects an enum co-located with its consumer, which the
  ceiling's author could not have known. The alternative was a suppression entry in that
  gate's shared exclude list. The file has one importer and no other consumer.
* **Two `# fallback-ok:` markers** are added to pre-existing constructs in files this change
  has to touch: the per-step workflow swallow (a failed step is an outcome governed by
  `error_action`, not an error to re-raise) and the development-detection or-chain (four
  independent platform signals, no ordered dispatch chain degrading through them).
* `pyproject.toml` 0.47.4 to 0.47.5, per the OMN-13411 release-identity gate.

Refs: OMN-17554

Evidence-Ticket: OMN-17554
Evidence-Source: OCC#8442
