### PR TITLE
test(OMN-18023): replace the operator personal e-mail fixtures with synthetic values

### DIFF
--- a/tests/unit/validation/doc_content_scan/test_handler_doc_content_scan_compute.py
+++ b/tests/unit/validation/doc_content_scan/test_handler_doc_content_scan_compute.py
@@ -25,6 +25,7 @@ These tests assert three things:
 from __future__ import annotations
 
 import asyncio
+from typing import Final
 
 import pytest
 
@@ -48,8 +49,8 @@ _VIOLATION_FIXTURES: tuple[str, ...] = (
     "The broker runs on 192.168.86.201 in the lab.",  # v-base-lan-ip
     "Deployed to .201 over the weekend.",  # v-base-host-shorthand
     "Logs are written to /Users/jonah/Code/omni_home/run.log",  # v-base-personal-path  # local-path-ok OMN-13569 fixture is the personal-path violation the scanner must flag
-    "Connect with `ssh jonah@192.168.86.201` then tail the logs.",  # v-base-ssh-line
-    "Questions go to jonah.neugass@gmail.com for now.",  # v-base-personal-email
+    "Connect with `ssh operator@192.168.86.201` then tail the logs.",  # v-base-ssh-line
+    "Questions go to someone@gmail.example for now.",  # v-base-personal-email  # the .example TLD is RFC 2606-reserved and non-routable; the provider label is what _PERSONAL_EMAIL keys on, so this row stays RED (example.com would NOT)
     "This was fixed in OMN-13294 last sprint.",  # v-base-omn-prose
     "Postgres listens on 10.0.0.5 inside the cluster.",  # v-mut-lan-ip-10-band
     "Valkey is reachable at 172.16.4.9 from the runners.",  # v-mut-lan-ip-172-band
@@ -78,6 +79,36 @@ _CLEAN_FIXTURES: tuple[str, ...] = (
 )
 
 
+# Each violation fixture's REQUIRED violation class — the class its ``# v-...``
+# tag names. This map is the ANTI-VACUITY guard for the corpus above.
+#
+# ``test_every_violation_fixture_is_flagged`` only asserts ``flagged is True``,
+# which ANY class on the line satisfies. Several rows carry more than one trace
+# — the ssh row also carries a LAN IP — so an edit that makes a fixture stop
+# matching its OWN class (a scrub, a regex narrowing, a rule retirement) leaves
+# the corpus test green on a co-located class while the rule that row was
+# pinning is no longer exercised anywhere. That is the failure mode this map
+# exists to catch, and it is why a fixture is scrubbed by swapping the
+# identifying value for a synthetic one the SAME rule still matches, never by
+# removing the trace.
+_VIOLATION_FIXTURE_REQUIRED_CLASS: Final[dict[str, EnumDocViolationType]] = {
+    _VIOLATION_FIXTURES[0]: EnumDocViolationType.LAN_IP,
+    _VIOLATION_FIXTURES[1]: EnumDocViolationType.HOST_SHORTHAND,
+    _VIOLATION_FIXTURES[2]: EnumDocViolationType.PERSONAL_PATH,
+    _VIOLATION_FIXTURES[3]: EnumDocViolationType.SSH_INVOCATION,
+    _VIOLATION_FIXTURES[4]: EnumDocViolationType.PERSONAL_EMAIL,
+    _VIOLATION_FIXTURES[5]: EnumDocViolationType.TICKET_REFERENCE,
+    _VIOLATION_FIXTURES[6]: EnumDocViolationType.LAN_IP,
+    _VIOLATION_FIXTURES[7]: EnumDocViolationType.LAN_IP,
+    _VIOLATION_FIXTURES[8]: EnumDocViolationType.HOST_SHORTHAND,
+    _VIOLATION_FIXTURES[9]: EnumDocViolationType.PERSONAL_PATH,
+    _VIOLATION_FIXTURES[10]: EnumDocViolationType.TICKET_REFERENCE,
+    _VIOLATION_FIXTURES[11]: EnumDocViolationType.TICKET_REFERENCE,
+    _VIOLATION_FIXTURES[12]: EnumDocViolationType.TICKET_REFERENCE,
+    _VIOLATION_FIXTURES[13]: EnumDocViolationType.TICKET_REFERENCE,
+    _VIOLATION_FIXTURES[14]: EnumDocViolationType.TICKET_REFERENCE,
+}
+
 # ---------------------------------------------------------------------------
 # Corpus acceptance — the verdict that gated the generation run
 # ---------------------------------------------------------------------------
@@ -98,6 +129,32 @@ def test_every_clean_fixture_passes(source: str) -> None:
     result = scan_source(source)
     assert result.flagged is False, f"clean fixture false-flagged: {source!r}"
     assert result.findings == ()
+
+
+@pytest.mark.unit
+def test_required_class_map_covers_every_violation_fixture() -> None:
+    """The anti-vacuity map must stay aligned with the corpus it guards."""
+    assert len(_VIOLATION_FIXTURES) == len(set(_VIOLATION_FIXTURES)), (
+        "violation fixtures must be unique so the required-class map can key on them"
+    )
+    assert set(_VIOLATION_FIXTURE_REQUIRED_CLASS) == set(_VIOLATION_FIXTURES)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("source", _VIOLATION_FIXTURES)
+def test_every_violation_fixture_yields_its_own_class(source: str) -> None:
+    """Anti-vacuity: each fixture must flag the class its tag names.
+
+    Non-vacuity is the whole point of a positive-control corpus. Asserting only
+    ``flagged is True`` lets a fixture keep passing on a co-located trace after
+    the rule it was pinning stopped matching it.
+    """
+    expected = _VIOLATION_FIXTURE_REQUIRED_CLASS[source]
+    observed = {finding.violation_type for finding in scan_source(source).findings}
+    assert expected in observed, (
+        f"fixture no longer exercises its own class {expected.value!r}: "
+        f"{source!r} produced {sorted(v.value for v in observed)}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -250,7 +307,7 @@ def test_file_marker_suppresses_the_whole_file() -> None:
         "<!-- doc-content-file-ok doc fixture -->\n"
         "host = 10.0.0.5\n"
         "see OMN-1234\n"
-        "ssh jonah@192.168.86.201"
+        "ssh operator@192.168.86.201"
     )
     result = scan_source(src)
     assert result.flagged is False

--- a/tests/unit/validation/test_receipt_honesty_validator.py
+++ b/tests/unit/validation/test_receipt_honesty_validator.py
@@ -665,7 +665,12 @@ class TestRuleDFakeHumanVerifier:
     )
     @pytest.mark.parametrize(
         "human_verifier",
-        ["jonah", "user", "human", "jonah.gabriel@gmail.com"],
+        # "jonah" stays: validator_receipt_honesty._HUMAN_VERIFIER_RE carries a
+        # literal `\bjonah\b` branch in SHIPPED source, and this is the only test
+        # of it — removing the value would widen a detection hole, not close one.
+        # The address is synthetic (RFC 2606 reserved domain); the regex's e-mail
+        # branch is domain-agnostic, so the rule is still exercised.
+        ["jonah", "user", "human", "someone@example.com"],
     )
     def test_agent_runner_human_verifier_fails(
         self, agent_runner: str, human_verifier: str
@@ -685,7 +690,7 @@ class TestRuleDFakeHumanVerifier:
 
     def test_both_human_handles_passes_rule_d(self) -> None:
         """Two human handles is unusual but not flagged by rule D (rule C handles it if equal)."""
-        receipt = _make_receipt(runner="jonah-manual", verifier="bret-reviewer")
+        receipt = _make_receipt(runner="operator-manual", verifier="reviewer-b")
         violations = check_receipt_honesty(receipt)
         assert not any(
             v.rule == EnumHonestyRule.FAKE_HUMAN_VERIFIER for v in violations
@@ -736,7 +741,7 @@ class TestRuleEDeployRealness:
             "kubectl rollout status",
             "psql -c 'SELECT 1'",
             "curl https://api.example.com/health",
-            "ssh jonah@192.168.86.201 docker ps",
+            "ssh operator@192.168.86.201 docker ps",
         ],
     )
     def test_deploy_evidence_with_real_verb_passes_rule_e(self, real_verb: str) -> None:


### PR DESCRIPTION
Closes OMN-18023 (child of OMN-17992, public-repo hygiene wave A item (d)).

Two public test files in this repo carried the operator's real personal e-mail addresses, the operator's first name as an ssh login, and a collaborator's real first name as a fixture identity.

## The trap, and why the plan's literal instruction was not followed

`_VIOLATION_FIXTURES` in `tests/unit/validation/doc_content_scan/test_handler_doc_content_scan_compute.py` is a RED positive-control corpus. Those rows must keep FAILING the scanner — the corpus is what proves the rule is non-vacuous. A scrub that makes a line stop matching silently retires the rule while the suite stays green.

The wave-A plan said to substitute RFC 2606 `example.com`. Read at HEAD, `src/omnibase_core/validation/doc_content_scan/handler.py` `_PERSONAL_EMAIL` is anchored on a fixed alternation of consumer mail providers (`gmail|yahoo|hotmail|outlook|icloud|protonmail|aol|mail|zoho|yandex|tutanota`) and **excludes `example.com` by construction** — `example.com` is a `_CLEAN_FIXTURES` row two blocks down. That substitution would have turned the personal-email positive control into a no-op, so it was not applied.

The fixture uses `someone@gmail.example` instead. The `.example` TLD is RFC 2606-reserved and non-routable, and the provider label is what the rule keys on, so the row stays RED for its own class.

## The anti-vacuity guard, written first

`_VIOLATION_FIXTURE_REQUIRED_CLASS` maps every violation fixture to the class its own `# v-...` tag names, and `test_every_violation_fixture_yields_its_own_class` asserts it. The pre-existing `test_every_violation_fixture_is_flagged` asserts only `flagged is True`, which any co-located class on the same line satisfies.

RED/GREEN discriminator, run in this order before the fix was written:

1. Guard added against the **unscrubbed** corpus — `67 passed`. The map is correct against current behaviour.
2. Naive `example.com` substitution — `2 failed, 65 passed`. `AssertionError: fixture no longer exercises its own class 'personal_email': ... produced []`.
3. The subtler case, which is the reason the guard exists: `"Questions go to someone@example.com about the .201 box."` — `1 failed, 66 passed`. The **pre-existing** corpus test PASSES here on `host_shorthand` while the personal-email rule is no longer exercised by anything; only the new guard catches it.
4. Correct scrub applied — `173 passed` across both files.

## Changes

- doc-content-scan test: the `v-base-ssh-line` row and the file-marker suppression fixture take user `operator`. The RFC1918 literal is kept so the row still co-exercises `LAN_IP`; the file already carries `onex-allow-file-internal-ip`.
- doc-content-scan test: the `v-base-personal-email` row takes `someone@gmail.example`.
- receipt-honesty test: the rule-D parametrised address becomes `someone@example.com` — that regex's e-mail branch is domain-agnostic (`[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`), so a reserved domain is correct there.
- receipt-honesty test: the two-human-handles fixture takes role-shaped identities; the rule-E real-verb ssh probe takes user `operator`.

## Deliberately NOT changed

- **The `"jonah"` entry in the rule-D parameter list.** `src/omnibase_core/validation/validator_receipt_honesty.py:283` carries a literal `\bjonah\b` branch in **shipped** source as a human-handle heuristic, and this parameter is the only test of it. Removing the value would widen a detection hole rather than close one. Only the address on that line changed.
- The `# local-path-ok` personal-home-path fixtures on adjacent lines — a different class, not in this item's scope.
- The `jonah/*` branch-name and `jonahgabriel` handle fixtures across `tests/unit/validation/` — a public GitHub handle.

## Two findings recorded rather than papered over

**1. `PERSONAL_EMAIL` is narrower than its name advertises.** It matches only twelve consumer mail providers. A personal address at a corporate, university or custom domain is not detected at all. Widening it changes production behaviour and needs its own RED corpus, so it is reported here, not done here.

**2. The operator's first name is hardcoded in shipped source.** `validator_receipt_honesty.py:283`. Publishing a named individual inside a wheel is the same disclosure class this epic exists to remove, but the fix is a behaviour change to a detection rule, not a fixture swap — it needs its own ticket and its own corpus.

## Gate

Scoped to this item's two files, with the pre-fix parent as the positive control:

```
git grep -nE '(jonah\.neugass|jonah\.gabriel)@|ssh jonah@' -- <the two files>
```
returns **5 rows at `origin/dev` 6f623a60** (the control) and **exit 1, no rows** at this branch head.

```
git grep -nw 'bret' -- .
```
returns **1 row at `origin/dev`** (`test_receipt_honesty_validator.py:688`) and **exit 1, no rows repo-wide** at this branch head.

## Probe

`uv run pytest tests/unit/validation/doc_content_scan/test_handler_doc_content_scan_compute.py tests/unit/validation/test_receipt_honesty_validator.py` → `173 passed`.
`uv run mypy --strict` on both files → `Success: no issues found in 2 source files`. `ruff format` + `ruff check` clean.
Governed pre-push (`prepush_smart_tests.sh`, no override of any kind): `6396 passed, 5 skipped in 573.58s`, `impacted tests passed; allowing push`.

## Out of scope, reported for the next lane

`scripts/hooks/pytest_full_suite_host_guard.py:260` and `scripts/hooks/prepush_dispatch.sh:1362` still carry `ssh <operator-first-name>@<tailnet host>` / `@<lab LAN IP>` in this repo's public tree. That is wave-A item (a) territory, whose anti-forgery premise (HEAD-read of the host table plus a committed digest) must survive — this change touches nothing under `scripts/hooks/`.

Evidence-Ticket: OMN-18023
Evidence-Source: OCC#8539
