### PR TITLE
fix(OMN-17523): type served model references

### DIFF
--- a/src/omnibase_core/models/routing/__init__.py
+++ b/src/omnibase_core/models/routing/__init__.py
@@ -63,6 +63,8 @@ from omnibase_core.models.routing.model_routing_policy import (
     ModelCiOverridePolicy,
     ModelRoutingPolicy,
 )
+from omnibase_core.models.routing.model_served_model_name import ModelServedModelName
+from omnibase_core.models.routing.model_served_model_ref import ModelServedModelRef
 from omnibase_core.models.routing.model_tier_attempt import ModelTierAttempt
 from omnibase_core.models.routing.model_tiered_resolution_config import (
     ModelTieredResolutionConfig,
@@ -86,6 +88,8 @@ __all__ = [
     "ModelHopConstraints",
     "ModelLlmRouteRejectedEvent",
     "ModelLlmRouteResolvedEvent",
+    "ModelServedModelRef",
+    "ModelServedModelName",
     "ModelPolicyBundle",
     "ModelRedactionPolicy",
     "ModelResolutionEvent",

--- a/src/omnibase_core/models/routing/model_llm_route_rejected_event.py
+++ b/src/omnibase_core/models/routing/model_llm_route_rejected_event.py
@@ -7,10 +7,12 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Self
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from omnibase_core.enums.enum_routing_error_class import RoutingErrorClass
+from omnibase_core.models.routing.model_served_model_ref import ModelServedModelRef
 
 
 class ModelLlmRouteRejectedEvent(BaseModel):
@@ -18,16 +20,16 @@ class ModelLlmRouteRejectedEvent(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
-    routing_decision_id: str = Field(
-        ..., description="Stable identifier for this routing decision."
+    routing_decision_id: UUID = Field(
+        ..., description="Router-owned UUID generated once for this routing decision."
     )
     correlation_id: str = Field(..., description="Originating correlation id.")
     logical_model_key: str = Field(
         ..., description="Logical model key requested by policy."
     )
-    served_model_id: str = Field(
-        default="",
-        description="Concrete model id if any model was attempted.",
+    served_model_id: ModelServedModelRef | None = Field(
+        default=None,
+        description="Provider-qualified model reference when a model was attempted.",
     )
     endpoint_ref: str = Field(
         default="",
@@ -62,6 +64,12 @@ class ModelLlmRouteRejectedEvent(BaseModel):
     def _policy_hash_alias_matches(self) -> Self:
         if self.policy_hash != self.routing_policy_hash:
             msg = "policy_hash must equal routing_policy_hash"
+            raise ValueError(msg)
+        if (
+            self.served_model_id is not None
+            and self.served_model_id.provider != self.provider
+        ):
+            msg = "served_model_id provider must equal event provider"
             raise ValueError(msg)
         return self
 

--- a/src/omnibase_core/models/routing/model_llm_route_resolved_event.py
+++ b/src/omnibase_core/models/routing/model_llm_route_resolved_event.py
@@ -7,8 +7,11 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Self
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from omnibase_core.models.routing.model_served_model_ref import ModelServedModelRef
 
 
 class ModelLlmRouteResolvedEvent(BaseModel):
@@ -16,15 +19,15 @@ class ModelLlmRouteResolvedEvent(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
 
-    routing_decision_id: str = Field(
-        ..., description="Stable identifier for this routing decision."
+    routing_decision_id: UUID = Field(
+        ..., description="Router-owned UUID generated once for this routing decision."
     )
     correlation_id: str = Field(..., description="Originating correlation id.")
     logical_model_key: str = Field(
         ..., description="Logical model key requested by policy."
     )
-    served_model_id: str = Field(
-        ..., description="Concrete served model id selected from the registry."
+    served_model_id: ModelServedModelRef = Field(
+        ..., description="Provider-qualified concrete model selected from the registry."
     )
     endpoint_ref: str = Field(
         ..., description="Contract-owned endpoint reference; never a secret value."
@@ -55,6 +58,9 @@ class ModelLlmRouteResolvedEvent(BaseModel):
     def _policy_hash_alias_matches(self) -> Self:
         if self.policy_hash != self.routing_policy_hash:
             msg = "policy_hash must equal routing_policy_hash"
+            raise ValueError(msg)
+        if self.served_model_id.provider != self.provider:
+            msg = "served_model_id provider must equal event provider"
             raise ValueError(msg)
         return self
 

--- a/src/omnibase_core/models/routing/model_served_model_name.py
+++ b/src/omnibase_core/models/routing/model_served_model_name.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Validated provider-local name of a model served by a router."""
+
+from __future__ import annotations
+
+from pydantic import ConfigDict, RootModel, field_validator
+
+
+class ModelServedModelName(RootModel[str]):
+    """Non-empty provider-local model name with a scalar JSON shape."""
+
+    model_config = ConfigDict(frozen=True)
+
+    @field_validator("root")
+    @classmethod
+    def _require_nonempty_name(cls, value: str) -> str:
+        if not value.strip():
+            msg = "served model name must be nonempty"
+            raise ValueError(msg)
+        return value
+
+
+__all__ = ["ModelServedModelName"]

--- a/src/omnibase_core/models/routing/model_served_model_ref.py
+++ b/src/omnibase_core/models/routing/model_served_model_ref.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed provider-qualified identity for a model served by a router."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omnibase_core.models.routing.model_served_model_name import ModelServedModelName
+
+
+class ModelServedModelRef(BaseModel):
+    """Identifies the provider and concrete model selected by a route."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+    provider: str = Field(..., description="Provider that served the model.")
+    model_id: ModelServedModelName = Field(
+        ..., description="Provider-local served model identifier."
+    )
+
+    @field_validator("provider")
+    @classmethod
+    def _require_nonempty_identifier(cls, value: str) -> str:
+        """Reject empty or whitespace-only provider and model identifiers."""
+        if not value.strip():
+            msg = "served-model reference identifiers must be nonempty"
+            raise ValueError(msg)
+        return value
+
+
+__all__ = ["ModelServedModelRef"]

--- a/tests/unit/models/routing/test_model_llm_route_events.py
+++ b/tests/unit/models/routing/test_model_llm_route_events.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from uuid import UUID, uuid4
 
 import pytest
 from pydantic import ValidationError
@@ -18,14 +19,19 @@ from omnibase_core.models.routing.model_llm_route_resolved_event import (
     ModelLlmRouteResolvedEvent,
 )
 from omnibase_core.models.routing.model_routing_policy import ModelRoutingPolicy
+from omnibase_core.models.routing.model_served_model_name import ModelServedModelName
+from omnibase_core.models.routing.model_served_model_ref import ModelServedModelRef
 
 
 def test_resolved_route_event_requires_policy_hash_alias_match() -> None:
+    routing_decision_id = uuid4()
     event = ModelLlmRouteResolvedEvent(
-        routing_decision_id="decision-1",
+        routing_decision_id=routing_decision_id,
         correlation_id="corr-1",
         logical_model_key="coder",
-        served_model_id="qwen3-coder-30b",
+        served_model_id=ModelServedModelRef(
+            provider="local", model_id="qwen3-coder-30b"
+        ),
         endpoint_ref="LLM_LOCAL_PRIMARY_URL",
         provider="local",
         registry_hash="sha256:registry",
@@ -39,15 +45,25 @@ def test_resolved_route_event_requires_policy_hash_alias_match() -> None:
 
     assert event.policy_hash == event.routing_policy_hash
     assert event.logical_model_key == "coder"
+    assert event.routing_decision_id == routing_decision_id
+    assert event.model_dump(mode="json")["routing_decision_id"] == str(
+        routing_decision_id
+    )
+    assert event.model_dump(mode="json")["served_model_id"] == {
+        "provider": "local",
+        "model_id": "qwen3-coder-30b",
+    }
 
 
 def test_resolved_route_event_rejects_mismatched_policy_hash_alias() -> None:
     with pytest.raises(ValidationError, match="policy_hash must equal"):
         ModelLlmRouteResolvedEvent(
-            routing_decision_id="decision-1",
+            routing_decision_id=uuid4(),
             correlation_id="corr-1",
             logical_model_key="coder",
-            served_model_id="qwen3-coder-30b",
+            served_model_id=ModelServedModelRef(
+                provider="local", model_id="qwen3-coder-30b"
+            ),
             endpoint_ref="LLM_LOCAL_PRIMARY_URL",
             provider="local",
             registry_hash="sha256:registry",
@@ -62,7 +78,7 @@ def test_resolved_route_event_rejects_mismatched_policy_hash_alias() -> None:
 
 def test_rejected_route_event_carries_failure_classification() -> None:
     event = ModelLlmRouteRejectedEvent(
-        routing_decision_id="decision-2",
+        routing_decision_id=uuid4(),
         correlation_id="corr-2",
         logical_model_key="coder",
         registry_hash="sha256:registry",
@@ -76,7 +92,81 @@ def test_rejected_route_event_carries_failure_classification() -> None:
     )
 
     assert event.failure_class is RoutingErrorClass.FALLBACK_UNAUTHORIZED
-    assert event.served_model_id == ""
+    assert event.served_model_id is None
+    assert event.model_dump(mode="json")["served_model_id"] is None
+
+
+def test_served_model_ref_rejects_empty_provider_or_model_id() -> None:
+    with pytest.raises(ValidationError, match="nonempty"):
+        ModelServedModelRef(provider=" ", model_id="qwen3-coder-30b")
+    with pytest.raises(ValidationError, match="nonempty"):
+        ModelServedModelRef(provider="local", model_id=" ")
+
+
+def test_served_model_name_is_frozen_and_serializes_as_scalar() -> None:
+    name = ModelServedModelName("qwen3-coder-30b")
+    assert name.root == "qwen3-coder-30b"
+    assert name.model_dump(mode="json") == "qwen3-coder-30b"
+    with pytest.raises(ValidationError, match="nonempty"):
+        ModelServedModelName(" \t")
+    with pytest.raises(ValidationError, match="frozen"):
+        name.root = "other"  # type: ignore[misc]
+
+
+def test_served_model_ref_keeps_model_id_as_nested_scalar() -> None:
+    reference = ModelServedModelRef(provider="local", model_id="qwen3-coder-30b")
+    assert reference.model_id.root == "qwen3-coder-30b"
+    assert reference.model_dump(mode="json") == {
+        "provider": "local",
+        "model_id": "qwen3-coder-30b",
+    }
+
+
+def test_resolved_route_event_rejects_mismatched_served_model_provider() -> None:
+    with pytest.raises(ValidationError, match="must equal event provider"):
+        ModelLlmRouteResolvedEvent(
+            routing_decision_id=uuid4(),
+            correlation_id="corr-1",
+            logical_model_key="coder",
+            served_model_id=ModelServedModelRef(
+                provider="remote", model_id="qwen3-coder-30b"
+            ),
+            endpoint_ref="LLM_LOCAL_PRIMARY_URL",
+            provider="local",
+            registry_hash="sha256:registry",
+            routing_policy_hash="sha256:policy",
+            policy_hash="sha256:policy",
+            pricing_manifest_hash="sha256:pricing",
+            created_at=datetime.now(UTC),
+        )
+
+
+def test_rejected_route_event_allows_only_null_or_provider_qualified_model_reference() -> (
+    None
+):
+    routing_decision_id = uuid4()
+    event = ModelLlmRouteRejectedEvent(
+        routing_decision_id=routing_decision_id,
+        correlation_id="corr-1",
+        logical_model_key="coder",
+        served_model_id=ModelServedModelRef(
+            provider="local", model_id="qwen3-coder-30b"
+        ),
+        endpoint_ref="LLM_LOCAL_PRIMARY_URL",
+        provider="local",
+        registry_hash="sha256:registry",
+        routing_policy_hash="sha256:policy",
+        policy_hash="sha256:policy",
+        pricing_manifest_hash="sha256:pricing",
+        failure_class=RoutingErrorClass.NO_ELIGIBLE_MODEL,
+        failure_reason="none",
+        created_at=datetime.now(UTC),
+    )
+
+    assert isinstance(event.routing_decision_id, UUID)
+    assert event.served_model_id == ModelServedModelRef(
+        provider="local", model_id="qwen3-coder-30b"
+    )
 
 
 def test_model_routing_policy_requires_fallback_when_roles_declared() -> None:


### PR DESCRIPTION
## OMN-17523 — typed route-event identity references

This Core-only change models the router-owned decision identifier as UUID and the selected model as an explicit immutable provider-qualified reference. Rejected events carry `null` when no model was attempted. `ModelServedModelName` preserves the scalar JSON representation of the provider-local model name, so the nested wire remains `{ "provider": "…", "model_id": "…" }`.

### Scope

- Core only; no OmniMarket change is included.
- The locked Market package boundary remains unresolved and is not claimed here.
- No release, deployment, runtime, Kafka, or pricing-provenance change.

### Local evidence

- `tests/unit/models/routing/test_model_llm_route_events.py`: 9 passed.
- Ruff, targeted strict mypy, string-version validation, targeted pre-commit, and `git diff --check`: passed.
- Exact product head: `c33ca209180e97ef665896c7c7375530b5087f56`.
- Coordination record: KBI #319 (open).

Exact-head OCC companion #8759 merged at a106bca2aacf9fd21b20b727014825e97e7fd01c. This PR remains unmerged with auto-merge off.

Ticket: OMN-17523
Evidence-Ticket: OMN-17523
Evidence-Source: OCC#8759
Evidence-Commit: a106bca2aacf9fd21b20b727014825e97e7fd01c