### PR TITLE
fix(OMN-18058): the release-identity fallback stays merge-base anchored

### DIFF
--- a/scripts/check_release_identity.py
+++ b/scripts/check_release_identity.py
@@ -113,9 +113,16 @@ def _packaged_source_changed(base: str | None, explicit: list[str]) -> bool:
         diff = _git(["diff", "--name-only", f"{base}...HEAD"])
         files = [f for f in diff.splitlines() if f.strip()]
         if not files:
-            # Fall back to a two-dot diff if the merge-base form yielded nothing.
-            diff = _git(["diff", "--name-only", base])
-            files = [f for f in diff.splitlines() if f.strip()]
+            # No commits of our own: look for uncommitted edits, still anchored on
+            # the MERGE BASE (OMN-18058). Never the two-dot ``git diff <base>``:
+            # that form describes the difference between two trees, so on a stale
+            # base it reports every packaged-source file a PEER landed on the base
+            # branch as this branch's change, arming this version gate against a
+            # branch that touched no packaged source at all.
+            merge_base = _git(["merge-base", base, "HEAD"])
+            if merge_base:
+                diff = _git(["diff", "--name-only", merge_base])
+                files = [f for f in diff.splitlines() if f.strip()]
     else:
         # No base and no explicit list: cannot prove the diff is exempt — enforce.
         return True

--- a/tests/scripts/test_check_release_identity.py
+++ b/tests/scripts/test_check_release_identity.py
@@ -211,3 +211,95 @@ def test_live_invocation_fails_when_version_is_not_ahead(tmp_path):
 
     assert result.returncode == 1, result.stdout
     assert "is NOT ahead of the latest published version" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# OMN-18058: the empty-three-dot fallback stays MERGE-BASE anchored.
+# ---------------------------------------------------------------------------
+
+
+def _omn18058_git(repo: Path, *args: str) -> str:
+    # OMN-14891: git exports GIT_DIR/GIT_WORK_TREE into every hook environment and
+    # those OVERRIDE `-C`, so an unscrubbed fixture would mutate the real worktree.
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=scrub_git_location_env(os.environ),
+    ).stdout
+
+
+def _omn18058_stale_base_repo(tmp_path: Path) -> Path:
+    """A branch with NO commits of its own, after which a peer advanced ``dev``.
+
+    The peer's commit touches packaged source (``src/``), so the two-dot form
+    attributes a packaged-source change to a branch that changed nothing.
+    """
+    origin = tmp_path / "omn18058-origin.git"
+    work = tmp_path / "omn18058-work"
+    subprocess.run(
+        ["git", "init", "-q", "--bare", str(origin)],
+        check=True,
+        env=scrub_git_location_env(os.environ),
+    )
+    subprocess.run(
+        ["git", "init", "-q", str(work)],
+        check=True,
+        env=scrub_git_location_env(os.environ),
+    )
+    _omn18058_git(work, "config", "user.email", "omn18058@example.invalid")
+    _omn18058_git(work, "config", "user.name", "omn18058 fixture")
+    _omn18058_git(work, "config", "commit.gpgsign", "false")
+    _omn18058_git(work, "checkout", "-q", "-b", "dev")
+    (work / "docs").mkdir(parents=True, exist_ok=True)
+    (work / "docs" / "base.md").write_text("base\n", encoding="utf-8")
+    _omn18058_git(work, "add", "-A")
+    _omn18058_git(work, "commit", "-q", "-m", "base")
+    _omn18058_git(work, "remote", "add", "origin", str(origin))
+    _omn18058_git(work, "push", "-q", "origin", "dev")
+
+    _omn18058_git(work, "checkout", "-q", "-b", "feature")
+    _omn18058_git(work, "checkout", "-q", "dev")
+    peer = work / "src" / "peer_pkg" / "landed_by_someone_else.py"
+    peer.parent.mkdir(parents=True, exist_ok=True)
+    peer.write_text("# a peer's packaged-source landing\n", encoding="utf-8")
+    _omn18058_git(work, "add", "-A")
+    _omn18058_git(work, "commit", "-q", "-m", "a peer's packaged-source landing")
+    _omn18058_git(work, "push", "-q", "origin", "dev")
+
+    _omn18058_git(work, "checkout", "-q", "feature")
+    _omn18058_git(work, "fetch", "-q", "origin", "dev")
+    return work
+
+
+@pytest.mark.unit
+def test_omn18058_empty_branch_diff_never_attributes_a_peers_packaged_source(
+    mod, monkeypatch, tmp_path
+):
+    """OMN-18058: a branch with no commits of its own is exempt, not armed.
+
+    The old fallback used the two-dot ``git diff origin/dev``, which describes
+    the difference between two TREES -- so every ``src/`` file a peer landed on
+    ``dev`` since the branch point was reported as this branch's change and the
+    version gate fired on work the branch never did.
+    """
+    repo = _omn18058_stale_base_repo(tmp_path)
+
+    # Positive controls, on this same fixture: the three-dot set really is empty
+    # (so the fallback under test is the branch that executes), and the two-dot
+    # form really does surface the peer's packaged-source file.
+    assert _omn18058_git(repo, "diff", "--name-only", "origin/dev...HEAD").strip() == ""
+    assert "src/peer_pkg/landed_by_someone_else.py" in _omn18058_git(
+        repo, "diff", "--name-only", "origin/dev", "HEAD"
+    )
+
+    monkeypatch.setattr(mod, "_REPO_ROOT", repo)
+    assert mod._packaged_source_changed("origin/dev", []) is False
+
+    # ...and the fallback still sees this branch's own UNCOMMITTED packaged edit.
+    own = repo / "src" / "own_pkg" / "mine.py"
+    own.parent.mkdir(parents=True, exist_ok=True)
+    own.write_text("# uncommitted, mine\n", encoding="utf-8")
+    _omn18058_git(repo, "add", "-A")
+    assert mod._packaged_source_changed("origin/dev", []) is True


### PR DESCRIPTION
## OMN-18058 — the release-identity fallback stays merge-base anchored

Closes OMN-18058 (sibling of the omnibase_infra change of the same name).

### What was wrong

`scripts/check_release_identity.py` `_packaged_source_changed` diffed the
three-dot `<base>...HEAD` set first and, when that came back empty, fell back to
the two-dot `git diff <base>`.

The two-dot form describes the difference between two **trees**, not the work on
one side of a merge base. On a branch cut from a stale base it therefore reports
every `src/` file a **peer** landed on the base branch since the branch point as
this branch's own change — arming the release-identity version gate against a
branch that touched no packaged source at all. The failure is silent and
inverted: the staler your base, the more of somebody else's packaged surface you
are asked to bump a version for.

### The fix

The fallback is now anchored on `git merge-base <base> HEAD`. It still sees this
branch's own **uncommitted** packaged edits — the case the fallback exists for —
and never a peer's commits. The verdict logic is otherwise byte-unchanged; only
the range moved.

### Evidence

New test in `tests/scripts/test_check_release_identity.py`, driving a real temp
git repo (branch with no commits of its own; peer advances `dev` with a `src/`
file), with three controls so no assertion can be vacuous:

- **Positive control A** — the three-dot set really is empty on that fixture, so
  the fallback under test is the branch that executes.
- **Positive control B** — the two-dot form on that **same** fixture really does
  surface the peer's packaged-source file.
- **Positive control C** — the narrowing does not disarm the gate: an
  uncommitted `src/` edit of the branch's own still returns `True`.

**RED control, captured before and after the fix:** reverting the fallback to
the two-dot form fails the new test with `assert True is False`; restoring it
passes.

The fixture shells out to git with a scrubbed environment (OMN-14891), so it
cannot retarget the real worktree from under a hook.

### Verification

- Focused: `uv run pytest tests/scripts/test_check_release_identity.py` — green.
- `ruff format` + `ruff check` clean on both touched files.
- `pre-commit` clean on the changed files.
- Governed pre-push selector (OMN-13973) ran and passed; no override env was set.

### Scope note

The OMN-18058 premise — that the OMN-14681 pre-push deploy-scope DoD gate and
the OMN-13973 governed selector derive their changed-file sets with a two-dot
diff — is **falsified**; both already resolve the merge base first. That finding,
its real-history replay, and the ratchets pinning both surfaces live in the
omnibase_infra PR of the same name. This PR fixes the one site in this repo that
genuinely did carry the two-dot attribution form.

Refs OMN-13411, OMN-13412, OMN-14681, OMN-13973.

Evidence-Ticket: OMN-18058
Evidence-Source: OCC#8763
