### PR TITLE
fix(OMN-16289): sync main through the REST ref update, not over git

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,19 +351,57 @@ jobs:
           TAG="$RELEASE_TAG"
           TAG_SHA=$(git rev-list -n 1 "$TAG")
           echo "Resolved tag $TAG -> commit $TAG_SHA"
-          # OMN-17272: actions/checkout persists the job's GITHUB_TOKEN as an
-          # http.<origin>.extraheader Authorization header in the local git
-          # config, and that header overrides the app token embedded in the
-          # push URL below -- so this push actually authenticated as
-          # github-actions[bot] (branch-activity-proven), which the OMN-16289
-          # main ruleset correctly declines (GH013), and which GitHub refuses
-          # to accept as a ruleset bypass actor ("The following actor(s) are
-          # invalid: GitHub Actions"). Drop the persisted header so the push
-          # authenticates as onexbot-occ-writer, the ruleset's bypass actor --
-          # the same identity omnimemory/omnimarket already sync main with,
-          # live-proven against their ACTIVE rulesets on 2026-08-31.
-          git config --local --unset-all "http.https://github.com/.extraheader" || true
-          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" "${TAG_SHA}:refs/heads/main"
+          # OMN-16289: main = the last release. This step moves the pointer.
+          #
+          # It used to push the tag SHA to refs/heads/main over git, with
+          # the App token embedded in the remote URL, after unsetting
+          # `http.<origin>.extraheader` so the persisted workflow GITHUB_TOKEN
+          # header could not override it (the OMN-17272 fix).
+          #
+          # That unset is now a NO-OP. actions/checkout v7 no longer persists
+          # the token in `--local` config -- it writes the header into a
+          # separate file and includes it through `includeIf.gitdir`:
+          #   git config --file .../git-credentials-<uuid>.config \
+          #     http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
+          #   git config --local includeIf.gitdir:<workdir>/.git.path <file>
+          # so `--unset-all` against --local removes nothing, the included
+          # header still overrides the URL credentials, and the push
+          # authenticates as github-actions[bot]. The OMN-16289 main ruleset's
+          # only bypass actor is the onexbot-occ-writer App, so it declines
+          # exactly that: GH013 "Cannot update this protected ref" (core run
+          # 34065670492, 2026-09-06 -- mint SUCCESS, push FAILURE).
+          #
+          # Update the ref through the REST API with the App token instead.
+          # No git credential layer is involved, so nothing can override the
+          # push identity. This is the shape omnimarket already syncs main
+          # with, live-proven against its ACTIVE ruleset (run 34050376661,
+          # 2026-09-06, main = v0.4.18). `"force": false` makes GitHub itself
+          # enforce the fast-forward, server-side, on top of this workflow's
+          # own ancestry guard.
+          case "$TAG_SHA" in
+            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+            *)
+              echo "::error::resolved release SHA is not a full commit SHA"
+              exit 1
+              ;;
+          esac
+          printf '{"sha":"%s","force":false}' "$TAG_SHA" > update-main-ref.json
+          http_code="$(curl -sS -o update-main-ref.out -w '%{http_code}' \
+            -X PATCH \
+            -H "Authorization: Bearer ${APP_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/git/refs/heads/main" \
+            --data @update-main-ref.json)"
+          cat update-main-ref.out
+          echo
+          case "$http_code" in
+            2*) ;;
+            *)
+              echo "::error::refs/heads/main update refused with HTTP ${http_code}"
+              exit 1
+              ;;
+          esac
           echo "main fast-forwarded to $TAG_SHA ($TAG)"
 
   # ---------------------------------------------------------------------------
@@ -490,15 +528,57 @@ jobs:
           TAG="$RELEASE_TAG"
           TAG_SHA=$(git rev-list -n 1 "$TAG")
           echo "Resolved tag $TAG -> commit $TAG_SHA"
-          # OMN-17272: actions/checkout persists the job's GITHUB_TOKEN as an
-          # http.<origin>.extraheader Authorization header, and that header
-          # overrides the app token embedded in the push URL below -- so the
-          # push would authenticate as github-actions[bot], which the
-          # OMN-16289 main ruleset correctly declines (GH013) and which GitHub
-          # refuses to accept as a ruleset bypass actor. Drop the persisted
-          # header so the push authenticates as onexbot-occ-writer.
-          git config --local --unset-all "http.https://github.com/.extraheader" || true
-          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" "${TAG_SHA}:refs/heads/main"
+          # OMN-16289: main = the last release. This step moves the pointer.
+          #
+          # It used to push the tag SHA to refs/heads/main over git, with
+          # the App token embedded in the remote URL, after unsetting
+          # `http.<origin>.extraheader` so the persisted workflow GITHUB_TOKEN
+          # header could not override it (the OMN-17272 fix).
+          #
+          # That unset is now a NO-OP. actions/checkout v7 no longer persists
+          # the token in `--local` config -- it writes the header into a
+          # separate file and includes it through `includeIf.gitdir`:
+          #   git config --file .../git-credentials-<uuid>.config \
+          #     http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
+          #   git config --local includeIf.gitdir:<workdir>/.git.path <file>
+          # so `--unset-all` against --local removes nothing, the included
+          # header still overrides the URL credentials, and the push
+          # authenticates as github-actions[bot]. The OMN-16289 main ruleset's
+          # only bypass actor is the onexbot-occ-writer App, so it declines
+          # exactly that: GH013 "Cannot update this protected ref" (core run
+          # 34065670492, 2026-09-06 -- mint SUCCESS, push FAILURE).
+          #
+          # Update the ref through the REST API with the App token instead.
+          # No git credential layer is involved, so nothing can override the
+          # push identity. This is the shape omnimarket already syncs main
+          # with, live-proven against its ACTIVE ruleset (run 34050376661,
+          # 2026-09-06, main = v0.4.18). `"force": false` makes GitHub itself
+          # enforce the fast-forward, server-side, on top of this workflow's
+          # own ancestry guard.
+          case "$TAG_SHA" in
+            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+            *)
+              echo "::error::resolved release SHA is not a full commit SHA"
+              exit 1
+              ;;
+          esac
+          printf '{"sha":"%s","force":false}' "$TAG_SHA" > update-main-ref.json
+          http_code="$(curl -sS -o update-main-ref.out -w '%{http_code}' \
+            -X PATCH \
+            -H "Authorization: Bearer ${APP_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/git/refs/heads/main" \
+            --data @update-main-ref.json)"
+          cat update-main-ref.out
+          echo
+          case "$http_code" in
+            2*) ;;
+            *)
+              echo "::error::refs/heads/main update refused with HTTP ${http_code}"
+              exit 1
+              ;;
+          esac
           echo "main fast-forwarded to $TAG_SHA ($TAG)"
 
 

--- a/tests/unit/validation/test_release_sync_main_dispatch.py
+++ b/tests/unit/validation/test_release_sync_main_dispatch.py
@@ -164,19 +164,45 @@ def test_the_sync_job_keeps_the_release_jobs_step_names() -> None:
     assert names.index(_MINT_STEP) < names.index(_SYNC_STEP), names
 
 
-def test_the_sync_push_uses_the_minted_app_token_not_the_workflow_token() -> None:
-    """The main ruleset's only bypass actor is the onexbot-occ-writer App."""
-    script = str(_step(_SYNC_JOB, _SYNC_STEP)["run"])
-    assert "x-access-token:${APP_TOKEN}@github.com" in script, script
-    assert (
-        'git config --local --unset-all "http.https://github.com/.extraheader"'
-        in script
-    ), (
-        "actions/checkout's persisted GITHUB_TOKEN header overrides the app token "
-        "in the push URL, so the push would authenticate as github-actions[bot] "
-        "and the ruleset would decline it (OMN-17272)"
-    )
-    assert "--force" not in script, script
+def test_the_sync_updates_the_ref_over_rest_with_the_minted_app_token() -> None:
+    """The main ruleset's only bypass actor is the onexbot-occ-writer App.
+
+    The pointer move must NOT go over git. actions/checkout v7 persists the
+    workflow GITHUB_TOKEN as an ``http.<origin>.extraheader`` written into a
+    separate file and pulled in through ``includeIf.gitdir`` -- NOT into
+    ``--local`` config. The OMN-17272 mitigation
+    (``git config --local --unset-all http.https://github.com/.extraheader``)
+    therefore removes nothing, the included header still overrides credentials
+    embedded in a remote URL, and the push authenticates as
+    ``github-actions[bot]``. The ruleset declines exactly that, with GH013
+    "Cannot update this protected ref" -- reproduced live on core runs
+    34065670492 and 34069756070 (2026-09-06): mint SUCCESS, sync FAILURE.
+
+    Updating ``refs/heads/main`` through the REST API with the App token has
+    no git credential layer that could override the identity. That is the
+    shape omnimarket already syncs main with, live-proven against its ACTIVE
+    ruleset (run 34050376661, main = v0.4.18).
+    """
+    for job in (_SYNC_JOB, _RELEASE_JOB):
+        script = str(_step(job, _SYNC_STEP)["run"])
+
+        # The token must never travel through a git remote URL again.
+        assert "access-token:" not in script, (job, script)
+        assert "git push" not in script, (job, script)
+
+        assert "-X PATCH" in script, (job, script)
+        assert (
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/git/refs/heads/main" in script
+        ), (job, script)
+        assert "Authorization: Bearer ${APP_TOKEN}" in script, (job, script)
+
+        # Server-side fast-forward enforcement, on top of this workflow's own
+        # ancestry guard. A forced ref update would defeat both.
+        assert '"force":false' in script, (job, script)
+        assert "--force" not in script, (job, script)
+
+        # A non-2xx ref update must fail the step, not be swallowed.
+        assert "http_code" in script, (job, script)
 
 
 def test_the_sync_app_token_can_write_refs_and_tagged_workflows() -> None:


### PR DESCRIPTION
## Summary

OMN-16289: `main` is stuck at v0.47.1 (`31e44e9d`) while the latest tag is v0.47.5 (`65079d65`). The release-synced-main fast-forward has never run on this repo. It had **two** independent defects, and #1661 fixed only the first — the sync would still have failed after it landed.

### Defect 1 — the minted token had no `contents` scope (fixed by #1661, already on `dev`)

Any `permission-*` input to `actions/create-github-app-token` **replaces** the installation's permission set with exactly what is listed; it does not add to it. OMN-17272 named `permission-workflows: write` alone, which silently dropped `contents: write`, so the token could not write **any** ref under any identity.

### Defect 2 — the push authenticated as the wrong identity (this PR)

`actions/checkout` v7 no longer persists the workflow `GITHUB_TOKEN` in `--local` git config. It writes the Authorization header into a separate file and pulls it in through `includeIf.gitdir`:

```
git config --file .../git-credentials-<uuid>.config \
  http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
git config --local includeIf.gitdir:<workdir>/.git.path <that file>
```

So the OMN-17272 mitigation — `git config --local --unset-all http.https://github.com/.extraheader` — removes nothing. The included header still overrides the credentials embedded in the remote URL, the push authenticates as `github-actions[bot]`, and the OMN-16289 `main` ruleset (whose only bypass actor is the `onexbot-occ-writer` App, `Integration:4361937`) declines exactly that:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Cannot update this protected ref.
```

Reproduced live on two runs today — [34065670492](https://github.com/OmniNode-ai/omnibase_core/actions/runs/34065670492) and [34069756070](https://github.com/OmniNode-ai/omnibase_core/actions/runs/34069756070). Both show **Mint onexbot-occ-writer app token → success** followed by **Sync main to release tag → failure**, which is why the permission grant alone did not close it. The GH013 wording reads like a ruleset rejection of the identity, and it is — just not of the identity anyone was inspecting.

## Change

Both sync sites — the tag-triggered `release` job's and the sync-only `sync-main` dispatch job's — now update `refs/heads/main` through the REST API with the App token:

```
PATCH ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/git/refs/heads/main
Authorization: Bearer ${APP_TOKEN}
{"sha":"<tag sha>","force":false}
```

No git credential layer is involved, so nothing can override the push identity. This is the shape **omnimarket** already syncs `main` with, live-proven against its ACTIVE ruleset ([run 34050376661](https://github.com/OmniNode-ai/omnimarket/actions/runs/34050376661), `main` = v0.4.18). `"force": false` makes GitHub itself enforce the fast-forward server-side, on top of this workflow's own ancestry guard, and a non-2xx response fails the step rather than being swallowed.

Step names are unchanged, so the OMN-18010 release-on-merge work reads the same evidence from them.

## Test plan

- `test_the_sync_updates_the_ref_over_rest_with_the_minted_app_token` now asserts the REST shape on **both** sync sites — the `release` job's step was previously unasserted — and asserts the token never travels through a git remote URL again (no `access-token:`, no `git push`), `"force":false`, no `--force`, and that a non-2xx `http_code` fails the step.
- `test_the_sync_app_token_can_write_refs_and_tagged_workflows` (from #1661) asserts both scopes on both mints.
- Verified RED-first: run against the pre-fix workflow, the REST assertion fails on `access-token:` still being present in the sync script.
- `tests/unit/validation/test_release_sync_main_dispatch.py` — 20 passed. Governed pre-push: 1955 passed.

## Proof this closes it

Once this lands, `gh workflow run release.yml --ref dev -f sync_main_to_tag=v0.47.5` is re-dispatched and `refs/heads/main` is read back against `git rev-list -n1 v0.47.5`. That readback is the OMN-17186 residual ("no release sync has been observed while a ruleset is active") and it is recorded on OMN-16289.

Evidence-Ticket: OMN-16289
Evidence-Source: OCC#8507
