### PR TITLE
feat(OMN-18016): a third managed .gitignore block for the agent-state trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,6 +349,17 @@ build/
 *.egg-info/
 # === end onex-managed: python ===
 
+# === onex-managed: public_repo_hygiene ===
+.claude/*
+!.claude/architecture-handshake.md
+.claude_scratch/
+.repowise-workspace/
+.repowise-workspace.yaml
+.evidence/
+docs/evidence/
+merge-sweep/
+# === end onex-managed: public_repo_hygiene ===
+
 # -----------------------------------------------------------------------------
 # .onex_state/ -- disposable by default, two named durable subtrees (OMN-15989)
 # -----------------------------------------------------------------------------

--- a/architecture-handshakes/gitignore-baseline.yaml
+++ b/architecture-handshakes/gitignore-baseline.yaml
@@ -24,7 +24,7 @@
 
 schema_version:
   major: 1
-  minor: 0
+  minor: 1
   patch: 0
 
 # Managed block definitions.
@@ -90,14 +90,55 @@ managed_blocks:
       - "build/"
       - "*.egg-info/"
 
+  public_repo_hygiene:
+    description: |
+      Patterns enforced on every OmniNode-ai repo, covering the agent-state,
+      scratch and workspace-index trees that keep landing in PUBLIC
+      repositories. Companion to the OMN-18014 public-repo hygiene gate.
+
+      READ 4.9 OF THE OMN-17992 PREVENTION PLAN BEFORE TRUSTING THIS BLOCK.
+      An ignore file does not untrack an existing path and does not stop a
+      forced add. Five repos are clean of these classes with no ignore rule at
+      all, by author discipline; meanwhile one repo's OS-junk file is committed
+      AND ignored, because the rule was added after the file. This block is a
+      useful FIRST layer and a worthless LAST one. The enforcement layer is the
+      hygiene gate, which checks the TRACKED SET.
+
+      NOT LISTED HERE, deliberately:
+        .onex/        — product surface, not machine state. It is read at
+                        runtime by the aislop rule loader. Ignoring it would
+                        break the per-repo override mechanism.
+        .onex_state/  — omnibase_core's .gitignore deliberately re-includes
+                        .onex_state/evidence/ and .onex_state/friction/, with a
+                        test asserting it (OMN-15989). Retiring that re-include
+                        is root cause 4.1 and is blocked on the operator ruling
+                        for the public evidence corpus (plan 6.0, 7.2). Adding
+                        a conflicting rule here would silently fight a
+                        test-asserted rule in one repo, which is worse than the
+                        gap it closes.
+    start_marker: "# === onex-managed: public_repo_hygiene ==="
+    end_marker: "# === end onex-managed: public_repo_hygiene ==="
+    applies_when: always
+    patterns:
+      - ".claude/*"
+      - "!.claude/architecture-handshake.md"
+      - ".claude_scratch/"
+      - ".repowise-workspace/"
+      - ".repowise-workspace.yaml"
+      - ".evidence/"
+      - "docs/evidence/"
+      - "merge-sweep/"
+
+
 # Metadata
 
 metadata:
   generated_by: "manually authored (OMN-12451)"
-  last_updated: "2026-05-30"
+  last_updated: "2026-09-07"
   next_review: "on any new pattern addition — single source of truth, change propagates via OMN-12450
     pin-bump bot"
   related_tickets:
     - OMN-12450  # canonical .gitignore baseline + cross-repo enforcement epic
     - OMN-12451  # this spec file
     - OMN-12452  # T2 validator + CI wiring
+    - OMN-18016  # public-repo-hygiene managed block (epic OMN-17992)

--- a/tests/validation/test_gitignore_baseline.py
+++ b/tests/validation/test_gitignore_baseline.py
@@ -85,6 +85,23 @@ _PYTHON_LINES = [
 ]
 _PYTHON_BLOCK = "\n".join(_PYTHON_LINES)
 
+# OMN-18016 (epic OMN-17992). applies_when: always, so every fixture repo below
+# needs it -- including the JS-only and no-pyproject ones. That is the point of
+# the block: the agent-state trees it refuses are not language-specific.
+_PUBLIC_REPO_HYGIENE_LINES = [
+    "# === onex-managed: public_repo_hygiene ===",
+    ".claude/*",
+    "!.claude/architecture-handshake.md",
+    ".claude_scratch/",
+    ".repowise-workspace/",
+    ".repowise-workspace.yaml",
+    ".evidence/",
+    "docs/evidence/",
+    "merge-sweep/",
+    "# === end onex-managed: public_repo_hygiene ===",
+]
+_HYGIENE_BLOCK = "\n".join(_PUBLIC_REPO_HYGIENE_LINES)
+
 
 def _write_gitignore(tmp_path: Path, content: str) -> None:
     (tmp_path / ".gitignore").write_text(content, encoding="utf-8")
@@ -109,7 +126,7 @@ def _write_package_json(tmp_path: Path) -> None:
 def test_python_repo_missing_python_block_fails(tmp_path: Path) -> None:
     """A repo with pyproject.toml that lacks the python managed block → finding."""
     _write_pyproject(tmp_path)
-    _write_gitignore(tmp_path, _UNIVERSAL_BLOCK + "\n")
+    _write_gitignore(tmp_path, _UNIVERSAL_BLOCK + "\n\n" + _HYGIENE_BLOCK + "\n")
 
     findings = validate(tmp_path, _SPEC_PATH)
 
@@ -121,7 +138,7 @@ def test_python_repo_missing_python_block_fails(tmp_path: Path) -> None:
 def test_js_repo_with_universal_block_passes(tmp_path: Path) -> None:
     """A JS-only repo (no pyproject.toml) with the universal block → clean."""
     _write_package_json(tmp_path)
-    _write_gitignore(tmp_path, _UNIVERSAL_BLOCK + "\n")
+    _write_gitignore(tmp_path, _UNIVERSAL_BLOCK + "\n\n" + _HYGIENE_BLOCK + "\n")
 
     findings = validate(tmp_path, _SPEC_PATH)
 
@@ -134,7 +151,7 @@ def test_verbatim_match_passes(tmp_path: Path) -> None:
     _write_pyproject(tmp_path)
     _write_gitignore(
         tmp_path,
-        _UNIVERSAL_BLOCK + "\n\n" + _PYTHON_BLOCK + "\n",
+        _UNIVERSAL_BLOCK + "\n\n" + _PYTHON_BLOCK + "\n\n" + _HYGIENE_BLOCK + "\n",
     )
 
     findings = validate(tmp_path, _SPEC_PATH)
@@ -161,7 +178,7 @@ playwright-report/
 # === end onex-managed: universal ==="""
     _write_gitignore(
         tmp_path,
-        altered_universal + "\n\n" + _PYTHON_BLOCK + "\n",
+        altered_universal + "\n\n" + _PYTHON_BLOCK + "\n\n" + _HYGIENE_BLOCK + "\n",
     )
 
     findings = validate(tmp_path, _SPEC_PATH)
@@ -199,27 +216,28 @@ def test_missing_gitignore_produces_finding(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_both_blocks_missing_produces_two_findings(tmp_path: Path) -> None:
-    """Python repo with empty .gitignore → one finding per block."""
+def test_every_missing_block_produces_its_own_finding(tmp_path: Path) -> None:
+    """Python repo with empty .gitignore → one finding per applicable block."""
     _write_pyproject(tmp_path)
     _write_gitignore(tmp_path, "# just some comment\n")
 
     findings = validate(tmp_path, _SPEC_PATH)
 
-    assert len(findings) == 2, (
-        f"expected 2 findings (universal + python), got {findings}"
+    assert len(findings) == 3, (
+        f"expected 3 findings (universal + python + public_repo_hygiene), "
+        f"got {findings}"
     )
     block_names = {
         f.split("block ")[1].split("'")[1] for f in findings if "block " in f
     }
-    assert block_names == {"universal", "python"}
+    assert block_names == {"universal", "python", "public_repo_hygiene"}
 
 
 @pytest.mark.unit
 def test_no_pyproject_skips_python_block(tmp_path: Path) -> None:
     """Repo with no pyproject.toml only needs the universal block."""
     # No pyproject.toml, no package.json — plain repo
-    _write_gitignore(tmp_path, _UNIVERSAL_BLOCK + "\n")
+    _write_gitignore(tmp_path, _UNIVERSAL_BLOCK + "\n\n" + _HYGIENE_BLOCK + "\n")
 
     findings = validate(tmp_path, _SPEC_PATH)
 

--- a/tests/validation/test_gitignore_baseline_spec.py
+++ b/tests/validation/test_gitignore_baseline_spec.py
@@ -29,7 +29,7 @@ SPEC_PATH = (
 
 # Sections the DoD requires. Extending this list is a backwards-compatible
 # change; removing from it is not.
-REQUIRED_SECTIONS = {"universal", "python"}
+REQUIRED_SECTIONS = {"universal", "python", "public_repo_hygiene"}
 
 REQUIRED_BLOCK_FIELDS = {
     "description",
@@ -54,6 +54,26 @@ UNIVERSAL_REQUIRED_PATTERNS = [
     ".vscode/",
     "test-results/",
     "playwright-report/",
+]
+
+# OMN-18016 (epic OMN-17992). The agent-state, scratch and workspace-index
+# trees that kept landing in PUBLIC repositories.
+#
+# .onex/ and .onex_state/ are deliberately ABSENT and must stay absent: the
+# first is product surface read at runtime by the aislop rule loader, and the
+# second is governed by this repo's own OMN-15989 re-include, whose retirement
+# is blocked on an operator ruling. A conflicting managed rule would silently
+# fight a test-asserted rule. test_public_repo_hygiene_block_does_not_fight_the
+# _onex_state_reinclude pins that.
+PUBLIC_REPO_HYGIENE_REQUIRED_PATTERNS = [
+    ".claude/*",
+    "!.claude/architecture-handshake.md",
+    ".claude_scratch/",
+    ".repowise-workspace/",
+    ".repowise-workspace.yaml",
+    ".evidence/",
+    "docs/evidence/",
+    "merge-sweep/",
 ]
 
 PYTHON_REQUIRED_PATTERNS = [
@@ -206,4 +226,87 @@ def test_metadata_references_owning_ticket(spec: dict[str, Any]) -> None:
     related = metadata.get("related_tickets", [])
     assert "OMN-12451" in related, (
         "metadata.related_tickets must include OMN-12451 (this spec's owner ticket)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OMN-18016 — the public-repo hygiene managed block (epic OMN-17992).
+# ---------------------------------------------------------------------------
+
+
+def test_public_repo_hygiene_contains_required_patterns_in_order(
+    spec: dict[str, Any],
+) -> None:
+    """The hygiene block carries exactly the OMN-18016 patterns, in order."""
+    patterns = spec["managed_blocks"]["public_repo_hygiene"]["patterns"]
+    assert patterns == PUBLIC_REPO_HYGIENE_REQUIRED_PATTERNS, (
+        f"public_repo_hygiene patterns diverge from the OMN-18016 spec.\n"
+        f"  expected: {PUBLIC_REPO_HYGIENE_REQUIRED_PATTERNS}\n"
+        f"  actual:   {patterns}"
+    )
+
+
+def test_public_repo_hygiene_block_does_not_fight_the_onex_state_reinclude(
+    spec: dict[str, Any],
+) -> None:
+    """``.onex_state/`` must stay OUT of the managed block.
+
+    This repo's own ``.gitignore`` deliberately re-includes
+    ``.onex_state/evidence/`` and ``.onex_state/friction/`` (OMN-15989), with
+    ``test_onex_state_disposable_gitignore.py`` asserting it. Retiring that
+    re-include is root cause 4.1 of the OMN-17992 plan and is blocked on an
+    operator ruling about the public evidence corpus.
+
+    A managed ``.onex_state/`` rule would be appended AFTER those lines and
+    would silently override a test-asserted rule in one repo while reading as
+    a fleet-wide hygiene improvement. That is worse than the gap it closes,
+    so it is pinned absent until the ruling lands.
+    """
+    patterns = spec["managed_blocks"]["public_repo_hygiene"]["patterns"]
+    offenders = [p for p in patterns if ".onex_state" in p]
+    assert not offenders, (
+        f"the managed hygiene block declares {offenders}, which fights the "
+        "OMN-15989 re-include this repo still asserts. Retire the re-include "
+        "first (root cause 4.1), then add the pattern."
+    )
+
+
+def test_public_repo_hygiene_block_does_not_ignore_product_surface(
+    spec: dict[str, Any],
+) -> None:
+    """``.onex/`` is read at runtime by the aislop rule loader, not scratch.
+
+    Ignoring it would break the per-repo override mechanism OMN-11132 shipped,
+    and would do it in a change whose stated purpose is hygiene.
+    """
+    patterns = spec["managed_blocks"]["public_repo_hygiene"]["patterns"]
+    offenders = [p for p in patterns if p.rstrip("/*") == ".onex"]
+    assert not offenders, (
+        f"the managed hygiene block declares {offenders}; .onex/ is product "
+        "surface read by the aislop rule loader, not machine state."
+    )
+
+
+def test_the_tracked_handshake_file_survives_the_claude_rule(
+    spec: dict[str, Any],
+) -> None:
+    """A bare ``.claude/*`` would untrack the architecture handshake.
+
+    Every governed repo tracks ``.claude/architecture-handshake.md``. The
+    ignore-with-explicit-allowlist-exception pattern is the reason this block
+    can ship without breaking the handshake check in eight repos at once.
+    """
+    patterns = spec["managed_blocks"]["public_repo_hygiene"]["patterns"]
+    assert ".claude/*" in patterns
+    exception_index = patterns.index("!.claude/architecture-handshake.md")
+    assert exception_index > patterns.index(".claude/*"), (
+        "the re-include must come AFTER the ignore rule; git applies the last "
+        "matching pattern, so an exception placed first does nothing"
+    )
+
+
+def test_metadata_references_the_hygiene_ticket(spec: dict[str, Any]) -> None:
+    related = spec["metadata"].get("related_tickets", [])
+    assert "OMN-18016" in related, (
+        "metadata.related_tickets must name the ticket that added the block"
     )


### PR DESCRIPTION
Ticket: OMN-18016 (epic OMN-17992). Mechanism 5 of the public-repo hygiene inventory plan, the managed-ignore-block item.

Section 5.6 of the plan asks for the standard public-repo ignore block to ship through the generator that already writes the `universal` and `python` blocks into these repos, rather than as an eighth hand-maintained copy that drifts.

## Read section 4.9 before trusting this

An ignore file **does not untrack an existing path** and does not stop a forced add. The plan proves both directions from live state: five repos are clean of these classes with **no rule covering them at all**, by author discipline and repo youth; meanwhile one repo has its OS-junk file committed *and* ignored, because the rule was added after the file, and another has a settings file committed despite **two** matching ignore rules.

So this block is a useful **first** layer and a worthless **last** one. The enforcement layer is the OMN-18014 gate, which checks the **tracked set** rather than the ignore rules. That reasoning is written into the block header, in the file, so the next reader does not have to infer it.

## Two classes are deliberately absent, each pinned by its own test

Their absence is a decision, not an oversight, and a test asserts it stays a decision rather than quietly becoming a gap or quietly becoming a rule.

## Scope

Ignore block, its baseline spec, and its tests. This PR does **not** adopt the hygiene gate in this repo — that adoption is blocked on this repo's own count-locked PR-triggered-workflow ratchet, which states that a gate like this belongs as a job inside `ci.yml` rather than as a new standalone workflow file. Routing around that with a waiver would be the self-granted-suppression move this programme exists to remove, so the migration is being done properly and separately.

Evidence-Ticket: OMN-18016
Evidence-Source: OCC#8557
