### PR TITLE
fix(OMN-18062): port the re-trigger-skip fix to omnibase_core's CI Summary gate

### DIFF
--- a/scripts/ci/ci_summary_gate.py
+++ b/scripts/ci/ci_summary_gate.py
@@ -262,6 +262,87 @@ def dedup_latest(
     return latest
 
 
+def _is_skipped_row(raw: dict[str, object]) -> bool:
+    """True for a completed check-run whose conclusion is ``skipped``."""
+
+    return (
+        str(raw.get("status") or "") == "completed"
+        and str(raw.get("conclusion") or "") == "skipped"
+    )
+
+
+def _skip_partition_key(raw: dict[str, object]) -> tuple[str, str]:
+    """Partition key for skip supersession: ``(context name, head SHA)``.
+
+    The head SHA is load-bearing, not decoration. A ``skipped`` row is only a
+    re-trigger artifact when a non-skipped row exists for the same name ON THE
+    SAME HEAD; a non-skipped row on a DIFFERENT head is a verdict about a
+    different commit and must not clear it. Partitioning by name alone would
+    let a ``success`` recorded on an earlier head silently suppress a
+    ``skipped`` on the head actually being gated — the exact skip-as-pass
+    vector (OMN-15057 / OMN-14854) the strict external bar exists for.
+
+    Rows carrying no ``head_sha`` field all share the ``""`` partition, so a
+    payload without head SHAs behaves exactly as it did before this guard.
+    Unreachable through the sanctioned caller — it fetches
+    ``commits/{sha}/check-runs`` for one head — but the safety of that rested
+    on convention, and this makes it a property of the function.
+    """
+
+    return (str(raw.get("name") or ""), str(raw.get("head_sha") or ""))
+
+
+def drop_superseded_skips(
+    check_runs: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Drop ``skipped`` rows for a ``(name, head_sha)`` that also carries a
+    non-skipped row (OMN-18062).
+
+    MECHANISM this closes, measured on onex_change_control#8709 (2026-09-08): a
+    ``gh pr edit`` of the PR body fires a SECOND ``pull_request`` run of a
+    workflow whose ``types:`` include ``edited``. A job in that run whose own
+    ``if:`` excludes ``edited`` is SKIPPED, and GitHub writes a FRESH check-run
+    with conclusion ``skipped`` onto the same, unchanged head SHA where that
+    very job reported ``success`` 64 seconds earlier. Latest-wins resolution in
+    :func:`_external_check_states` picks the skip, L4 admits only ``success``
+    (see :data:`EXPECTED_EXTERNAL_CONTEXTS`), and ``CI Summary`` fails closed on
+    a head nothing regressed on. Re-running ``CI Summary`` cannot clear it — the
+    skip is and stays the newest row for that name — so only a new head SHA can,
+    and every lane that edits a PR body (OCC autobind stamps, union-resolves)
+    pays a re-push cycle.
+
+    A ``skipped`` row is evidence about a WORKFLOW RUN — a job's ``if:`` was
+    false for that run's event — not about the head. When a non-skipped row for
+    the same name exists on the same head, that row is the verdict about the
+    head and the skip is a re-trigger artifact.
+
+    What this deliberately does NOT relax:
+
+    * ``skipped`` with **no** non-skipped row for that name still stands and
+      still fails closed — a producer whose ``if:`` was false for the whole life
+      of the head never ran, which is exactly the skip-as-pass vector
+      (OMN-15057 / OMN-14854) the strict external bar exists for.
+    * A ``failure`` (or ``cancelled``) after a ``success`` still wins on
+      recency — a failure IS a verdict about the head.
+    * A still-running row is non-skipped, so a later skip can never suppress
+      PENDING into a stale green.
+    * A skip on a DIFFERENT head SHA. Supersession is partitioned by
+      ``(name, head_sha)``, not by name alone — see
+      :func:`_skip_partition_key`.
+    """
+
+    non_skipped_keys = {
+        _skip_partition_key(raw)
+        for raw in check_runs
+        if str(raw.get("name") or "") and not _is_skipped_row(raw)
+    }
+    return [
+        raw
+        for raw in check_runs
+        if not (_is_skipped_row(raw) and _skip_partition_key(raw) in non_skipped_keys)
+    ]
+
+
 def _external_check_states(
     check_runs: list[dict[str, object]],
 ) -> dict[str, JobState]:
@@ -272,10 +353,14 @@ def _external_check_states(
     kept by latest ``started_at`` (lexicographic ISO-8601 compare; ties keep
     array order, last wins) so a stale failed rerun can never outrank a fresh
     success, mirroring the run-attempt dedup used for in-run jobs above.
+
+    Rows are read after :func:`drop_superseded_skips`, so a re-trigger skip
+    cannot supersede a real conclusion already recorded for that name on this
+    head (OMN-18062).
     """
 
     best: dict[str, tuple[str, JobState]] = {}
-    for raw in check_runs:
+    for raw in drop_superseded_skips(check_runs):
         name = str(raw.get("name") or "")
         if not name:
             continue

--- a/tests/unit/scripts/ci/test_ci_summary_gate.py
+++ b/tests/unit/scripts/ci/test_ci_summary_gate.py
@@ -30,6 +30,7 @@ from scripts.ci.ci_summary_gate import (
     SOFT_ALLOWLIST,
     SPEC_REQUIRED_VALIDATOR_JOBS,
     STRICT_SUCCESS_JOBS,
+    drop_superseded_skips,
     evaluate,
     evaluate_external,
 )
@@ -59,6 +60,7 @@ def _check_run(
     *,
     status: str = "completed",
     started_at: str = "",
+    head_sha: str = "",
 ) -> dict:
     """Build a ``commits/{sha}/check-runs`` row (L4 external-context fixture)."""
     return {
@@ -66,6 +68,7 @@ def _check_run(
         "status": status,
         "conclusion": conclusion,
         "started_at": started_at,
+        "head_sha": head_sha,
     }
 
 
@@ -877,3 +880,164 @@ class TestEnforceEverythingCompleteness:
                     f"{path.name} is neither a live PR validator nor "
                     "workflow_dispatch-only -- classify it"
                 )
+
+
+# --------------------------------------------------------------------------- #
+# OMN-18062 -- a `skipped` row that lands on a head SHA which ALREADY carries a
+# non-skipped row for the same context name is a RE-TRIGGER ARTIFACT, not a
+# verdict about that head.
+#
+# Live shape being pinned (onex_change_control#8709, 2026-09-08): `gh pr edit`
+# fired a second `pull_request` run of a workflow whose `types:` include
+# `edited`; a job whose own `if:` excludes `edited` was SKIPPED, and GitHub
+# wrote a fresh `skipped` check-run onto the unchanged head 64 seconds after
+# that same job reported `success`. Latest-wins resolution
+# (`_external_check_states`) read the newest row; L4 admits only `success`; the
+# required `CI Summary` context failed closed on a head nothing regressed on.
+# Re-running `CI Summary` could not clear it -- the skip is and stays the
+# newest row -- so only a new head SHA could.
+#
+# This was fixed in four repos (omnimarket#2422, onex_change_control#8748,
+# omnibase_infra#3348, omniclaude#2126) and NOT here; the defect was
+# reproduced against this file's own pre-fix code before this suite was added.
+#
+# Every relaxation below is paired with a positive control that must STILL
+# fail, and the head-SHA partition is pinned separately.
+# --------------------------------------------------------------------------- #
+
+_HEAD_A = "a" * 40
+_HEAD_B = "b" * 40
+_T0 = "2026-09-08T20:47:00Z"
+_T0_PLUS_64 = "2026-09-08T20:48:04Z"
+
+
+def _external_rows(*, head_sha: str = _HEAD_A, started_at: str = _T0) -> list[dict]:
+    """Every L4 context present + completed + success on one head."""
+
+    return [
+        _check_run(name, "success", started_at=started_at, head_sha=head_sha)
+        for name in EXPECTED_EXTERNAL_CONTEXTS
+    ]
+
+
+def _with_second_row(
+    target: str,
+    conclusion: str | None,
+    *,
+    status: str = "completed",
+    head_sha: str = _HEAD_A,
+) -> list[dict]:
+    """All-green L4 rows, plus a SECOND row for ``target`` 64 seconds later."""
+
+    runs = _external_rows()
+    runs.append(
+        _check_run(
+            target,
+            conclusion,
+            status=status,
+            started_at=_T0_PLUS_64,
+            head_sha=head_sha,
+        )
+    )
+    return runs
+
+
+class TestSupersededSkips:
+    """OMN-18062 port: a re-trigger skip must not supersede a real verdict."""
+
+    def test_all_green_baseline_is_success(self) -> None:
+        """CONTROL for every zero below: the unperturbed fixture passes."""
+
+        failures, missing = evaluate_external(_external_rows())
+        assert failures == []
+        assert missing == []
+
+    def test_skip_after_success_on_same_head_is_not_a_regression(self) -> None:
+        """GREEN: success at t0, skipped at t0+64s, SAME head -> success.
+
+        This is the case that was failing closed before this change.
+        """
+
+        target = EXPECTED_EXTERNAL_CONTEXTS[0]
+        runs = _with_second_row(target, "skipped")
+        failures, missing = evaluate_external(runs)
+        assert failures == [], failures
+        assert missing == [], missing
+
+    def test_failure_after_success_on_same_head_still_fails(self) -> None:
+        """POSITIVE CONTROL: a real verdict at t0+64s still wins on recency."""
+
+        target = EXPECTED_EXTERNAL_CONTEXTS[0]
+        failures, _missing = evaluate_external(_with_second_row(target, "failure"))
+        assert failures == [target]
+
+    def test_cancelled_after_success_on_same_head_still_fails(self) -> None:
+        """POSITIVE CONTROL: `cancelled` is a verdict too, not an artifact."""
+
+        target = EXPECTED_EXTERNAL_CONTEXTS[0]
+        failures, _missing = evaluate_external(_with_second_row(target, "cancelled"))
+        assert failures == [target]
+
+    def test_lone_skip_with_no_other_row_still_fails_closed(self) -> None:
+        """POSITIVE CONTROL: a name whose ONLY row is `skipped` fails closed.
+
+        This is the skip-as-pass vector (OMN-15057 / OMN-14854) the strict L4
+        bar exists for -- a producer whose `if:` was false for the whole life
+        of the head never ran, and must never read green.
+        """
+
+        target = EXPECTED_EXTERNAL_CONTEXTS[0]
+        runs = [r for r in _external_rows() if r["name"] != target]
+        runs.append(
+            _check_run(target, "skipped", started_at=_T0_PLUS_64, head_sha=_HEAD_A)
+        )
+        failures, _missing = evaluate_external(runs)
+        assert failures == [target]
+
+    def test_in_progress_after_success_is_still_pending(self) -> None:
+        """POSITIVE CONTROL: a live re-run stays PENDING, never stale-green."""
+
+        target = EXPECTED_EXTERNAL_CONTEXTS[0]
+        runs = _with_second_row(target, None, status="in_progress")
+        failures, missing = evaluate_external(runs)
+        assert failures == []
+        assert missing == [target]
+
+    def test_skip_after_success_does_not_leak_across_names(self) -> None:
+        """POSITIVE CONTROL: a non-skipped row for one name cannot clear a
+        skip recorded against a DIFFERENT name."""
+
+        rows = [
+            _check_run("a", "success", head_sha=_HEAD_A),
+            _check_run("b", "skipped", head_sha=_HEAD_A),
+        ]
+        assert drop_superseded_skips(rows) == rows
+
+    def test_skip_on_a_different_head_is_not_superseded(self) -> None:
+        """The head SHA partitions supersession (OMN-18062 follow-up).
+
+        A `success` recorded on head A is a verdict about head A. It must not
+        clear a `skipped` recorded on head B -- doing so would re-open the
+        skip-as-pass vector on the head actually being gated. Unreachable
+        through the sanctioned caller (which fetches one head's
+        `commits/{sha}/check-runs`), so this makes it a property of the
+        function rather than of the convention.
+        """
+
+        target = EXPECTED_EXTERNAL_CONTEXTS[0]
+        runs = _with_second_row(target, "skipped", head_sha=_HEAD_B)
+        assert len(drop_superseded_skips(runs)) == len(runs)
+        failures, _missing = evaluate_external(runs)
+        assert failures == [target]
+
+    def test_rows_without_a_head_sha_still_supersede(self) -> None:
+        """POSITIVE CONTROL for the partition: rows carrying no `head_sha`
+        share one partition, so a payload without head SHAs behaves exactly as
+        it did before the head guard."""
+
+        rows = [
+            {"name": "x", "status": "completed", "conclusion": "success"},
+            {"name": "x", "status": "completed", "conclusion": "skipped"},
+        ]
+        kept = drop_superseded_skips(rows)
+        assert [r["conclusion"] for r in kept] == ["success"]


### PR DESCRIPTION
## OMN-18062 — port the re-trigger-skip fix to this repo's `CI Summary` gate

This repo's `scripts/ci/ci_summary_gate.py` was **unpatched**. The OMN-18062 fix
landed in four repos (`omnimarket#2422`, `onex_change_control#8748`,
`omnibase_infra#3348`, `omniclaude#2126`) and never reached the two remaining
copies — this one and `omninode_infra` (`omninode_infra#1267`, companion).

### The mechanism

A `gh pr edit` of a PR body fires a **second** `pull_request` run of any workflow
whose `types:` include `edited`. A job in that run whose own `if:` excludes
`edited` is SKIPPED, and GitHub writes a **fresh** check-run with conclusion
`skipped` onto the same, unchanged head SHA where that very job reported
`success` 64 seconds earlier. Latest-wins resolution in
`_external_check_states` picks the skip, L4 admits only `success`, and the
required `CI Summary` context fails closed on a head nothing regressed on.
Re-running `CI Summary` cannot clear it — the skip is and stays the newest row —
so only a new head SHA can. Measured on `onex_change_control#8709`, 2026-09-08.

### Fact vs. inference

**Fact — defect reproduced against this file's own pre-fix code.**
`DB ownership CI twin (B1)` (`EXPECTED_EXTERNAL_CONTEXTS[0]`) with success@t0 +
skipped@t0+64s on one head resolved to `skipped`, and `evaluate_external`
returned it as a failure. Positive control: the same fixture with no second row
returned `([], [])`.

**Fact — latent today.** Neither asserted producer here
(`check-db-ownership.yml`, `check-llm-refs-drift.yml`) has an action-dependent
`if:`, so the shape is not currently firing in this repo.

**Inference — one workflow edit from live.** Either producer gaining an
event-conditional `if:` on a workflow carrying `edited` reproduces it.

### The head SHA is part of the key from the start

`_skip_partition_key` is `(name, head_sha)`, never name alone. A `success` on
head A is a verdict about head A and must not clear a `skipped` on head B —
that would re-open the skip-as-pass vector (OMN-15057 / OMN-14854) on the head
actually being gated. Unreachable through the sanctioned caller, which fetches
`commits/{sha}/check-runs` for one head, so this converts a convention into a
property of the function. Rows carrying no `head_sha` share the `""` partition,
so existing payloads and fixtures are unaffected.

### What this deliberately does NOT relax

Each pinned by a positive control that must still fail: a lone `skipped` with no
other row for that name still fails closed; `failure` and `cancelled` after a
`success` still win on recency; an `in_progress` re-run stays PENDING rather
than reading stale-green; a non-skipped row for one name never clears a skip on
another.

### Evidence

| Proof | Result |
|---|---|
| RED, behavioural — `drop_superseded_skips` defined but un-wired from `_external_check_states` | `test_skip_after_success_on_same_head_is_not_a_regression` FAILS (`['DB ownership CI twin (B1)'] == []`); the other 8 pass |
| RED, head partition — `_skip_partition_key` degraded to name-only | `test_skip_on_a_different_head_is_not_superseded` FAILS (`2 == 3`) |
| GREEN | `uv run pytest tests/unit/scripts/ci/test_ci_summary_gate.py` → **63 passed** (9 new) |
| Lint / types | `ruff format`, `ruff check`, `mypy scripts/ci/ci_summary_gate.py --strict` all clean |
| Pre-push | governed impacted-test selector (`prepush_smart_tests.sh`), unmodified, no override env |

Every zero above has a positive control; no verification command had its stderr
suppressed.

### Deploy surface

**None.** A CI gate script and its unit tests.

Ticket: **OMN-18062**

Evidence-Source: OCC#8766
Evidence-Ticket: OMN-18062
