### PR TITLE
fix(OMN-16289): the main-sync App token needs contents:write, not only workflows:write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,9 +319,17 @@ jobs:
           private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
-          # The release tag can legitimately contain workflow changes. GitHub
-          # rejects that protected-branch update unless the App token carries
-          # this explicit scope (run 33525584540, OMN-17272).
+          # OMN-16289: a `permission-*` input REPLACES the installation's full
+          # permission set with exactly what is listed. OMN-17272 added
+          # `permission-workflows: write` alone, which silently dropped
+          # `contents: write` -- so the minted token could not push ANY ref and
+          # the fast-forward died on `GH013 ... Cannot update this protected
+          # ref` (run 34065670492, v0.47.5). omnimarket, whose sync has worked
+          # throughout, mints with `permission-contents: write`. Both scopes are
+          # required: contents to move the ref at all, workflows because a
+          # release tag can legitimately contain changes under
+          # .github/workflows/ (run 33525584540, OMN-17272).
+          permission-contents: write
           permission-workflows: write
 
       # OMN-16289: main = the last release. Once a release publishes
@@ -465,9 +473,11 @@ jobs:
           private-key: ${{ secrets.ONEXBOT_OCC_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
-          # A release tag can legitimately contain workflow changes; GitHub
-          # rejects that protected-branch update unless the App token carries
-          # this explicit scope (run 33525584540, OMN-17272).
+          # Both scopes are required, and a `permission-*` input REPLACES the
+          # installation's full set: contents to move refs/heads/main at all,
+          # workflows because a release tag can legitimately contain changes
+          # under .github/workflows/ (OMN-16289 run 34065670492, OMN-17272).
+          permission-contents: write
           permission-workflows: write
 
       - name: Sync main to release tag

--- a/tests/unit/validation/test_release_sync_main_dispatch.py
+++ b/tests/unit/validation/test_release_sync_main_dispatch.py
@@ -179,11 +179,34 @@ def test_the_sync_push_uses_the_minted_app_token_not_the_workflow_token() -> Non
     assert "--force" not in script, script
 
 
-def test_the_sync_app_token_can_write_tagged_workflows() -> None:
-    """A release tag may itself change .github/workflows/**."""
-    with_block = _step(_SYNC_JOB, _MINT_STEP)["with"]
-    assert isinstance(with_block, dict)
-    assert with_block["permission-workflows"] == "write"
+def test_the_sync_app_token_can_write_refs_and_tagged_workflows() -> None:
+    """Both scopes, because a ``permission-*`` input REPLACES the whole set.
+
+    ``actions/create-github-app-token`` does not ADD to the installation's
+    permissions when a ``permission-*`` input is present -- it narrows the
+    minted token to exactly what is listed. Listing only
+    ``permission-workflows: write`` therefore drops ``contents: write``, and a
+    token with no contents scope cannot move ``refs/heads/main`` at all: run
+    34065670492 (v0.47.5) minted successfully and then died on
+    ``GH013 ... Cannot update this protected ref``, which reads exactly like a
+    ruleset rejection of the identity. omnimarket, whose sync has worked
+    throughout, mints with ``permission-contents: write``.
+    """
+    for job in (_SYNC_JOB, _RELEASE_JOB):
+        # The release job's mint step carries a repo-specific suffix in some
+        # repos, so resolve it by `id` rather than by exact name; the sync-only
+        # job's names are the ones OMN-18010 reads and those stay canonical.
+        mint = next(step for step in _steps(job) if step.get("id") == "app-token")
+        with_block = mint["with"]
+        assert isinstance(with_block, dict)
+        assert with_block["permission-contents"] == "write", (
+            f"the {job} job's main-sync App token has no contents scope, so the "
+            "fast-forward push is rejected before the ruleset is even consulted"
+        )
+        assert with_block["permission-workflows"] == "write", (
+            f"the {job} job's main-sync App token cannot fast-forward a release "
+            "tag that changes .github/workflows/**"
+        )
 
 
 def test_the_mint_and_push_steps_are_skipped_when_main_is_already_synced() -> None:


### PR DESCRIPTION
## Summary

The release-synced-main fast-forward (OMN-16289) has never actually pushed on this repo. The last blocker looked like a ruleset rejection of the App identity and was not.

`actions/create-github-app-token` does **not add to** the installation's permissions when a `permission-*` input is present — it narrows the minted token to **exactly** what is listed. OMN-17272 added `permission-workflows: write` on its own, which silently dropped `contents: write`. A token with no contents scope cannot move any ref, so the push died on:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Cannot update this protected ref.
 ! [remote rejected]   65079d65... -> main (push declined due to repository rule violations)
```

That is run [34065670492](https://github.com/OmniNode-ai/omnibase_core/actions/runs/34065670492), the first sync-only dispatch (v0.47.5), where the earlier failure mode had already been cleared:

| step | conclusion |
|---|---|
| Validate sync tag | success |
| Mint onexbot-occ-writer app token | **success** (the HTTP 422 is gone — the installation now has `workflows: write`) |
| Sync main to release tag | **failure** — GH013 above |

The GH013 wording reads exactly like the ruleset declining the identity, which is what sent OMN-17272 after the persisted-`extraheader` theory in the first place. The comparison that settles it: **omnimarket**, whose sync has worked throughout, mints with `permission-contents: write`; **omnimemory** mints with no `permission-*` at all and so keeps the installation's full set. Only `omnibase_core` and `omnibase_infra` list `permission-workflows` alone, and only those two have never synced.

## Change

Both scopes on **both** mint steps — the tag-triggered `release` job's and the sync-only `sync-main` job's — so the two paths cannot drift:

```yaml
permission-contents: write
permission-workflows: write
```

`contents` to move `refs/heads/main` at all; `workflows` because a release tag can legitimately contain changes under `.github/workflows/` (the OMN-17272 case, run 33525584540).

## Test plan

`test_the_sync_app_token_can_write_refs_and_tagged_workflows` asserts both scopes on both jobs, resolving the mint step by `id` rather than by name, and records the replace-not-add semantics that made the single-scope form look correct. `tests/unit/validation/test_release_sync_main_dispatch.py` — 20 passed. `pre-commit run --files` clean on both changed files.

## Proof this closes it

`main` is at v0.47.1 (`31e44e9d`) while the latest tag is v0.47.5 (`65079d65`). Once this lands, `gh workflow run release.yml --ref dev -f sync_main_to_tag=v0.47.5` is re-dispatched and `refs/heads/main` is read back against `git rev-list -n1 v0.47.5`. That readback is the OMN-17186 residual ("no release sync has been observed while a ruleset is active") and it is recorded on OMN-16289.

Evidence-Source: OCC#8483
Evidence-Ticket: OMN-16289
