### PR TITLE
feat(OMN-18056): a dod_evidence item can declare which acceptance criteria it covers

### DIFF
--- a/src/omnibase_core/models/contracts/ticket/model_dod_evidence_item.py
+++ b/src/omnibase_core/models/contracts/ticket/model_dod_evidence_item.py
@@ -59,6 +59,40 @@ class ModelDodEvidenceItem(BaseModel):
     id: str = Field(..., min_length=1)
     description: str = Field(..., min_length=1)
     checks: list[ModelDodEvidenceCheck] = Field(default_factory=list)
+    # OMN-18056. WHICH ACCEPTANCE CRITERIA THIS ITEM CLAIMS TO COVER.
+    #
+    # Until this field existed the relation between a ticket's acceptance
+    # criteria and its evidence items was not merely undeclared, it was
+    # UNDECLARABLE: ``extra="forbid"`` above meant a contract that tried to
+    # state it would fail to parse. So the only question the evidence
+    # autoclose sweep could ask of a green verdict was "how many checks
+    # passed", never "which criterion did any of them cover".
+    #
+    # Measured (DoD closeout sweep run 2, 2026-09-08): 8 of 9 adjudicated
+    # sprint tickets satisfied the closer's full flip predicate and 7 of those
+    # 8 were not done — in every held case the acceptance criterion that
+    # decides the ticket was bound to no check in its contract. A corpus grep
+    # over all 8709 contracts for any binding field returned 0 files, against
+    # a positive control of 8708 for ``dod_evidence``.
+    #
+    # OPTIONAL AND DEFAULTED, so all 8709 existing contracts keep parsing
+    # unchanged; ``extra="forbid"`` stays, because forbidding what is not
+    # declared is the property that made this field necessary rather than a
+    # defect to route around.
+    #
+    # HONEST LIMIT, stated rather than implied: this is the AUTHOR'S CLAIM. A
+    # consumer can verify that a named check ran and was probative; it cannot
+    # verify that the check proves the criterion. What the field removes is
+    # the SILENT case — a criterion nothing even claims to cover — not
+    # authorial error.
+    binds_ac: tuple[str, ...] = Field(
+        default=(),
+        description=(
+            "Acceptance-criterion labels (`AC1`, `DoD2`) from the ticket body "
+            "that this evidence item claims to prove. Empty means the item "
+            "claims none, which is a coverage gap rather than a pass."
+        ),
+    )
 
     @model_validator(mode="after")
     def reject_sole_file_exists_check(self) -> ModelDodEvidenceItem:

--- a/src/omnibase_core/models/ticket/model_contract_dod_item.py
+++ b/src/omnibase_core/models/ticket/model_contract_dod_item.py
@@ -58,6 +58,26 @@ class ModelContractDodItem(BaseModel):
         default="generated",
         description="Where this DoD item originated",
     )
+    # OMN-18056. WHICH ACCEPTANCE CRITERIA THIS ITEM CLAIMS TO COVER.
+    #
+    # This model owns the item-level field set the DoD verifier validates
+    # contracts against, so a binding declared only on the receipt-gate model
+    # would be rejected here as an unknown field. Both models carry it, for
+    # the same reason and with the same meaning.
+    #
+    # See ModelDodEvidenceItem for the measurement that motivated it: the
+    # relation between a ticket's acceptance criteria and its evidence was
+    # UNDECLARABLE under `extra="forbid"`, so a green verdict could only ever
+    # report how many checks passed, never which criterion any covered.
+    binds_ac: tuple[str, ...] = Field(
+        default=(),
+        max_length=_MAX_LIST_ITEMS,
+        description=(
+            "Acceptance-criterion labels (`AC1`, `DoD2`) from the ticket body "
+            "that this evidence item claims to prove. Empty means it claims "
+            "none, which is a coverage gap rather than a pass."
+        ),
+    )
     linear_dod_text: str | None = Field(
         default=None,
         description="Original DoD text from Linear, if sourced from Linear",

--- a/tests/unit/models/contracts/test_model_dod_evidence_item.py
+++ b/tests/unit/models/contracts/test_model_dod_evidence_item.py
@@ -205,3 +205,21 @@ def test_an_undeclared_field_is_still_refused() -> None:
             ],
             binds_acceptance_criteria=("AC1",),  # type: ignore[call-arg]
         )
+
+
+def test_the_governance_item_model_carries_the_same_binding() -> None:
+    """Both item models own the field, because both gate on the field set.
+
+    ``ModelContractDodItem`` is what the DoD verifier validates a contract's
+    items against; a binding declared only on the receipt-gate model would be
+    rejected THERE as an unknown field, so a contract could not carry it at
+    all. One meaning, two owners, added together.
+    """
+    from omnibase_core.models.ticket.model_contract_dod_item import (
+        ModelContractDodItem,
+    )
+
+    assert ModelContractDodItem(id="dod-1", description="x").binds_ac == ()
+    assert ModelContractDodItem(
+        id="dod-1", description="x", binds_ac=("AC1",)
+    ).binds_ac == ("AC1",)

--- a/tests/unit/models/contracts/test_model_dod_evidence_item.py
+++ b/tests/unit/models/contracts/test_model_dod_evidence_item.py
@@ -155,3 +155,53 @@ class TestModelDodEvidenceItemAcceptedShapes:
             checks=[],
         )
         assert item.checks == []
+
+
+# -- OMN-18056: the acceptance-criterion binding ---------------------------
+
+
+def test_binds_ac_defaults_to_empty_so_the_whole_corpus_keeps_parsing() -> None:
+    """8709 existing contracts declare no binding; none of them may break.
+
+    The field is the enabling half of OMN-18056 and it is additive by
+    construction: an item that says nothing about acceptance criteria is still
+    a valid item, it just covers none of them — which is a coverage gap for
+    the consumer to report, never a parse error here.
+    """
+    item = ModelDodEvidenceItem(
+        id="dod-1",
+        description="tests pass",
+        checks=[ModelDodEvidenceCheck(check_type="test_passes", check_value="pytest")],
+    )
+    assert item.binds_ac == ()
+
+
+def test_a_contract_can_declare_which_criteria_an_item_covers() -> None:
+    """THE RECORDED DEFECT, at the layer that made it unfixable.
+
+    Before this field, ``extra="forbid"`` meant a contract that TRIED to state
+    which criterion an evidence item proves would fail to parse — so the
+    relation was not merely undeclared across the corpus, it was undeclarable,
+    and the only question a consumer could ask of a green verdict was how many
+    checks passed.
+    """
+    item = ModelDodEvidenceItem(
+        id="dod-tests",
+        description="terminal isolation covered on both call sites",
+        checks=[ModelDodEvidenceCheck(check_type="test_passes", check_value="pytest")],
+        binds_ac=("AC2", "AC3"),
+    )
+    assert item.binds_ac == ("AC2", "AC3")
+
+
+def test_an_undeclared_field_is_still_refused() -> None:
+    """`extra="forbid"` stays. It is why the field was needed, not a defect."""
+    with pytest.raises(ValidationError):
+        ModelDodEvidenceItem(
+            id="dod-1",
+            description="x",
+            checks=[
+                ModelDodEvidenceCheck(check_type="test_passes", check_value="pytest")
+            ],
+            binds_acceptance_criteria=("AC1",),  # type: ignore[call-arg]
+        )


### PR DESCRIPTION
## OMN-18056 — a `dod_evidence` item can declare which acceptance criteria it covers

Two models, one meaning, added together: `binds_ac: tuple[str, ...] = ()` on `ModelDodEvidenceItem` (the receipt-gate model) and on `ModelContractDodItem` (what the DoD verifier validates a contract's items against).

### Why both, and why the field is needed at all

Until now the relation between a ticket's acceptance criteria and its evidence items was not merely undeclared across the corpus — it was **UNDECLARABLE**. `extra="forbid"` meant a contract that tried to state it would fail to parse. So the only question the evidence autoclose sweep could ask of a green verdict was *how many* checks passed, never *which criterion* any of them covered.

A binding declared on only one of the two models would be rejected as an unknown field on the other, so a contract could not carry it at all. Both, in one change.

### The measurement

DoD closeout sweep run 2, 2026-09-08: **7 of the 9** tickets that satisfied the closer's full flip predicate were **not** done, and in every held case the criterion that decides the ticket was bound to no check. A corpus grep across all 8709 contracts for any binding field returned **0** files; positive control on the same corpus for `dod_evidence` returned **8708**.

### Scope and compatibility

Optional and defaulted, so every existing contract keeps parsing unchanged. `extra="forbid"` stays — forbidding the undeclared is exactly why the field was needed rather than a rule to route around.

**Honest limit, stated in the model itself:** this is the author's CLAIM. A consumer can verify that a named check ran and was probative; it cannot verify that the check proves the criterion. What the field removes is the *silent* case — an evidence corpus with no expressible relation to the criteria it is supposed to prove.

### Consumer sequencing, so the release is not a surprise

`onex_change_control` resolves `omnibase-core` from a **PyPI release pin** — `omnibase-core>=0.46.8,<0.47.0` in `pyproject.toml`, `uv.lock` at `0.46.13`, from `registry = "https://pypi.org/simple"`; the git override was removed in OMN-13878. Its validators that import core models (`scripts/validation/check_receipt_hardening.py` → `ModelDodReceipt`, `validator_receipt_gate`) therefore run against the *released* core, not against `dev`.

So **no contract may declare `binds_ac` until a core release inside that range carries this change** — `extra="forbid"` would reject it in OCC CI. Whether and when to cut that release is the orchestrator's call, not this PR's; nothing in this PR depends on it, and the enforcing half (omnibase_infra#3347) reads `binds_ac` off the dod_verify verdict JSON and imports no core model.

### Verification

- 15 focused tests green: `tests/unit/models/contracts/test_model_dod_evidence_item.py`.
- The governed pre-push selector ran **off-box on the lab** and passed: `44998 passed, 53 skipped, 3 xpassed in 5752.16s (1:35:52)`, then `[prepush-smart-tests] impacted tests passed; allowing push.` No `PREPUSH_*` override, no `-k` narrowing, no bypass flag.
- `mypy --strict`, `pyright`, and every pre-commit gate passed as part of that push.

**Lab-first (CLAUDE.md rule 24), stated rather than borrowed:** this is two Pydantic model fields with no runtime surface — nothing deploys, no lane or cluster is touched — so there is no lab pass to cite and **none is claimed**. The evidence above is the governed pre-push plus the focused suite.

Ticket: OMN-18056

Evidence-Source: OCC#8753
Evidence-Ticket: OMN-18056