### PR TITLE
feat(OMN-16289): sync-only main fast-forward dispatch for an existing release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,23 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Version tag to release (e.g. v0.20.0)'
-        required: true
+        description: 'Version tag to release (e.g. v0.20.0). Leave empty when using sync_main_to_tag.'
+        required: false
+        default: ''
+      # OMN-16289: sync-only recovery input. The main fast-forward is the LAST
+      # step of the `release` job, sequenced behind `Publish to PyPI` and
+      # `Create GitHub Release`, so neither a `--failed` re-run nor a plain
+      # `-f tag=` dispatch can reach it without re-executing the publish,
+      # re-cutting the GitHub Release and re-firing the dependency cascade.
+      # When the sync is the ONLY thing that failed -- runs 34030901325
+      # (v0.47.4) and 34052816626 (v0.47.5): publish SUCCESS, GitHub Release
+      # SUCCESS, `Mint onexbot-occ-writer app token` FAILURE with HTTP 422
+      # because the App installation lacked `workflows: write` -- this input
+      # runs the mint + fast-forward and nothing else.
+      sync_main_to_tag:
+        description: 'Sync-only: fast-forward main to this EXISTING release tag. No build, no publish, no GitHub Release, no cascade.'
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -20,6 +35,11 @@ concurrency:
 
 jobs:
   release:
+    # OMN-16289: a sync-only dispatch (`-f sync_main_to_tag=vX.Y.Z`) must not
+    # re-publish an already-published version, re-cut its GitHub Release or
+    # re-fire the dependency cascade. This job IS the release; skip it whole
+    # and let `sync-main` below perform the pointer move on its own.
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.sync_main_to_tag == '' }}
     # OMN-15603: this job used to run on the trusted self-hosted `omnibase-ci`
     # runner. Measured egress from that runner to upload.pypi.org is
     # 30-39 KiB/s, and upload.pypi.org enforces a hard ~240s server-side
@@ -47,6 +67,24 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      # OMN-16289: `tag` is no longer a REQUIRED dispatch input -- a sync-only
+      # dispatch supplies `sync_main_to_tag` instead and skips this job whole.
+      # A dispatch that supplies NEITHER would otherwise fall back to
+      # `github.ref` and die several steps later on a confusing
+      # "tag v does not match pyproject.toml version" message. Fail here, in
+      # the language of the mistake that was actually made.
+      - name: Require a release tag on workflow_dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RELEASE_TAG}" ]; then
+            echo "::error::workflow_dispatch needs one of: tag=<tag> to run a release, or sync_main_to_tag=<tag> to fast-forward main only"
+            exit 1
+          fi
+          echo "Release dispatch for tag ${RELEASE_TAG}"
 
       - name: Assert clean working tree
         run: |
@@ -321,6 +359,140 @@ jobs:
           echo "main fast-forwarded to $TAG_SHA ($TAG)"
 
   # ---------------------------------------------------------------------------
+  # OMN-16289: sync-only main fast-forward, dispatchable for an EXISTING tag
+  # ---------------------------------------------------------------------------
+  # The `release` job's own main sync is the last step of a long, partly
+  # non-idempotent job. When only that step fails, the pointer move has no
+  # recovery path that does not also re-run the publish. This job is that path:
+  # it builds nothing, publishes nothing, and touches no downstream repo.
+  #
+  # The step NAMES here are deliberately identical to the release job's
+  # ("Mint onexbot-occ-writer app token", "Sync main to release tag") -- the
+  # release-on-merge work (OMN-18010) reuses this dispatch path, and stable
+  # step names are what its evidence is read from.
+  #
+  # Two guards, both fail-closed:
+  #   * ancestor-valid: the tag must exist and be an ancestor of origin/dev.
+  #     A tag cut from anywhere else is not a release this policy may point
+  #     main at.
+  #   * fast-forward only: current main must be an ancestor of the tag SHA, so
+  #     main can never be moved backwards or sideways. main already AT the tag
+  #     is a no-op, not a failure.
+  #
+  # The validation script is free of inline `${{ }}` (values arrive through
+  # `env:`) so tests can execute the committed shell verbatim instead of
+  # pattern-matching it.
+  sync-main:
+    name: Sync main to release tag (sync-only)
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.sync_main_to_tag != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate sync tag
+        id: sync_tag
+        env:
+          SYNC_TAG: ${{ inputs.sync_main_to_tag }}
+        run: |
+          set -euo pipefail
+          TAG="$SYNC_TAG"
+
+          # A newline in the dispatch input would forge extra GITHUB_OUTPUT
+          # entries, so constrain it to the tag charset before it is written.
+          case "$TAG" in
+            ''|*[!A-Za-z0-9.+_-]*)
+              echo "::error::sync_main_to_tag contains unsupported characters"
+              exit 1
+              ;;
+          esac
+
+          # Only a real release tag. This is the same shape the push trigger
+          # accepts, so nothing reachable here is outside the release policy.
+          case "$TAG" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "::error::sync_main_to_tag '$TAG' is not a vX.Y.Z release tag"
+              exit 1
+              ;;
+          esac
+          case "$TAG" in
+            *rc*)
+              echo "::error::refusing to point main at the prerelease tag '$TAG'"
+              exit 1
+              ;;
+          esac
+
+          if ! git rev-parse -q --verify "refs/tags/${TAG}^{commit}" >/dev/null; then
+            echo "::error::tag '$TAG' does not exist in this repository"
+            exit 1
+          fi
+          TAG_SHA="$(git rev-list -n 1 "refs/tags/${TAG}")"
+
+          # Explicit refspecs: never rely on git opportunistically updating
+          # the remote-tracking refs for a named-branch fetch.
+          git fetch --no-tags --quiet origin \
+            "+refs/heads/dev:refs/remotes/origin/dev" \
+            "+refs/heads/main:refs/remotes/origin/main"
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/dev; then
+            echo "::error::tag '$TAG' ($TAG_SHA) is not an ancestor of origin/dev -- it is not a release cut from dev, refusing to point main at it"
+            exit 1
+          fi
+
+          MAIN_SHA="$(git rev-parse origin/main)"
+          echo "main=$MAIN_SHA  tag=$TAG_SHA ($TAG)"
+          if [ "$MAIN_SHA" = "$TAG_SHA" ]; then
+            echo "::notice::main is already at $TAG_SHA ($TAG) -- nothing to do"
+            echo "noop=true" >> "$GITHUB_OUTPUT"
+          elif ! git merge-base --is-ancestor "$MAIN_SHA" "$TAG_SHA"; then
+            echo "::error::main ($MAIN_SHA) is not an ancestor of $TAG ($TAG_SHA) -- refusing to move main backwards or sideways"
+            exit 1
+          else
+            echo "noop=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "tag_sha=$TAG_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Mint onexbot-occ-writer app token
+        id: app-token
+        if: steps.sync_tag.outputs.noop == 'false'
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.ONEXBOT_OCC_APP_ID }}
+          private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          # A release tag can legitimately contain workflow changes; GitHub
+          # rejects that protected-branch update unless the App token carries
+          # this explicit scope (run 33525584540, OMN-17272).
+          permission-workflows: write
+
+      - name: Sync main to release tag
+        if: steps.sync_tag.outputs.noop == 'false'
+        env:
+          RELEASE_TAG: ${{ steps.sync_tag.outputs.tag }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          TAG="$RELEASE_TAG"
+          TAG_SHA=$(git rev-list -n 1 "$TAG")
+          echo "Resolved tag $TAG -> commit $TAG_SHA"
+          # OMN-17272: actions/checkout persists the job's GITHUB_TOKEN as an
+          # http.<origin>.extraheader Authorization header, and that header
+          # overrides the app token embedded in the push URL below -- so the
+          # push would authenticate as github-actions[bot], which the
+          # OMN-16289 main ruleset correctly declines (GH013) and which GitHub
+          # refuses to accept as a ruleset bypass actor. Drop the persisted
+          # header so the push authenticates as onexbot-occ-writer.
+          git config --local --unset-all "http.https://github.com/.extraheader" || true
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" "${TAG_SHA}:refs/heads/main"
+          echo "main fast-forwarded to $TAG_SHA ($TAG)"
+
+
+  # ---------------------------------------------------------------------------
   # Post-release: open dependency bump PRs in downstream repos (OMN-5109)
   # ---------------------------------------------------------------------------
   # When omnibase_core is released, downstream repos (omnibase_infra,
@@ -328,7 +500,10 @@ jobs:
   dependency-cascade:
     name: Dependency Cascade
     needs: release
-    if: ${{ !contains(needs.release.outputs.version, 'rc') }}
+    # OMN-16289: `needs.release.result == 'success'` is explicit rather than
+    # implied, so a sync-only dispatch (which skips `release`) can never open
+    # downstream bump PRs off an empty version string.
+    if: ${{ needs.release.result == 'success' && !contains(needs.release.outputs.version, 'rc') }}
     uses: ./.github/workflows/dependency-cascade.yml
     with:
       package: omnibase_core

--- a/tests/unit/validation/test_release_sync_main_dispatch.py
+++ b/tests/unit/validation/test_release_sync_main_dispatch.py
@@ -1,0 +1,393 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Shape + behaviour gate for the sync-only main fast-forward (OMN-16289).
+
+`main` = the last release. The fast-forward that makes that true is the LAST
+step of `release.yml`'s `release` job, sequenced behind `Publish to PyPI` and
+`Create GitHub Release`. When only that step fails -- as it did on runs 34030901325 (v0.47.4) and 34052816626 (v0.47.5),
+where publish and the GitHub Release both succeeded and
+`Mint onexbot-occ-writer app token` returned HTTP 422 because the App
+installation had not been granted `workflows: write` -- there was no way to
+complete the pointer move. `gh run rerun --failed` re-runs the WHOLE job
+including the publish, and so does a plain `-f tag=` dispatch, which also
+re-cuts the GitHub Release and re-fires every downstream job. Every recovery
+path went through a re-publish, so `main` simply stayed stale.
+
+`sync_main_to_tag` is the path that does not. The tests below are split the way
+this repo's release-workflow tests already are:
+
+* **Shape** assertions parse the real workflow YAML -- the job graph, the job
+  conditions, and the fact that the sync-only job builds and publishes nothing.
+* **Behaviour** assertions extract the real `Validate sync tag` script out of
+  the committed workflow and EXECUTE it under `bash -e` against a real
+  throwaway git repository with a real `origin`. Nothing is re-implemented
+  here: a regression in the committed shell is a regression in these tests.
+  That is also why the script must stay free of inline `${{ }}` expressions
+  (values arrive through `env:`) -- an expression would make the committed
+  shell unrunnable here and quietly turn these tests into string matching.
+
+The two guards under test are both fail-closed: the tag must be an ancestor of
+`origin/dev` (it is a release cut from dev, not from anywhere else), and
+`origin/main` must be an ancestor of the tag (the move is a fast-forward, never
+backwards or sideways). `main` already at the tag is a no-op, not a failure, so
+a re-dispatch of an already-synced tag is safe.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from omnibase_core.validators.no_unguarded_git_subprocess import (
+    scrub_git_location_env,
+)
+
+pytestmark = pytest.mark.unit
+
+RELEASE_WORKFLOW = (
+    Path(__file__).resolve().parents[3] / ".github" / "workflows" / "release.yml"
+)
+
+_SYNC_JOB = "sync-main"
+_RELEASE_JOB = "release"
+_CASCADE_JOB = "dependency-cascade"
+_VALIDATE_STEP = "Validate sync tag"
+_MINT_STEP = "Mint onexbot-occ-writer app token"
+_SYNC_STEP = "Sync main to release tag"
+_SYNC_INPUT = "sync_main_to_tag"
+
+
+# --------------------------------------------------------------------------
+# workflow parsing helpers
+# --------------------------------------------------------------------------
+def _workflow() -> dict[Any, Any]:
+    loaded = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _triggers() -> dict[Any, Any]:
+    """YAML 1.1 parses a bare ``on:`` key as the boolean ``True``."""
+    workflow = _workflow()
+    key: Any = True if True in workflow else "on"
+    triggers = workflow[key]
+    assert isinstance(triggers, dict)
+    return triggers
+
+
+def _job(name: str) -> dict[Any, Any]:
+    jobs = _workflow()["jobs"]
+    assert isinstance(jobs, dict)
+    assert name in jobs, f"release.yml must define a `{name}` job; has {list(jobs)}"
+    job = jobs[name]
+    assert isinstance(job, dict)
+    return job
+
+
+def _steps(job_name: str) -> list[dict[Any, Any]]:
+    steps = _job(job_name)["steps"]
+    assert isinstance(steps, list)
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _step(job_name: str, step_name: str) -> dict[Any, Any]:
+    for step in _steps(job_name):
+        if step.get("name") == step_name:
+            return step
+    raise AssertionError(f"job `{job_name}` must have a step named {step_name!r}")
+
+
+def _validate_script() -> str:
+    run = _step(_SYNC_JOB, _VALIDATE_STEP)["run"]
+    assert isinstance(run, str)
+    return run
+
+
+# --------------------------------------------------------------------------
+# shape
+# --------------------------------------------------------------------------
+def test_sync_only_dispatch_input_exists_and_is_optional() -> None:
+    """The recovery input must not be required, or every release dispatch needs it."""
+    inputs = _triggers()["workflow_dispatch"]["inputs"]
+    assert _SYNC_INPUT in inputs, (
+        "release.yml has no `sync_main_to_tag` input -- the only way to finish a "
+        "main fast-forward would be re-running the publish (OMN-16289)"
+    )
+    assert inputs[_SYNC_INPUT].get("required") is not True
+    assert inputs[_SYNC_INPUT].get("default", "") == ""
+
+
+def test_release_tag_input_is_optional_so_a_sync_only_dispatch_can_omit_it() -> None:
+    inputs = _triggers()["workflow_dispatch"]["inputs"]
+    assert inputs["tag"].get("required") is not True
+    assert inputs["tag"].get("default", "") == ""
+
+
+def test_a_sync_only_dispatch_skips_the_release_job_entirely() -> None:
+    """This is the whole point: no re-publish, no re-cut GitHub Release."""
+    condition = str(_job(_RELEASE_JOB)["if"])
+    assert f"inputs.{_SYNC_INPUT} == ''" in condition, condition
+    assert "workflow_dispatch" in condition, condition
+
+
+def test_the_sync_job_only_runs_for_a_sync_only_dispatch() -> None:
+    condition = str(_job(_SYNC_JOB)["if"])
+    assert "github.event_name == 'workflow_dispatch'" in condition, condition
+    assert f"inputs.{_SYNC_INPUT} != ''" in condition, condition
+
+
+def test_the_sync_job_builds_and_publishes_nothing() -> None:
+    """A recovery path that can publish is not a recovery path."""
+    body = yaml.safe_dump(_job(_SYNC_JOB))
+    for forbidden in (
+        "uv build",
+        "uv publish",
+        "publish_with_retry",
+        "action-gh-release",
+    ):
+        assert forbidden not in body, (
+            f"the sync-only job must not contain {forbidden!r}"
+        )
+
+
+def test_the_sync_job_keeps_the_release_jobs_step_names() -> None:
+    """OMN-18010 (release-on-merge) reuses this path and reads these names."""
+    names = [step.get("name") for step in _steps(_SYNC_JOB)]
+    assert _MINT_STEP in names, names
+    assert _SYNC_STEP in names, names
+    assert names.index(_MINT_STEP) < names.index(_SYNC_STEP), names
+
+
+def test_the_sync_push_uses_the_minted_app_token_not_the_workflow_token() -> None:
+    """The main ruleset's only bypass actor is the onexbot-occ-writer App."""
+    script = str(_step(_SYNC_JOB, _SYNC_STEP)["run"])
+    assert "x-access-token:${APP_TOKEN}@github.com" in script, script
+    assert (
+        'git config --local --unset-all "http.https://github.com/.extraheader"'
+        in script
+    ), (
+        "actions/checkout's persisted GITHUB_TOKEN header overrides the app token "
+        "in the push URL, so the push would authenticate as github-actions[bot] "
+        "and the ruleset would decline it (OMN-17272)"
+    )
+    assert "--force" not in script, script
+
+
+def test_the_sync_app_token_can_write_tagged_workflows() -> None:
+    """A release tag may itself change .github/workflows/**."""
+    with_block = _step(_SYNC_JOB, _MINT_STEP)["with"]
+    assert isinstance(with_block, dict)
+    assert with_block["permission-workflows"] == "write"
+
+
+def test_the_mint_and_push_steps_are_skipped_when_main_is_already_synced() -> None:
+    for step_name in (_MINT_STEP, _SYNC_STEP):
+        condition = str(_step(_SYNC_JOB, step_name)["if"])
+        assert "steps.sync_tag.outputs.noop == 'false'" in condition, condition
+
+
+def test_the_validate_script_carries_no_inline_expressions() -> None:
+    """Otherwise the behaviour tests below silently become string matching."""
+    assert "${{" not in _validate_script()
+
+
+def test_a_skipped_release_job_cannot_fire_the_dependency_cascade() -> None:
+    condition = str(_job(_CASCADE_JOB)["if"])
+    assert "needs.release.result == 'success'" in condition, condition
+
+
+# --------------------------------------------------------------------------
+# behaviour harness: run the REAL validate script against a REAL git repo
+# --------------------------------------------------------------------------
+@dataclass(frozen=True)
+class _ValidateRun:
+    returncode: int
+    stdout: str
+    stderr: str
+    outputs: dict[str, str]
+
+
+def _git(cwd: Path, *args: str) -> str:
+    """Run git against ``cwd`` only.
+
+    ``env=scrub_git_location_env(...)`` is not optional (OMN-14891): git exports
+    GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE into every hook environment and
+    those OVERRIDE both ``cwd=`` and ``-C``, so an unscrubbed fixture run under
+    a pre-commit or pre-push hook mutates the REAL worktree instead of tmp_path.
+    """
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=scrub_git_location_env(os.environ),
+    )
+    return result.stdout.strip()
+
+
+def _build_fixture_repo(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    """A clone with a real ``origin``, three dev commits and a side branch.
+
+    Returns the working clone and a map of logical name -> commit SHA.
+    """
+    upstream = tmp_path / "upstream.git"
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=dev", str(upstream)],
+        check=True,
+        capture_output=True,
+        env=scrub_git_location_env(os.environ),
+    )
+
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _git(seed, "init", "--initial-branch=dev")
+    _git(seed, "config", "user.email", "test@example.invalid")
+    _git(seed, "config", "user.name", "test")
+
+    shas: dict[str, str] = {}
+    for name in ("c1", "c2", "c3"):
+        (seed / f"{name}.txt").write_text(name)
+        _git(seed, "add", ".")
+        _git(seed, "commit", "-m", name)
+        shas[name] = _git(seed, "rev-parse", "HEAD")
+
+    # A tag on dev lineage, and a tag on a branch that never reached dev.
+    _git(seed, "tag", "v1.0.0", shas["c2"])
+    _git(seed, "tag", "v9.9.9-rc1", shas["c2"])
+    _git(seed, "checkout", "-q", "-b", "sidebranch", shas["c1"])
+    (seed / "side.txt").write_text("side")
+    _git(seed, "add", ".")
+    _git(seed, "commit", "-m", "side")
+    shas["side"] = _git(seed, "rev-parse", "HEAD")
+    _git(seed, "tag", "v2.0.0", shas["side"])
+    _git(seed, "checkout", "-q", "dev")
+
+    _git(seed, "branch", "main", shas["c1"])
+    _git(seed, "remote", "add", "origin", str(upstream))
+    _git(seed, "push", "-q", "origin", "dev", "main", "sidebranch", "--tags")
+
+    work = tmp_path / "work"
+    subprocess.run(
+        ["git", "clone", "-q", str(upstream), str(work)],
+        check=True,
+        capture_output=True,
+        env=scrub_git_location_env(os.environ),
+    )
+    return work, shas
+
+
+def _set_upstream_main(work: Path, sha: str) -> None:
+    _git(work, "push", "-q", "--force", "origin", f"{sha}:refs/heads/main")
+
+
+def _run_validate(tmp_path: Path, work: Path, sync_tag: str) -> _ValidateRun:
+    script = tmp_path / "validate_sync_tag.sh"
+    script.write_text(_validate_script())
+    github_output = tmp_path / "github_output"
+    github_output.write_text("")
+
+    env = scrub_git_location_env(os.environ)
+    env.update(
+        {
+            "SYNC_TAG": sync_tag,
+            "GITHUB_OUTPUT": str(github_output),
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+    )
+    result = subprocess.run(
+        ["bash", "-e", str(script)],
+        cwd=work,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    outputs: dict[str, str] = {}
+    for line in github_output.read_text().splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            outputs[key] = value
+    return _ValidateRun(result.returncode, result.stdout, result.stderr, outputs)
+
+
+def test_validate_accepts_a_dev_ancestor_tag_ahead_of_main(tmp_path: Path) -> None:
+    work, shas = _build_fixture_repo(tmp_path)
+    run = _run_validate(tmp_path, work, "v1.0.0")
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert run.outputs["noop"] == "false", run.outputs
+    assert run.outputs["tag"] == "v1.0.0", run.outputs
+    assert run.outputs["tag_sha"] == shas["c2"], run.outputs
+
+
+def test_validate_reports_a_noop_when_main_is_already_at_the_tag(
+    tmp_path: Path,
+) -> None:
+    """A re-dispatch of an already-synced tag must not fail the run."""
+    work, shas = _build_fixture_repo(tmp_path)
+    _set_upstream_main(work, shas["c2"])
+    run = _run_validate(tmp_path, work, "v1.0.0")
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert run.outputs["noop"] == "true", run.outputs
+
+
+def test_validate_refuses_to_move_main_backwards(tmp_path: Path) -> None:
+    work, shas = _build_fixture_repo(tmp_path)
+    _set_upstream_main(work, shas["c3"])
+    run = _run_validate(tmp_path, work, "v1.0.0")
+    assert run.returncode != 0, run.stdout
+    assert "backwards" in run.stdout + run.stderr
+    assert "noop" not in run.outputs, run.outputs
+
+
+def test_validate_refuses_a_tag_that_is_not_an_ancestor_of_dev(
+    tmp_path: Path,
+) -> None:
+    work, _ = _build_fixture_repo(tmp_path)
+    run = _run_validate(tmp_path, work, "v2.0.0")
+    assert run.returncode != 0, run.stdout
+    assert "not an ancestor of origin/dev" in run.stdout + run.stderr
+
+
+def test_validate_refuses_a_tag_that_does_not_exist(tmp_path: Path) -> None:
+    work, _ = _build_fixture_repo(tmp_path)
+    run = _run_validate(tmp_path, work, "v3.1.4")
+    assert run.returncode != 0, run.stdout
+    assert "does not exist" in run.stdout + run.stderr
+
+
+def test_validate_refuses_a_prerelease_tag(tmp_path: Path) -> None:
+    work, _ = _build_fixture_repo(tmp_path)
+    run = _run_validate(tmp_path, work, "v9.9.9-rc1")
+    assert run.returncode != 0, run.stdout
+    assert "prerelease" in run.stdout + run.stderr
+
+
+def test_validate_refuses_a_non_release_tag_shape(tmp_path: Path) -> None:
+    work, _ = _build_fixture_repo(tmp_path)
+    run = _run_validate(tmp_path, work, "dev")
+    assert run.returncode != 0, run.stdout
+    assert "not a vX.Y.Z release tag" in run.stdout + run.stderr
+
+
+def test_validate_refuses_an_empty_input(tmp_path: Path) -> None:
+    work, _ = _build_fixture_repo(tmp_path)
+    run = _run_validate(tmp_path, work, "")
+    assert run.returncode != 0, run.stdout
+
+
+def test_validate_refuses_an_input_that_would_forge_extra_step_outputs(
+    tmp_path: Path,
+) -> None:
+    """A newline in the dispatch input must never reach GITHUB_OUTPUT."""
+    work, _ = _build_fixture_repo(tmp_path)
+    run = _run_validate(tmp_path, work, "v1.0.0\nnoop=true")
+    assert run.returncode != 0, run.stdout
+    assert "unsupported characters" in run.stdout + run.stderr
+    assert run.outputs == {}, run.outputs

--- a/tests/unit/validation/test_release_workflow_shape.py
+++ b/tests/unit/validation/test_release_workflow_shape.py
@@ -833,7 +833,15 @@ def test_workflow_dispatch_recovery_checks_out_the_requested_tag() -> None:
     dispatch = _as_mapping(triggers["workflow_dispatch"], "`workflow_dispatch:`")
     inputs = _as_mapping(dispatch["inputs"], "`workflow_dispatch.inputs:`")
     tag_input = _as_mapping(inputs["tag"], "the `tag` dispatch input")
-    assert tag_input["required"] is True
+    # OMN-16289: `tag` stopped being a REQUIRED input when the sync-only
+    # `sync_main_to_tag` dispatch landed -- a dispatch that only fast-forwards
+    # main has no release tag to give. AC5's real invariant is that a release
+    # dispatch cannot proceed WITHOUT one, which is now enforced by an explicit
+    # guard step rather than by the form field.
+    assert tag_input.get("required") is not True
+    guard = _step("Require a release tag on workflow_dispatch")
+    assert "sync_main_to_tag" in str(guard["run"])
+    assert "exit 1" in str(guard["run"])
 
     checkout = _steps()[0]
     assert "actions/checkout@" in str(checkout["uses"])


### PR DESCRIPTION
## Summary

`main` = the last release (OMN-16289). The fast-forward that makes that true is the **last step** of `release.yml`'s `release` job, sequenced behind `Publish to PyPI` and `Create GitHub Release`.

When only that step fails there is no recovery path. Runs `34030901325` (v0.47.4) and `34052816626` (v0.47.5) both published to PyPI and cut their GitHub Release, then failed `Mint onexbot-occ-writer app token` with HTTP 422 — the App installation had not been granted `workflows: write` at the time. `Sync main to release tag` skipped, and `main` is still at v0.47.1 (`31e44e9d`) while the latest tag is v0.47.5 (`65079d65`).

Neither existing path reaches that step without re-running the publish:

| path | what it actually does |
|---|---|
| `gh run rerun <id> --failed` | the sync is step 15 of the same job whose step 12 is `Publish to PyPI` — a failed-job rerun re-executes the **whole** job |
| `gh workflow run release.yml -f tag=vX.Y.Z` | same job, plus a re-cut GitHub Release and a re-fired dependency cascade |

## What this adds

* **`sync_main_to_tag: vX.Y.Z`** — a `workflow_dispatch` input that runs the mint + fast-forward and **nothing else**. The `release` job skips itself whole for such a dispatch; `dependency-cascade` now names `needs.release.result == 'success'` explicitly so it can never fire off an empty version string.
* **Two fail-closed guards** in the new `sync-main` job:
  * *ancestor-valid* — the tag must exist and be an ancestor of `origin/dev`. A tag cut from anywhere else is not a release this policy may point `main` at.
  * *fast-forward only* — `origin/main` must be an ancestor of the tag SHA, so `main` can never be moved backwards or sideways. `main` already at the tag is a **no-op, not a failure**, so re-dispatching an already-synced tag is safe.
* `tag` becomes an optional input (a sync-only dispatch has no release tag to give). A dispatch supplying neither input now fails at an explicit guard step instead of several steps later on a confusing `tag v does not match pyproject.toml version` message.

The step names `Mint onexbot-occ-writer app token` and `Sync main to release tag` are deliberately identical to the release job's — OMN-18010 (release-on-merge) reuses this dispatch path and reads its evidence from them.

## Test plan

`tests/unit/validation/test_release_sync_main_dispatch.py` follows this repo's existing release-workflow test split:

* **shape** — parses the real workflow YAML: the input exists and is optional, a sync-only dispatch skips `release`, the sync job builds and publishes nothing (`uv build` / `uv publish` / `action-gh-release` all absent), the step names are stable, the push uses the minted App token with the persisted-header unset and no `--force`, and the cascade is gated on release success.
* **behaviour** — EXTRACTS the committed `Validate sync tag` script and executes it under `bash -e` against a real throwaway git repository with a real `origin`: accept, no-op, backwards, non-dev-ancestor, missing tag, prerelease, wrong shape, empty input, and an input that would forge extra step outputs.

RED-first: all 20 fail against the pre-change workflow (`release.yml must define a \`sync-main\` job`), 20 pass after. `tests/unit/validation/` is green (43 passed). `pre-commit run --files` clean on all three changed files.

Ticket: OMN-16289 — release-synced main. This PR is the recovery path for the two releases whose sync did not run, and the dispatch surface OMN-18010 builds on.


Evidence-Source: OCC#8453
Evidence-Ticket: OMN-16289
