### PR TITLE
docs(OMN-18004): no public prose names the private knowledge base

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -365,7 +365,6 @@ Brief description of changes
 
 - [Documentation](https://github.com/OmniNode-ai/knowledge-base) — the OmniNode knowledge base is this repository's documentation home
 - [Node Building Guide](https://github.com/OmniNode-ai/knowledge-base/blob/main/guides/onex-node-building-overview.md)
-- Node purity failure guide — in the OmniNode internal knowledge base
 - [GitHub Issues](https://github.com/OmniNode-ai/omnibase_core/issues)
 
 ### Questions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- onex-allow-file-todo-marker reason="historical changelog entries include literal TODO marker tokens" -->
 
+## v0.47.6 (2026-09-06)
+
+### Changes
+- docs no public prose in this repository names the private knowledge base (#1660). One `README.md` paragraph named a private repository, enumerated its contents and stated that teammates have access; it is deleted, since the public knowledge-base links beside it already serve the reader. The same phrasing had reached twenty other sites: fourteen shipped `src/` docstrings that go out inside the published wheel and each pointed at a generation-provenance record the reader cannot reach (seven also cited an internal memory slug), `architecture-handshakes/check-policy-gate.sh` which printed a private destination into PUBLIC CI logs on failure, `.github/CONTRIBUTING.md`, `CLAUDE.md`'s documentation map, and three changelog entries. Each now states that the record is not part of this repository and cites the ticket. Text only: no test, script or gate resolves any of it. The version moves because fourteen of the edited files are packaged source, so the wheel bytes change and the release-identity gate correctly refuses new packaged code on an already-published version — a docstring is shipped code.
+
 ## v0.47.5 (2026-09-06)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2494,7 +2494,7 @@ Actions now include `lease_id` and `epoch` for idempotent retries, preventing du
 
 ### Migration Guide (v0.3.x to v0.4.0)
 
-> **Estimated Migration Time**: 30-60 minutes for typical projects. **Full Guide**: See the declarative-node migration guide (now in the OmniNode internal knowledge base) for comprehensive migration instructions with complete examples.
+> **Estimated Migration Time**: 30-60 minutes for typical projects. **Full Guide**: See the declarative-node migration guide for comprehensive migration instructions with complete examples.
 
 #### Quick Migration Checklist
 
@@ -2529,7 +2529,7 @@ class MyReducer(NodeReducer):
 #### 3. Adopt FSM/Workflow Patterns
 - **Reducer nodes**: Implement `ModelIntent` emission instead of direct state updates
 - **Orchestrator nodes**: Use `ModelAction` with lease management for coordination
-- See the declarative-node migration guide (now in the OmniNode internal knowledge base) for detailed examples
+- See the declarative-node migration guide for detailed examples
 
 #### 4. Update Error Handling
 ```python
@@ -2569,7 +2569,7 @@ class MyReducer(NodeReducerBase):
 - Legacy imports (`NodeReducerLegacy`, `NodeOrchestratorLegacy`) will **fail immediately** - no deprecation warnings
 - The `omnibase_core.nodes.legacy` namespace **does not exist**
 - All nodes must use FSM-driven (`NodeReducer`) or workflow-driven (`NodeOrchestrator`) patterns
-- See the declarative-node migration guide (now in the OmniNode internal knowledge base) for migration instructions
+- See the declarative-node migration guide for migration instructions
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2489,7 +2489,7 @@ Actions now include `lease_id` and `epoch` for idempotent retries, preventing du
 
 ### Migration Guide (v0.3.x to v0.4.0)
 
-> **Estimated Migration Time**: 30-60 minutes for typical projects. **Full Guide**: See the declarative-node migration guide (now in the OmniNode internal knowledge base) for comprehensive migration instructions with complete examples.
+> **Estimated Migration Time**: 30-60 minutes for typical projects. **Full Guide**: See the declarative-node migration guide for comprehensive migration instructions with complete examples.
 
 #### Quick Migration Checklist
 
@@ -2524,7 +2524,7 @@ class MyReducer(NodeReducer):
 #### 3. Adopt FSM/Workflow Patterns
 - **Reducer nodes**: Implement `ModelIntent` emission instead of direct state updates
 - **Orchestrator nodes**: Use `ModelAction` with lease management for coordination
-- See the declarative-node migration guide (now in the OmniNode internal knowledge base) for detailed examples
+- See the declarative-node migration guide for detailed examples
 
 #### 4. Update Error Handling
 ```python
@@ -2564,7 +2564,7 @@ class MyReducer(NodeReducerBase):
 - Legacy imports (`NodeReducerLegacy`, `NodeOrchestratorLegacy`) will **fail immediately** - no deprecation warnings
 - The `omnibase_core.nodes.legacy` namespace **does not exist**
 - All nodes must use FSM-driven (`NodeReducer`) or workflow-driven (`NodeOrchestrator`) patterns
-- See the declarative-node migration guide (now in the OmniNode internal knowledge base) for migration instructions
+- See the declarative-node migration guide for migration instructions
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,7 @@ in `extra_forbid_waivers.yaml`.
 | Handler System | https://github.com/OmniNode-ai/knowledge-base/blob/main/guides/onex-handler-contracts.md |
 | Claude Code Hooks | https://github.com/OmniNode-ai/knowledge-base/blob/main/architecture/onex-claude-code-hook-models.md |
 | Mixins | https://github.com/OmniNode-ai/knowledge-base/blob/main/architecture/onex-mixin-architecture.md |
-| Migration guides | OmniNode internal knowledge base (private) |
+| Migration guides | Not part of this repository |
 | Threading | https://github.com/OmniNode-ai/knowledge-base/blob/main/guides/onex-threading.md |
 | Error Handling | https://github.com/OmniNode-ai/knowledge-base/blob/main/guides/onex-error-handling-best-practices.md |
 | ONEX Terminology | https://github.com/OmniNode-ai/knowledge-base/blob/main/reference/onex-terminology.md |

--- a/README.md
+++ b/README.md
@@ -151,12 +151,6 @@ High-signal entrypoints:
 - [Contributing](.github/CONTRIBUTING.md)
 - [Security](SECURITY.md)
 
-Internal-only and in-flight-migration material for this package (per-repo
-architecture handshakes, the mixin/handler/protocol migration guides, repo CI
-operations, and the validator generation-provenance records) lives in the
-OmniNode internal knowledge base instead — teammates have access; it is not
-linked from here because that repository is private.
-
 ## License
 
 [MIT](LICENSE)

--- a/architecture-handshakes/check-policy-gate.sh
+++ b/architecture-handshakes/check-policy-gate.sh
@@ -250,7 +250,7 @@ main() {
         done
         echo ""
         echo "To fix: install handshake and add CI workflow."
-        echo "See: the omnibase_core architecture-handshakes reference in the OmniNode internal knowledge base"
+        echo "See: OMN-13291 for the handshake requirements this gate enforces"
         echo ""
 
         if [[ "${STRICT}" == "true" ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.5"
+version = "0.47.6"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.4"
+version = "0.47.5"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/validation/doc_content_scan/__init__.py
+++ b/src/omnibase_core/validation/doc_content_scan/__init__.py
@@ -7,7 +7,7 @@ local-model-first through the real delegation chain, and accepted ONLY because i
 passed a deterministic acceptance corpus
 (``node_generation_consumer.validator_corpora.corpus_doc_content_scan``) in the
 hardened sandbox — the corpus verdict, not the LLM, is the acceptance authority
-(OMN-13289). See the validator's generation-provenance record in the OmniNode internal knowledge base.
+(OMN-13289). The generation-provenance record is not part of this repository (OMN-13289).
 
 Invariant: a documentation file (``*.md`` / ``.mdx`` / ``.rst`` / ``.txt`` /
 ``.adoc``) must not carry local-environment traces (RFC1918 LAN IP literals,

--- a/src/omnibase_core/validation/doc_content_scan/handler.py
+++ b/src/omnibase_core/validation/doc_content_scan/handler.py
@@ -14,7 +14,7 @@ in the hardened sandbox on the FIRST attempt: it flagged every ``violation_fixtu
 (6 base + 9 adversarial mutation) and produced zero findings on every
 ``clean_fixture`` (13, incl. 8 adversarial mutation). The corpus verdict — not the
 LLM's self-report — was the acceptance authority (memory
-``feedback_adversarial_receipts``). See the validator's generation-provenance record in the OmniNode internal knowledge base; the raw generated ``handle(input_data)`` is committed verbatim in
+the adversarial-corpus rule). The generation-provenance record is not part of this repository (OMN-13289); the raw generated ``handle(input_data)`` is committed verbatim in
 ``omnimarket/docs/evidence/OMN-13569/doc-content-scan.generation.json``.
 
 The invariant — "a documentation file (``*.md`` / ``.mdx`` / ``.rst`` / ``.txt`` /

--- a/src/omnibase_core/validation/hardcoded_topic/__init__.py
+++ b/src/omnibase_core/validation/hardcoded_topic/__init__.py
@@ -9,7 +9,7 @@ produced by the canonical generator ``HandlerGenerationConsumer``
 ONLY because it passed a deterministic acceptance corpus
 (``node_generation_consumer.validator_corpora.corpus_hardcoded_topic.HARDCODED_TOPIC_CORPUS``)
 in the hardened sandbox — the corpus verdict, not the LLM, is the acceptance
-authority (OMN-13289). See the validator's generation-provenance record in the OmniNode internal knowledge base.
+authority (OMN-13289). The generation-provenance record is not part of this repository (OMN-13289).
 
 Architecture (§1A — validator = COMPUTE node over a swappable bus), mirroring the
 G1 local-paths canary and the G2 private-IP / unfinished-work-marker validators:

--- a/src/omnibase_core/validation/hardcoded_topic/handler.py
+++ b/src/omnibase_core/validation/hardcoded_topic/handler.py
@@ -15,7 +15,7 @@ suffix, deeper 5-segment) and produced zero findings on every ``clean_fixture``
 (contract-resolved topic, dotted python import path, two-segment ``onex.core``
 below the topic shape, a non-``onex`` dotted ``kafka.cluster.broker.id`` string).
 The corpus verdict — not the LLM's self-report — was the acceptance authority
-(memory ``feedback_adversarial_receipts``). See the validator's generation-provenance record in the OmniNode internal knowledge base; the raw generated ``handle(input_data)`` is committed verbatim in
+. The generation-provenance record is not part of this repository (OMN-13289); the raw generated ``handle(input_data)`` is committed verbatim in
 ``docs/evidence/hardcoded-topic-string/hardcoded-topic-string.generation.json``.
 
 The core scan is the regex ``(['"])onex\\.[a-z0-9]+\\.[a-z0-9]+\\.[a-z0-9]+

--- a/src/omnibase_core/validation/localhost_url/__init__.py
+++ b/src/omnibase_core/validation/localhost_url/__init__.py
@@ -10,7 +10,7 @@ The residual G2 mechanical scanner of the validator-standardization plan
 delegation chain, and accepted ONLY because it passed a deterministic acceptance
 corpus (``node_generation_consumer.validator_corpora.corpus_hardcoded_localhost_url``)
 in the hardened sandbox — the corpus verdict, not the LLM, is the acceptance
-authority (OMN-13289). See the validator's generation-provenance record in the OmniNode internal knowledge base.
+authority (OMN-13289). The generation-provenance record is not part of this repository (OMN-13289).
 
 Coverage rationale (why this is NOT a duplicate of ``validator_url_authority``):
 url-authority's ``public-https-literal`` rule deliberately EXCLUDES localhost /

--- a/src/omnibase_core/validation/localhost_url/handler.py
+++ b/src/omnibase_core/validation/localhost_url/handler.py
@@ -13,7 +13,7 @@ mutation) and produced zero findings on every ``clean_fixture`` (public host URL
 contract-sourced endpoint reference, bare ``localhost`` prose word, a public host
 whose NAME merely contains ``localhost``, and a suppression-marker line). The corpus
 verdict — not the LLM's self-report — was the acceptance authority (memory
-``feedback_adversarial_receipts``). See the validator's generation-provenance record in the OmniNode internal knowledge base.
+the adversarial-corpus rule). The generation-provenance record is not part of this repository (OMN-13289).
 
 ONEX node type: COMPUTE. Handler output: ``result`` only (no events / intents /
 projections). The handler is PURE and DETERMINISTIC: it scans the source TEXT

--- a/src/omnibase_core/validation/no_faked_boundary/__init__.py
+++ b/src/omnibase_core/validation/no_faked_boundary/__init__.py
@@ -8,7 +8,7 @@ dispatch boundary from entering the codebase. The scanning logic was GENERATED b
 delegation chain, and accepted ONLY because it passed a deterministic acceptance
 corpus (``node_generation_consumer.validator_corpora.corpus_no_faked_boundary``)
 in the hardened sandbox — the corpus verdict, not the LLM, is the acceptance
-authority (OMN-13289). See the validator's generation-provenance record in the OmniNode internal knowledge base.
+authority (OMN-13289). The generation-provenance record is not part of this repository (OMN-13289).
 
 Architecture (validator = COMPUTE node over a swappable bus), mirroring the
 private-IP / local-paths validators:

--- a/src/omnibase_core/validation/no_faked_boundary/handler.py
+++ b/src/omnibase_core/validation/no_faked_boundary/handler.py
@@ -13,8 +13,8 @@ mutation) and produced zero findings on every ``clean_fixture`` (recorded-from-r
 replay completion, real ``RoutingResolvedJudgeInferenceAdapter`` usage, real
 ``EventBusInmemory`` usage, external Slack/boto3 mocks, recorded literal whose
 prose merely contains the word 'prompt'). The corpus verdict — not the LLM's
-self-report — was the acceptance authority (memory ``feedback_adversarial_receipts``).
-See the validator's generation-provenance record in the OmniNode internal knowledge base.
+self-report — was the acceptance authority.
+The generation-provenance record is not part of this repository (OMN-13289).
 
 ONEX node type: COMPUTE. Handler output: ``result`` only (no events / intents /
 projections). The handler is PURE and DETERMINISTIC: it scans the source TEXT

--- a/src/omnibase_core/validation/pin_hygiene/__init__.py
+++ b/src/omnibase_core/validation/pin_hygiene/__init__.py
@@ -12,7 +12,7 @@ the real delegation chain, and accepted ONLY because it passed a deterministic
 acceptance corpus
 (``node_generation_consumer.validator_corpora.corpus_pin_hygiene``) in the
 hardened sandbox — the corpus verdict, not the LLM, is the acceptance authority
-(OMN-13289). See the validator's generation-provenance record in the OmniNode internal knowledge base.
+(OMN-13289). The generation-provenance record is not part of this repository (OMN-13289).
 
 Architecture (validator = COMPUTE node over a swappable bus), mirroring the
 private-IP / no-faked-boundary validators, with ONE deliberate difference: the

--- a/src/omnibase_core/validation/pin_hygiene/handler.py
+++ b/src/omnibase_core/validation/pin_hygiene/handler.py
@@ -14,8 +14,8 @@ mutation: PEP-508 ``@rev`` form, uv.lock ``?rev=`` form, diverged ``branch=main`
 and an ``unknown`` fail-closed pin) and produced zero findings on every
 ``clean_fixture`` (ancestor pin in each syntax, a non-sibling git pin, a
 version-range pin with no git rev). The corpus verdict — not the LLM's
-self-report — was the acceptance authority (memory ``feedback_adversarial_receipts``).
-See the validator's generation-provenance record in the OmniNode internal knowledge base.
+self-report — was the acceptance authority.
+The generation-provenance record is not part of this repository (OMN-13289).
 
 Hand-hardening applied to the corpus-accepted seed (the seed is a SEED, not
 drop-in — it hallucinated a module path and carried a fail-OPEN hole):

--- a/src/omnibase_core/validation/private_ip/__init__.py
+++ b/src/omnibase_core/validation/private_ip/__init__.py
@@ -10,7 +10,7 @@ validator-standardization plan
 ONLY because it passed a deterministic acceptance corpus
 (``node_generation_consumer.validator_corpora.corpus_hardcoded_ip``) in the
 hardened sandbox — the corpus verdict, not the LLM, is the acceptance authority
-(OMN-13289). See the validator's generation-provenance record in the OmniNode internal knowledge base.
+(OMN-13289). The generation-provenance record is not part of this repository (OMN-13289).
 
 Architecture (§1A — validator = COMPUTE node over a swappable bus), mirroring the
 G1 local-paths canary:

--- a/src/omnibase_core/validation/private_ip/handler.py
+++ b/src/omnibase_core/validation/private_ip/handler.py
@@ -11,7 +11,7 @@ hardened sandbox: it flagged every ``violation_fixture`` (3 base + 4 adversarial
 mutation) and produced zero findings on every ``clean_fixture`` (public IP,
 SemVer-shaped token, 172.15 below-band public, suppression-marker line,
 contract-sourced endpoint). The corpus verdict — not the LLM's self-report — was
-the acceptance authority (memory ``feedback_adversarial_receipts``). See the validator's generation-provenance record in the OmniNode internal knowledge base.
+the acceptance authority. The generation-provenance record is not part of this repository (OMN-13289).
 
 ONEX node type: COMPUTE. Handler output: ``result`` only (no events / intents /
 projections). The handler is PURE and DETERMINISTIC: it scans the source TEXT

--- a/src/omnibase_core/validation/todo_marker/__init__.py
+++ b/src/omnibase_core/validation/todo_marker/__init__.py
@@ -9,7 +9,7 @@ scanner for agent-left TODO/FIXME/HACK markers, produced by the canonical genera
 live model and accepted ONLY because it passed a deterministic acceptance corpus
 (``node_generation_consumer.validator_corpora.corpus_todo_marker.TODO_MARKER_CORPUS``)
 in the hardened sandbox — the corpus verdict, not the LLM, is the acceptance
-authority (OMN-13289). See the validator's generation-provenance record in the OmniNode internal knowledge base.
+authority (OMN-13289). The generation-provenance record is not part of this repository (OMN-13289).
 
 Architecture (§1A — validator = COMPUTE node over a swappable bus), mirroring the
 G1 local-paths canary and the G2 private-IP validator:

--- a/src/omnibase_core/validation/todo_marker/handler.py
+++ b/src/omnibase_core/validation/todo_marker/handler.py
@@ -13,7 +13,7 @@ in the hardened sandbox: it flagged every ``violation_fixture`` (2 base + 3
 adversarial mutation) and produced zero findings on every ``clean_fixture``
 (ordinary comment, marker-substring identifier, ``hackathon`` lowercase substring,
 lowercase prose "to do"). The corpus verdict — not the LLM's self-report — was the
-acceptance authority (memory ``feedback_adversarial_receipts``). See the validator's generation-provenance record in the OmniNode internal knowledge base.
+acceptance authority. The generation-provenance record is not part of this repository (OMN-13289).
 
 The raw generated ``handle(input_data)`` (623 chars) is committed verbatim in the
 provenance evidence

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.4"
+version = "0.47.5"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.5"
+version = "0.47.6"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Epic OMN-17992, lane `hygiene-a2-unblock`, child OMN-18004. Completes the wave-A residual left by lane `public-repo-hygiene-wave-a`, which had this commit written but never pushed.

## What changed

This is the operator's own finding, and the 21 sites the same phrasing reached.

`README.md` carried the paragraph seen on 2026-09-06: it named a private repository, enumerated its contents, and stated that teammates have access. It was added two days earlier by the documentation-migration lane as a courtesy note explaining where the moved prose went. Nobody asked whether the public audience should be told any of it. Deleted outright — the public knowledge-base links immediately above already serve the reader.

The other 20:

- **Fourteen shipped `src/` docstrings** that go out inside the published wheel. Each pointed at a generation-provenance record the reader cannot reach; each now says the record is not part of this repository and cites the ticket. Seven of them also cited an internal memory slug — the same class of pointer, removed for the same reason.
- **`architecture-handshakes/check-policy-gate.sh`** printed a private destination into PUBLIC CI logs on failure. It now cites the ticket.
- **`.github/CONTRIBUTING.md`** listed a guide an outside contributor cannot open.
- **`CLAUDE.md`**'s documentation map, and three `CHANGELOG` entries — text only, the historical record is otherwise unchanged.

Verified live before the edit: the literal repository slug appears ZERO times in this repository. Every one of the 21 hits is the prose form, so a slug-only sweep reports this repo clean and misses the finding entirely.

Nothing here is machine-read: no test, script or gate resolves any of it.

Greps at this branch head and at its merge base on `dev`, no stderr suppressed. The parent run is the positive control; a zero-row grep on its own is not evidence of absence.

- `git grep -ciE 'knowledge-base-internal|internal knowledge base' HEAD` → no rows at this branch head.
- The same grep at `ebaa4e44` (the `dev` commit this branch sits on) → **19 files**, 21 hits: `.github/CONTRIBUTING.md`, `CHANGELOG.md` (3), `CLAUDE.md`, `README.md`, `architecture-handshakes/check-policy-gate.sh`, and the fourteen `src/omnibase_core/validation/**` docstrings.

## Version

The wave-A commit bumped `pyproject` 0.47.4 → 0.47.5 because fourteen edited files are packaged source and the OMN-13411 release-identity gate correctly refuses new packaged code on an already-published version. `dev` has since reached 0.47.5 on its own (via #1656), and 0.47.5 is unpublished on PyPI (latest published is 0.47.4), so after the rebase the bump is a no-op and drops out — the packaged change still lands on an unpublished version.

## Why this branch carries a merge commit

The branch existed on `origin` at `a1368acc`, the same change on the pre-#1656 base, while this worktree held `08061a0b`, the rebase of that same change onto current `dev`. They are rebase siblings, so neither is an ancestor of the other and a plain push is a non-fast-forward. Force-pushing was not an option and was not used. `origin` was merged in instead, which makes the push a fast-forward and keeps ONE branch and ONE PR for this ticket rather than a second branch that would open a duplicate. `git diff 08061a0b 9ea0eb58` is empty — the merge introduces nothing.

## Governed pre-push

The selection escalated to a heavy fail-closed full-suite run and was placed off-box:

```
selection: is_full_suite=True reason=shared_module paths=[ tests/ ]
remote leg: dispatching heavy fail-closed full-suite escalation to h101.2 ... 
remote leg: NO completion marker from h101.2 (wrapper exit unknown) -- treating as NO EVIDENCE (not a pass, not a failure)
lab placement: h101.2 returned no usable evidence; trying the next fit host
REMOTE LAB RUN PASS ... h101 ran 44888 tests green on 9ea0eb58ffe86d4f5eaaf3245a28f332ed02113e
  (suite log sha256 fc3a83e4310c0f7b1ca1d9e5af6a5155966eeb25b3261c21fb702676f443fe97, 6407s)
```

Dispatcher receipt: `{"head_sha":"9ea0eb58...","chosen_host":"stickybeatz","chosen_label":"h101","pytest_exit":0,"collected":44888,"duration_s":6407}`.

An earlier attempt on `h101.2` was refused on two rows in `tests/scripts/test_prepush_hook_host_identity_guard.py`. Both were self-contention, not a defect of this change: those rows shell out to the pre-push picker, and the whole-suite run they were part of was itself holding that host's heavy-suite slot, so the picker reported every host `slot-unknown` and refused. Both pass standalone in the same worktree at the same commit (`2 passed in 5.13s`). This change touches no file under `scripts/hooks/`. Nothing was bypassed: no override grant was minted, no `PREPUSH_*` variable was set.

## Deliberately not done here

The two personal e-mail addresses used as RED positive-control fixtures in `tests/unit/validation/`, the lab host table at `scripts/hooks/prepush_hosts.tsv` and its `docs/evidence/prepush-hcloud/` receipt, and the re-vendoring from the merged omnibase_infra host-table commit are separate inventory rows and are untouched. No history rewrite, no repository-settings change, no credential action.

Inventory: `knowledge-base-internal` → `beta/plans/2026-09-06-public-repo-hygiene-inventory-and-prevention-plan.md`, section 3.3, omnibase_core rows 12 and 13.

<!-- OMN-18004 -->

Evidence-Ticket: OMN-18004
Evidence-Source: OCC#8473
