### PR TITLE
fix(OMN-15660): run-scope the handler consumer group and refuse a sibling invocation's handler input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- onex-allow-file-todo-marker reason="historical changelog entries include literal TODO marker tokens" -->
 
+## v0.47.7 (2026-09-09)
+
+### Changes
+- fix run-scope the RuntimeLocal handler consumer group and refuse another invocation's handler input. #1645 closed the TERMINAL leg of the cross-invocation isolation defect: the terminal consumer group became run-scoped and `_terminal_correlation_matches` refuses a terminal naming another run. The HANDLER leg was untouched. `RuntimeLocal._run_event_driven` still subscribed to the command topic with `derive_runtime_local_group_id(entry.handler_name)` — a group id identical for every invocation of the same handler — and `LocalRuntimeBusAdapter.on_message` read `correlation_id` for logging only, with no conditional between deserialize and invoke. Two concurrent invocations therefore shared one group on the command topic and the broker handed each command to exactly one of them, so a run's own work executed in the sibling's process. The subscribe group is now suffixed with the invocation's `run_id` and the adapter refuses a message declaring a correlation that is not this invocation's. Both are gated on the correlation predicate being armed, for the reason the terminal group already documents: a brand-new group reads the retained log from the beginning, so scoping without a filter trades the uncommitted tail for the entire retention window. A message declaring NO correlation is still invoked on, which is the lesson #1655 paid for on the terminal leg — the canonical def-B message is a bare domain model with no field to carry a correlation. A refusal is not routed through `on_error`: a sibling's record is not this run's failure.
+
 ## v0.47.6 (2026-09-06)
 
 ### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.6"
+version = "0.47.7"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/runtime/runtime_local.py
+++ b/src/omnibase_core/runtime/runtime_local.py
@@ -1509,6 +1509,7 @@ class RuntimeLocal:
                     on_result=_make_result_cb(entry.output_topic),
                     published_events=published_events,
                     multi_event_seam_enabled=multi_event_seam_enabled,
+                    expected_correlation_id=self._expected_correlation_id,
                 )
 
                 if not entry.input_topic:
@@ -1520,10 +1521,31 @@ class RuntimeLocal:
                     )
                     continue
 
+                # OMN-15660 AC3, handler half. The terminal group below is
+                # run-scoped; this one was still derived from the handler name
+                # alone, so two concurrent invocations of the same handler
+                # joined ONE group on the command topic and the broker gave
+                # each record to exactly one of them — a run's own command
+                # executed in the other run's process, which is the handler-leg
+                # form of the cross-talk this ticket was filed on.
+                #
+                # Gated on the correlation predicate being armed for the same
+                # reason as the terminal group: a brand-new group reads the
+                # retained log from the beginning, so scoping WITHOUT a filter
+                # trades "the uncommitted tail" for "the entire retention
+                # window". The filter is ``expected_correlation_id`` on the
+                # adapter above; when nothing correlated reached the wire there
+                # is no operand for it, so the shared group is left exactly as
+                # it was rather than made worse.
+                handler_group_node = entry.handler_name
+                if self._expected_correlation_id is not None:
+                    handler_group_node = (
+                        f"{entry.handler_name}_run_{self.run_id.hex[:12]}"
+                    )
                 unsub = await bus.subscribe(
                     entry.input_topic,
                     on_message=adapter.on_message,
-                    group_id=derive_runtime_local_group_id(entry.handler_name),
+                    group_id=derive_runtime_local_group_id(handler_group_node),
                 )
                 unsubscribe_handles.append(unsub)
 

--- a/src/omnibase_core/runtime/runtime_local_adapter.py
+++ b/src/omnibase_core/runtime/runtime_local_adapter.py
@@ -96,6 +96,7 @@ class LocalRuntimeBusAdapter:
         on_result: Callable[[object], None] | None = None,
         published_events: Mapping[str, str] | None = None,
         multi_event_seam_enabled: bool = False,
+        expected_correlation_id: UUID | None = None,
     ) -> None:
         self.handler = handler
         self.handler_name = handler_name
@@ -114,6 +115,34 @@ class LocalRuntimeBusAdapter:
         # class varies per phase. None/empty keeps the single-``output_topic`` path.
         self.published_events: Mapping[str, str] = published_events or {}
         self.multi_event_seam_enabled = multi_event_seam_enabled
+        # OMN-15660 AC2, handler half. The correlation id THIS invocation put on
+        # the wire, or ``None`` when nothing correlated reached it. Armed, it is
+        # the refusal operand in ``_correlation_matches``: a message that names
+        # a DIFFERENT run is not this run's input and is not invoked on. Group
+        # ids alone cannot carry this — Kafka fans every record to every group,
+        # so a run-scoped group still sees every other run's records; the
+        # refusal is the actual isolation boundary.
+        self.expected_correlation_id = expected_correlation_id
+
+    def _correlation_matches(self, correlation_id: str | None) -> bool:
+        """Whether a handler input belongs to THIS invocation (OMN-15660 AC2).
+
+        Returns ``True`` when no predicate is armed — there is no operand to
+        compare against, so the pre-OMN-15660 behaviour stands unchanged for
+        the offline / in-memory path.
+
+        Returns ``True`` when the message declares NO correlation id. That is
+        deliberate and it is the OMN-17980 lesson, already paid for once on the
+        terminal leg: the canonical def-B message is the handler's bare domain
+        model (``handle(request: ModelX) -> ModelY``), which has no field in
+        which to carry a correlation. Refusing that shape would not isolate the
+        run, it would make every def-B chain unrunnable after its first hop.
+
+        Once a correlation IS declared it must be this invocation's own.
+        """
+        if self.expected_correlation_id is None or correlation_id is None:
+            return True
+        return correlation_id == str(self.expected_correlation_id)
 
     async def on_message(self, msg: ProtocolLocalRuntimeMessage) -> None:
         """Receive bus message, invoke handler, publish result."""
@@ -154,6 +183,20 @@ class LocalRuntimeBusAdapter:
             )
             if self.on_error:
                 self.on_error()
+            return
+
+        # 1b. Refuse another invocation's input (OMN-15660 AC2, handler half).
+        # Deliberately NOT an ``on_error``: a foreign record is not a failure of
+        # this run, and marking the workflow FAILED on one would make every
+        # concurrent invocation fail the moment a sibling published.
+        if not self._correlation_matches(correlation_id):
+            logger.info(
+                "LocalRuntimeBusAdapter: discarding input for %s — this "
+                "invocation awaits correlation %s, the message names %s",
+                self.handler_name,
+                self.expected_correlation_id,
+                correlation_id,
+            )
             return
 
         # 2. Invoke handler

--- a/tests/unit/runtime/test_runtime_local_adapter_correlation_refusal.py
+++ b/tests/unit/runtime/test_runtime_local_adapter_correlation_refusal.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""The handler-path correlation refusal on ``LocalRuntimeBusAdapter`` (OMN-15660).
+
+OMN-15660 names two legs. The TERMINAL leg landed in ``omnibase_core#1645``:
+``RuntimeLocal._terminal_correlation_matches`` refuses a terminal that names
+another run. The HANDLER leg had no equivalent — ``on_message`` read
+``correlation_id`` and used it for logging only, with no conditional between
+deserialize and invoke, so a message belonging to a concurrent invocation was
+executed as this invocation's own input.
+
+Group-id uniqueness cannot substitute for the refusal and the ticket says so:
+Kafka fans every record to every consumer group, so a run-scoped group still
+observes every other run's records. The group id bounds which records this run
+is *served*; the refusal is what decides which it *acts on*.
+
+Every refusal assertion here is paired with a counter-assertion pinning what the
+refusal must NOT destroy — an unarmed adapter, and a message that declares no
+correlation at all. Refusing those two would satisfy a naive "isolate
+everything" reading while making the offline path and every def-B chain
+unrunnable, which is the OMN-17980 regression already paid for once on the
+terminal leg.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import cast
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from omnibase_core.protocols.runtime.protocol_local_runtime_bus import (
+    ProtocolLocalRuntimeBus,
+)
+from omnibase_core.protocols.runtime.protocol_local_runtime_callable_target import (
+    ProtocolLocalRuntimeCallableTarget,
+)
+from omnibase_core.runtime.runtime_local_adapter import LocalRuntimeBusAdapter
+
+_OUTPUT_TOPIC = "onex.evt.omn15660.handler-refusal.v1"
+
+
+class ModelRefusalCommand(BaseModel):
+    """Input model that carries a correlation, like every wire command."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    correlation_id: UUID | None = None
+    prompt: str = ""
+
+
+class _RecordingHandler:
+    """Records every input it was actually invoked on."""
+
+    def __init__(self) -> None:
+        self.invocations: list[object] = []
+
+    def handle(self, request: object) -> None:
+        self.invocations.append(request)
+
+
+class _FakeBus:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, bytes]] = []
+
+    async def start(self) -> None:  # pragma: no cover - unused
+        return None
+
+    async def close(self) -> None:  # pragma: no cover - unused
+        return None
+
+    async def publish(self, topic: str, key: object, value: bytes) -> object:
+        self.published.append((topic, value))
+        return None
+
+    async def subscribe(
+        self, topic: str, *, on_message: object, group_id: str
+    ) -> object:  # pragma: no cover - unused
+        return None
+
+
+class _FakeMsg:
+    def __init__(self, value: bytes) -> None:
+        self.value = value
+
+
+def _adapter(
+    handler: _RecordingHandler,
+    *,
+    expected_correlation_id: UUID | None,
+    input_model_cls: type[BaseModel] | None = ModelRefusalCommand,
+) -> LocalRuntimeBusAdapter:
+    return LocalRuntimeBusAdapter(
+        handler=cast("ProtocolLocalRuntimeCallableTarget", handler),
+        handler_name="omn15660-refusal-probe",
+        input_model_cls=input_model_cls,
+        output_topic=_OUTPUT_TOPIC,
+        bus=cast("ProtocolLocalRuntimeBus", _FakeBus()),
+        expected_correlation_id=expected_correlation_id,
+    )
+
+
+def _msg(payload: dict[str, object]) -> _FakeMsg:
+    return _FakeMsg(json.dumps(payload).encode("utf-8"))
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_foreign_correlation_is_not_invoked_on() -> None:
+    """The defect, stated directly: another run's input must not be executed.
+
+    RED before the fix: ``on_message`` had no conditional between deserialize and
+    invoke, so this handler recorded the sibling's command.
+    """
+    handler = _RecordingHandler()
+    mine, theirs = uuid4(), uuid4()
+    adapter = _adapter(handler, expected_correlation_id=mine)
+
+    await adapter.on_message(cast("object", _msg({"correlation_id": str(theirs)})))  # type: ignore[arg-type]
+
+    assert handler.invocations == [], (
+        "the handler executed a command belonging to correlation "
+        f"{theirs} while this invocation awaits {mine}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_this_runs_own_correlation_is_invoked_on() -> None:
+    """Counter-assertion: the refusal must still let this run's own input through."""
+    handler = _RecordingHandler()
+    mine = uuid4()
+    adapter = _adapter(handler, expected_correlation_id=mine)
+
+    await adapter.on_message(cast("object", _msg({"correlation_id": str(mine)})))  # type: ignore[arg-type]
+
+    assert len(handler.invocations) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_unarmed_adapter_invokes_on_anything() -> None:
+    """Counter-assertion: no predicate armed means no operand to filter on.
+
+    The offline / in-memory path publishes commands that never carried a
+    correlation onto a wire. Refusing there would break it for no isolation gain
+    — an in-memory bus dies with its process and has no second run to collide
+    with.
+    """
+    handler = _RecordingHandler()
+    adapter = _adapter(handler, expected_correlation_id=None)
+
+    await adapter.on_message(cast("object", _msg({"correlation_id": str(uuid4())})))  # type: ignore[arg-type]
+
+    assert len(handler.invocations) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_message_declaring_no_correlation_is_invoked_on() -> None:
+    """Counter-assertion, and the OMN-17980 lesson applied to the handler leg.
+
+    The canonical def-B message is the handler's bare domain model, which has no
+    field in which to carry a correlation id. Refusing an undeclared correlation
+    would make every def-B chain stall after its first hop — the exact regression
+    the terminal leg shipped and had to fix.
+    """
+    handler = _RecordingHandler()
+    adapter = _adapter(handler, expected_correlation_id=uuid4())
+
+    await adapter.on_message(cast("object", _msg({"prompt": "no correlation here"})))  # type: ignore[arg-type]
+
+    assert len(handler.invocations) == 1, (
+        "a bare def-B domain payload was refused; that breaks every def-B chain "
+        "rather than isolating anything"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_foreign_correlation_inside_an_envelope_is_refused() -> None:
+    """The envelope shape carries the correlation at the top, not in the payload.
+
+    ``_unwrap_envelope_dict`` is what the adapter already uses to find it, so the
+    refusal must read the unwrapped value or the fan-out wire shape would slip
+    past unchecked.
+    """
+    handler = _RecordingHandler()
+    mine, theirs = uuid4(), uuid4()
+    adapter = _adapter(handler, expected_correlation_id=mine)
+
+    envelope: dict[str, object] = {
+        "envelope_id": str(uuid4()),
+        "correlation_id": str(theirs),
+        "event_type": "omn15660.refusal-probe",
+        "payload": {"prompt": "someone else's work"},
+    }
+    await adapter.on_message(cast("object", _msg(envelope)))  # type: ignore[arg-type]
+
+    assert handler.invocations == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_refusal_is_not_reported_as_a_handler_failure() -> None:
+    """A sibling's record is not this run's failure.
+
+    Routing the refusal through ``on_error`` would mark the workflow FAILED the
+    moment any concurrent invocation published, turning an isolation fix into a
+    concurrency outage.
+    """
+    handler = _RecordingHandler()
+    errors: list[int] = []
+    adapter = LocalRuntimeBusAdapter(
+        handler=cast("ProtocolLocalRuntimeCallableTarget", handler),
+        handler_name="omn15660-refusal-probe",
+        input_model_cls=ModelRefusalCommand,
+        output_topic=_OUTPUT_TOPIC,
+        bus=cast("ProtocolLocalRuntimeBus", _FakeBus()),
+        on_error=lambda: errors.append(1),
+        expected_correlation_id=uuid4(),
+    )
+
+    await adapter.on_message(cast("object", _msg({"correlation_id": str(uuid4())})))  # type: ignore[arg-type]
+
+    assert handler.invocations == []
+    assert errors == [], "a foreign record marked this run's workflow FAILED"

--- a/tests/unit/runtime/test_runtime_local_terminal_isolation.py
+++ b/tests/unit/runtime/test_runtime_local_terminal_isolation.py
@@ -88,6 +88,32 @@ class HandlerIsolationEcho:
         }
 
 
+# Which handler INSTANCE observed which correlation. A module-level registry is
+# the only way to see that: the runtime constructs its own handler instance from
+# the contract, so a test never holds a reference to it. Instances are kept alive
+# by this list, so ``id()`` stays a stable identity for the run of a test.
+_HANDLER_OBSERVATIONS: list[tuple[object, str]] = []
+
+
+class HandlerIsolationRecorder:
+    """Host-mode handler that records which instance executed which correlation.
+
+    Behaviourally identical to :class:`HandlerIsolationEcho`; the only addition is
+    the registry write, which is what makes handler-leg cross-talk observable at
+    all. Without it two concurrent runs both complete and the wrong-process
+    execution is invisible.
+    """
+
+    async def handle(self, payload: ModelIsolationCommand) -> dict[str, str]:
+        _HANDLER_OBSERVATIONS.append((self, str(payload.correlation_id)))
+        await asyncio.sleep(0.30 if payload.prompt == "slow" else 0.01)
+        return {
+            "status": "success",
+            "correlation_id": str(payload.correlation_id),
+            "prompt": payload.prompt,
+        }
+
+
 # ---------------------------------------------------------------------------
 # A retaining broker double: Kafka semantics (retained log + per-group committed
 # offsets) with no Kafka. The in-memory bus dies with the process and is immune
@@ -169,6 +195,9 @@ class _DurableBus:
             group for topic, group in self.subscriptions if topic == _TERMINAL_TOPIC
         ]
 
+    def handler_groups(self) -> list[str]:
+        return [group for topic, group in self.subscriptions if topic == _COMMAND_TOPIC]
+
     async def start(self) -> None:
         return None
 
@@ -199,7 +228,9 @@ class _DurableBus:
         return _unsub
 
 
-def _write_contract(target: Path) -> None:
+def _write_contract(
+    target: Path, *, handler_name: str = "HandlerIsolationEcho"
+) -> None:
     contract: dict[str, Any] = {
         "workflow_id": "omn-15660-terminal-isolation",
         "name": "terminal_isolation_probe",
@@ -213,7 +244,7 @@ def _write_contract(target: Path) -> None:
             "handlers": [
                 {
                     "operation": "start",
-                    "handler": {"module": _MODULE, "name": "HandlerIsolationEcho"},
+                    "handler": {"module": _MODULE, "name": handler_name},
                     "event_model": {"module": _MODULE, "name": "ModelIsolationCommand"},
                     "output_topic": _TERMINAL_TOPIC,
                 }
@@ -230,12 +261,13 @@ def _build_runtime(
     host_handlers: bool = True,
     timeout: int = 2,
     prompt: str = "probe",
+    handler_name: str = "HandlerIsolationEcho",
 ) -> RuntimeLocal:
     """One runtime, with its own state_root — a distinct `onex delegate` process."""
     run_dir.mkdir(parents=True, exist_ok=True)
     contract_path = run_dir / "contract.yaml"
     input_path = run_dir / "input.json"
-    _write_contract(contract_path)
+    _write_contract(contract_path, handler_name=handler_name)
     input_path.write_text(
         json.dumps({"correlation_id": str(correlation_id), "prompt": prompt}),
         encoding="utf-8",
@@ -604,3 +636,126 @@ def test_envelope_payload_failure_beats_an_envelope_level_success(
     runtime._on_terminal_event(payload)
 
     assert runtime._result is EnumWorkflowResult.FAILED
+
+
+# ---------------------------------------------------------------------------
+# OMN-15660 AC2/AC3, handler leg: the command-topic consumer group and the
+# handler-path correlation refusal. The terminal leg above landed in #1645; this
+# is the half AC3 names as `:1211`/`:1226` and calls out by name — "a fix that
+# scopes only one path is incomplete".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_host_mode_handler_group_is_run_scoped(tmp_path: Path) -> None:
+    """The handler subscribe must not use a group derived from the handler name.
+
+    RED before the fix: ``group_id=derive_runtime_local_group_id(entry.handler_name)``
+    is identical for every invocation of the same handler, so two concurrent runs
+    joined one group on the command topic and the broker handed each record to
+    exactly one of them.
+    """
+    broker = _DurableBroker()
+    run_dir = tmp_path / "run"
+    runtime = _build_runtime(run_dir, correlation_id=uuid.uuid4())
+    bus = _DurableBus(broker)
+    _bind(runtime, bus)
+
+    await runtime.run_async()
+
+    groups = bus.handler_groups()
+    assert len(groups) == 1
+    assert runtime.run_id.hex[:12] in groups[0], (
+        "the handler subscription reused the handler-name-derived group id "
+        f"{groups[0]!r}; two concurrent invocations of this handler collide on it"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_two_concurrent_host_runs_do_not_share_a_handler_group(
+    tmp_path: Path,
+) -> None:
+    """AC3, both call sites: the terminal groups AND the handler groups differ."""
+    broker = _DurableBroker()
+    slow_dir = tmp_path / "handler_slow"
+    fast_dir = tmp_path / "handler_fast"
+    slow = _build_runtime(
+        slow_dir, correlation_id=uuid.uuid4(), timeout=5, prompt="slow"
+    )
+    fast = _build_runtime(
+        fast_dir, correlation_id=uuid.uuid4(), timeout=5, prompt="fast"
+    )
+    slow_bus = _DurableBus(broker)
+    fast_bus = _DurableBus(broker)
+    _bind(slow, slow_bus)
+    _bind(fast, fast_bus)
+
+    await asyncio.gather(slow.run_async(), fast.run_async())
+
+    assert slow_bus.handler_groups() != fast_bus.handler_groups(), (
+        "both concurrent runs joined the same handler consumer group on the "
+        "command topic"
+    )
+    assert slow_bus.terminal_groups() != fast_bus.terminal_groups()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_concurrent_run_never_executes_a_siblings_command(
+    tmp_path: Path,
+) -> None:
+    """AC1/AC2, the handler leg: each process executes only its own command.
+
+    RED before the fix: sharing one command-topic group, the first-registered
+    run's handler instance drained BOTH commands and the sibling's instance
+    executed nothing — the run's work ran in the wrong process. The assertion is
+    on instance identity rather than on the returned result because the echo
+    handler returns the payload's own correlation either way, which is exactly
+    why this defect survived the terminal-leg fix.
+    """
+    _HANDLER_OBSERVATIONS.clear()
+    broker = _DurableBroker()
+    slow_correlation = uuid.uuid4()
+    fast_correlation = uuid.uuid4()
+    slow_dir = tmp_path / "recorder_slow"
+    fast_dir = tmp_path / "recorder_fast"
+    slow = _build_runtime(
+        slow_dir,
+        correlation_id=slow_correlation,
+        timeout=5,
+        prompt="slow",
+        handler_name="HandlerIsolationRecorder",
+    )
+    fast = _build_runtime(
+        fast_dir,
+        correlation_id=fast_correlation,
+        timeout=5,
+        prompt="fast",
+        handler_name="HandlerIsolationRecorder",
+    )
+    _bind(slow, _DurableBus(broker))
+    _bind(fast, _DurableBus(broker))
+
+    slow_result, fast_result = await asyncio.gather(slow.run_async(), fast.run_async())
+
+    by_instance: dict[int, set[str]] = {}
+    for instance, correlation in _HANDLER_OBSERVATIONS:
+        by_instance.setdefault(id(instance), set()).add(correlation)
+
+    assert len(by_instance) == 2, (
+        "expected one handler instance per run; one process executed both "
+        f"commands (observations={_HANDLER_OBSERVATIONS!r})"
+    )
+    for observed in by_instance.values():
+        assert len(observed) == 1, (
+            f"a single handler instance executed {len(observed)} different "
+            "runs' commands"
+        )
+    assert {next(iter(v)) for v in by_instance.values()} == {
+        str(slow_correlation),
+        str(fast_correlation),
+    }
+    assert slow_result is EnumWorkflowResult.COMPLETED
+    assert fast_result is EnumWorkflowResult.COMPLETED

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.6"
+version = "0.47.7"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## OMN-15660 — the handler leg: run-scope the command-topic group and refuse a sibling's handler input

`omnibase_core#1645` closed this ticket's **terminal** leg. AC3 names **two** call
sites and says in its own sentence that *a fix that scopes only one path is
incomplete*. This closes the handler leg, and with it AC1, AC2 and AC3.

### What was still open at `origin/dev` `09fdb3f7`

| Call site | State before this PR |
|---|---|
| terminal consumer group (`runtime_local.py:1562`) | run-scoped — `#1645` |
| terminal message path (`_terminal_correlation_matches`) | filtered — `#1645`, corrected by `#1655` |
| **handler consumer group (`runtime_local.py:1526`)** | **`derive_runtime_local_group_id(entry.handler_name)` — identical for every invocation of the same handler** |
| **handler message path (`LocalRuntimeBusAdapter.on_message`)** | **`correlation_id` read for logging only; no conditional between deserialize and invoke** |

Two concurrent invocations therefore joined **one** group on the command topic.
A broker hands a record to exactly one member of a group, so a run's own command
was executed in the sibling's process, and nothing on the receiving side refused
it.

### The change

- `runtime_local.py` suffixes the handler subscribe group with the invocation's
  `run_id`, using the shape already eight lines below it at `:1555-1562`.
- `LocalRuntimeBusAdapter` takes `expected_correlation_id` and refuses a message
  declaring a correlation that is not this invocation's, before the handler
  invoke.

Both are gated on the correlation predicate being armed, for the reason the
terminal group already documents: a brand-new group reads the retained log from
the beginning, so scoping **without** a filter trades "the uncommitted tail" for
"the entire retention window" — strictly worse. Neither half is sufficient
alone; that is AC3's point.

### What this deliberately does NOT do

- **A message declaring NO correlation is still invoked on.** The canonical
  def-B message is the handler's bare domain model, which has no field in which
  to carry a correlation. This is the lesson `#1655` paid for on the terminal
  leg; refusing that shape would stall every def-B chain after its first hop
  rather than isolating anything.
- **A refusal is not routed through `on_error`.** A sibling's record is not this
  run's failure; failing on one would make every concurrent invocation fail the
  moment a sibling published.
- **An unarmed adapter refuses nothing** — the offline / in-memory path is
  byte-for-byte unchanged.

Each of the three is pinned by its own counter-assertion, so "refuse everything"
does not pass this suite.

### Evidence

| Proof | Result |
|---|---|
| RED control — the two source files stashed, the tests kept | **9 failed, 14 passed**. `test_a_concurrent_run_never_executes_a_siblings_command` failed with *"one process executed both commands"*; `test_host_mode_handler_group_is_run_scoped` and `test_two_concurrent_host_runs_do_not_share_a_handler_group` failed on the shared group id `local.omnibase_core.handlerisolationecho.consume.v1` |
| GREEN | `uv run pytest tests/unit/runtime/test_runtime_local_adapter_correlation_refusal.py tests/unit/runtime/test_runtime_local_terminal_isolation.py -q` → **23 passed** |
| No regression on adjacent paths | `test_runtime_local.py`, `test_runtime_local_client_mode.py`, `test_runtime_local_adapter_fanout.py`, `test_runtime_local_adapter_event_type.py`, `test_runtime_dispatch.py` → **99 passed** |
| Lint / types | `ruff format`, `ruff check --fix`, `mypy ... --strict` → clean, "no issues found in 2 source files" |
| Pre-push | governed impacted-test selector, unmodified, no override env. It escalated to the fail-closed full suite and the lab leg accepted it: **h101.2 ran 45073 tests green** on `e60465b328d1124ff247224d29516e7183aa38b9` (5684s) |
| Lab | not applicable — `RuntimeLocal` is an in-process library path, exercised by the suite above, not by a deployed lane. No lane was mutated by this work. |

The RED control for the new adapter test file is a `TypeError` on the
constructor kwarg rather than a behavioural failure, stated rather than glossed:
the refusal did not exist to fail. The behavioural RED lives in the three
runtime-level tests above, which run the real `RuntimeLocal` against a durable
broker double.

`pre-commit run --all-files` reports three failures on files this PR does not
touch (`util_topic_suffix.py`, `harness/harness_topics.py`,
`node_no_env_fallbacks_check_compute/*`, `model_llm_route_resolved_event.py`).
Positive control: all three reproduce byte-identically on a clean `origin/dev`
tree with this branch's changes stashed. The staged-file run at commit time is
clean.

### Deploy surface

Library code under `src/omnibase_core/runtime/`. No deployment, no contract
schema change, no wire-format change. Version bumped to `0.47.7` because
packaged source changed on an already-published `0.47.6`.

Ticket: **OMN-15660**

Evidence-Source: OCC#8804
Evidence-Ticket: OMN-15660
