### PR TITLE
fix(OMN-18012): inherit the SASL credentials on the occ-companion-effect caller

### DIFF
--- a/.github/workflows/call-occ-companion-effect.yml
+++ b/.github/workflows/call-occ-companion-effect.yml
@@ -68,10 +68,21 @@
 # branch (same follow-up named in the infra caller and in OMN-14812, which is
 # a separate ticket about the legacy autobind publisher's own promotion).
 #
-# SECRET-FREE: no `secrets: inherit` — the dev-lane broker comes from
-# omnimarket's committed config/ci_bus_lanes.yaml overlay (OMN-14813), and the
-# dev-lane listener is plaintext. This repo needs no Kafka secrets for this
-# workflow.
+# BROKER-SECRET-FREE, SASL-CREDENTIALLED (OMN-14813 + OMN-18012). The paragraph
+# this replaces asserted that this workflow needs no Kafka secrets because the
+# dev-lane listener was unauthenticated. The BROKER half still holds and always
+# will:
+# it comes from omnimarket's committed config/ci_bus_lanes.yaml overlay and must
+# never be a secret, because an opaque broker value is the OMN-14800 silent-
+# repoint surface. The transport half expired at ~16:40Z on 2026-09-07, when
+# OMN-18012 Phase B enabled SASL/SCRAM-SHA-256 on the dev-lane listener. The
+# overlay now DECLARES that transport (SASL_PLAINTEXT / SCRAM-SHA-256 —
+# authenticated, not encrypted) and omnimarket's publisher reads the protocol
+# from it rather than inferring TLS from credential presence. `secrets: inherit`
+# is therefore required below so KAFKA_SASL_{USERNAME,PASSWORD} reach the
+# publisher; without them it fail-fasts on the declared SASL lane instead of
+# publishing unauthenticated. A credential is not a broker address and
+# re-creates none of the OMN-14800 surface.
 #
 # Ticket: OMN-14990 (OMN-14941 / OMN-14811 / OMN-14987 lineage)
 
@@ -109,5 +120,12 @@ jobs:
     # the caller-level duplicate of the gate (which produced NO check run at
     # all) is removed.
     uses: OmniNode-ai/omniclaude/.github/workflows/call-occ-companion-effect-reusable.yml@dev
+    # OMN-18012: the dev lane declares SASL_PLAINTEXT/SCRAM-SHA-256, so the
+    # publisher needs the KAFKA_SASL_* credentials. The broker is still
+    # resolved from omnimarket's committed overlay, never from a secret.
+    # pragma: allowlist secret -- `secrets: inherit` is a GHA syntax keyword,
+    # not a literal secret; the repo secret scanner's Secret Keyword heuristic
+    # false-positives on the word "secrets:" here.
+    secrets: inherit  # pragma: allowlist secret
     with:
       lane: dev


### PR DESCRIPTION
## Summary

Follow-up to OmniNode-ai/omnimarket#2387 and OmniNode-ai/omniclaude#2121, mirroring the omnibase_infra caller fix that landed as `d68896913`.

This repo's `.github/workflows/call-occ-companion-effect.yml` still called the omniclaude companion-effect reusable with no `secrets: inherit`, and its header still asserted the dev-lane listener needed no Kafka credentials. That assertion expired at ~16:40Z on 2026-09-07 when OMN-18012 Phase B enabled SASL/SCRAM-SHA-256 on the dev-lane listener. The publisher now resolves the transport from omnimarket's committed `config/ci_bus_lanes.yaml` overlay (`security_protocol: SASL_PLAINTEXT`, `sasl_mechanism: SCRAM-SHA-256`) and fail-fasts when the credentials are absent rather than publishing unauthenticated, so every companion-effect publish from this repo has been failing.

Changes, all in the one caller workflow:

- `secrets: inherit` on the job that calls the omniclaude reusable, so `KAFKA_SASL_USERNAME` / `KAFKA_SASL_PASSWORD` reach the publish step.
- The stale header paragraph replaced with the corrected one.

Unlike the four sibling repos in this fan-out, this caller has no `workflow_dispatch` manual-replay job, so there is no second publish step to credential here.

The broker is still resolved from the committed overlay and is deliberately NOT a secret — an opaque broker value is the OMN-14800 silent-repoint surface. A credential is not a broker address.

## Verification

The change is workflow YAML only, so the autobind emitter declines to mint (skip:NO_RED_DERIVABLE_CHECK, OMN-15247) and the companion is minted by the companion-effect path instead. The evidence is a content check on the committed workflow, RED on `origin/dev` and GREEN on this head:

```
# RED on origin/dev
git show origin/dev:.github/workflows/call-occ-companion-effect.yml | grep -cE "^[[:space:]]+secrets: inherit"   -> 0
git show origin/dev:.github/workflows/call-occ-companion-effect.yml | grep -c  "listener is plaintext"           -> 1

# GREEN on this branch
grep -cE "^[[:space:]]+secrets: inherit" .github/workflows/call-occ-companion-effect.yml   -> 1
grep -c  "listener is plaintext"         .github/workflows/call-occ-companion-effect.yml   -> 0
```

Parsed-YAML check (not a text grep): the job whose `uses:` names `call-occ-companion-effect-reusable.yml` has `secrets == "inherit"`.

Governed pre-push selector on this head: 1990 passed, 4 warnings, 129s — `[prepush-smart-tests] impacted tests passed; allowing push.`

Ticket: OMN-18012

Evidence-Ticket: OMN-18012
Evidence-Source: OCC#8615
