### PR TITLE
fix(OMN-18069): companion-merged gate reads the autobind outcome check (port of omnibase_infra#3353)

### DIFF
--- a/scripts/ci/check_occ_companion_merged.py
+++ b/scripts/ci/check_occ_companion_merged.py
@@ -91,6 +91,13 @@ ENFORCED_EVENTS: frozenset[str] = frozenset({"pull_request", "merge_group"})
 EVIDENCE_SOURCE_RE = re.compile(
     r"^Evidence-Source:\s+(\S.*)$", re.IGNORECASE | re.MULTILINE
 )
+# OMN-18069 -- the autobind producer's terminal outcome, posted as a check-run on
+# the product PR's own head SHA by
+# omnimarket/.../handlers/occ_autobind_outcome.py. The name and the marker
+# prefix are a cross-repo contract; changing either is a two-repo change.
+AUTOBIND_OUTCOME_CHECK_NAME = "occ-autobind / outcome"
+AUTOBIND_OUTCOME_MARKER_PREFIX = "occ-autobind-outcome:"
+AUTOBIND_OUTCOME_ERROR = "ERROR"
 OCC_PR_REF_RE = re.compile(r"^OCC#(\d+)$", re.IGNORECASE)
 HEX_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
 MERGE_GROUP_PR_RE = re.compile(r"/pr-(\d+)-")
@@ -147,6 +154,31 @@ class GhFetcher:
             return None
         return data if isinstance(data, dict) else None
 
+    def check_runs(self, repo: str, head_sha: str) -> list[dict[str, object]] | None:
+        """Check-runs on *head_sha*, or ``None`` when the read itself failed.
+
+        ``None`` is deliberately distinct from ``[]``: an empty list is
+        evidence that no outcome was posted, a failed read is evidence of
+        nothing at all, and this gate must never convert the second into the
+        first (rule 16 -- an empty result is not evidence of absence).
+        """
+        raw = self._run(
+            [
+                "gh",
+                "api",
+                f"repos/{repo}/commits/{head_sha}/check-runs?per_page=100",
+                "--jq",
+                ".check_runs",
+            ]
+        )
+        if raw is None:
+            return None
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        return data if isinstance(data, list) else None
+
     def compare_status(self, repo: str, base: str, head_sha: str) -> str | None:
         """``identical``/``behind`` ⇒ ``head_sha`` is an ancestor of ``base``."""
         raw = self._run(
@@ -167,6 +199,54 @@ def parse_evidence_source(body: str) -> str | None:
     return match.group(1).strip() if match else None
 
 
+def read_autobind_outcome(
+    check_runs: list[dict[str, object]],
+) -> tuple[str, str] | None:
+    """Return ``(outcome, reason)`` from the newest autobind outcome check-run.
+
+    OMN-18069. The producer writes a machine-readable first line into the
+    check-run summary:
+
+    ``occ-autobind-outcome: ERROR repo=... pr=... correlation_id=... reason=...``
+
+    Returns ``None`` when no such check-run is present, which is the ordinary
+    case for a PR whose autobind has not reported yet.
+    """
+    latest: dict[str, object] | None = None
+    for run in check_runs:
+        if not isinstance(run, dict):
+            continue
+        if str(run.get("name") or "") != AUTOBIND_OUTCOME_CHECK_NAME:
+            continue
+        if str(run.get("status") or "") != "completed":
+            continue
+        if latest is None or str(run.get("completed_at") or "") >= str(
+            latest.get("completed_at") or ""
+        ):
+            latest = run
+    if latest is None:
+        return None
+
+    output = latest.get("output")
+    summary = ""
+    if isinstance(output, dict):
+        summary = str(output.get("summary") or "")
+    for line in summary.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith(AUTOBIND_OUTCOME_MARKER_PREFIX):
+            continue
+        payload = stripped[len(AUTOBIND_OUTCOME_MARKER_PREFIX) :].strip()
+        if not payload:
+            break
+        outcome = payload.split(None, 1)[0]
+        reason = ""
+        marker = "reason="
+        if marker in payload:
+            reason = payload.split(marker, 1)[1].strip()
+        return outcome, reason
+    return None
+
+
 def resolve_pr_number(
     event_name: str, pr_number: str, merge_group_head_ref: str
 ) -> str:
@@ -178,6 +258,33 @@ def resolve_pr_number(
         if match:
             return match.group(1)
     return ""
+
+
+def _terminal_autobind_error(
+    fetcher: GhFetcher, repo: str, pr_number: str, head_sha: str
+) -> str | None:
+    """The producer's ERROR reason for *head_sha*, or ``None``.
+
+    Fail-OPEN by design, and only here: an unreadable check-run list, a missing
+    head SHA, or any non-ERROR outcome all return ``None`` and leave the caller
+    on its existing PENDING path. This short-circuit may only ever turn a
+    would-be timeout into a fast, reasoned failure -- it must never be able to
+    fail a PR on its own, because the evidence it reads is written by a
+    different repo's runtime and an outage there would otherwise become an
+    outage here.
+    """
+    if not head_sha:
+        return None
+    check_runs = fetcher.check_runs(repo, head_sha)
+    if check_runs is None:
+        return None
+    parsed = read_autobind_outcome(check_runs)
+    if parsed is None:
+        return None
+    outcome, reason = parsed
+    if outcome.upper() != AUTOBIND_OUTCOME_ERROR:
+        return None
+    return reason or "(no reason recorded)"
 
 
 def evaluate_once(
@@ -207,7 +314,7 @@ def evaluate_once(
     if evidence_source_override is None:
         # Live body, never the event payload: occ-autobind PATCHes
         # Evidence-Source onto the body AFTER the triggering event fired.
-        pr_data = fetcher.pr_view(repo, pr_number, "body,author")
+        pr_data = fetcher.pr_view(repo, pr_number, "body,author,headRefOid")
         if pr_data is None:
             return Verdict(
                 EXIT_PENDING, f"could not fetch {repo}#{pr_number} (retryable)"
@@ -224,11 +331,31 @@ def evaluate_once(
                 "exemption mirrored; no OCC evidence applicable",
             )
 
+        head_sha = str(pr_data.get("headRefOid") or "")
+
         evidence_source = parse_evidence_source(str(pr_data.get("body") or ""))
     else:
         evidence_source = evidence_source_override
+        head_sha = ""
 
     if not evidence_source:
+        # OMN-18069: before deciding this is "still in flight", ask the producer.
+        # On 2026-09-09 the autobind effect consumed 37 commands and minted
+        # nothing; this gate spent its full 1500-second deadline on each of them
+        # and then reported only that a deadline had passed -- never the reason,
+        # which the runtime already knew and had already typed. A terminal ERROR
+        # outcome on the head SHA means the companion is not coming, so waiting
+        # is not merely wasteful, it is wrong.
+        outcome = _terminal_autobind_error(fetcher, repo, pr_number, head_sha)
+        if outcome is not None:
+            return Verdict(
+                EXIT_FAIL,
+                f"{repo}#{pr_number} has no 'Evidence-Source:' line and the "
+                f"occ-autobind producer reported {AUTOBIND_OUTCOME_ERROR} for this "
+                f"head: {outcome}. The OCC companion will NOT appear on its own -- "
+                "repair the reported fault and re-run the publisher, or hand-author "
+                "the companion (OMN-18069).",
+            )
         return Verdict(
             EXIT_PENDING,
             f"{repo}#{pr_number} body has no 'Evidence-Source:' line yet "

--- a/tests/unit/scripts/ci/test_check_occ_companion_merged.py
+++ b/tests/unit/scripts/ci/test_check_occ_companion_merged.py
@@ -383,7 +383,7 @@ class TestAutobindOutcomeShortCircuit:
     failures that each cost this gate its full 1500-second deadline.
     """
 
-    HEAD = "615219ec46868e2ebf09f8b35a9e6cfc6d743dea"
+    HEAD = "615219ec46868e2ebf09f8b35a9e6cfc6d743dea"  # pragma: allowlist secret
     REASON = "failed: Could not parse the provided public key."
 
     def _outcome_run(

--- a/tests/unit/scripts/ci/test_check_occ_companion_merged.py
+++ b/tests/unit/scripts/ci/test_check_occ_companion_merged.py
@@ -16,6 +16,8 @@ These tests pin the fail-closed verdict table:
 * SHA ancestor of dev/main    → PASS
 * SHA not an ancestor         → FAIL (OMN-15216 strandable pre-merge pin)
 * missing Evidence-Source     → PENDING (autobind mint may be in flight)
+* missing Evidence-Source AND the producer reported ERROR on this head
+                              → FAIL immediately, naming the reason (OMN-18069)
 * malformed Evidence-Source   → FAIL
 * dependency-bot author       → PASS (mirrors occ-preflight OMN-13762)
 * non-PR event                → PASS (gate not applicable)
@@ -28,12 +30,15 @@ from __future__ import annotations
 import pytest
 
 from scripts.ci.check_occ_companion_merged import (
+    AUTOBIND_OUTCOME_CHECK_NAME,
+    AUTOBIND_OUTCOME_MARKER_PREFIX,
     EXIT_FAIL,
     EXIT_PASS,
     EXIT_PENDING,
     evaluate_once,
     main,
     parse_evidence_source,
+    read_autobind_outcome,
     resolve_pr_number,
 )
 
@@ -51,9 +56,14 @@ class FakeFetcher:
         *,
         prs: dict[tuple[str, str], dict[str, object] | None] | None = None,
         compare: dict[tuple[str, str], str | None] | None = None,
+        check_runs: dict[tuple[str, str], list[dict[str, object]] | None] | None = None,
     ) -> None:
         self._prs = prs or {}
         self._compare = compare or {}
+        # OMN-18069. Default `[]` = "the producer posted no outcome", the
+        # ordinary case; `None` = "the read itself failed", which must be a
+        # distinct input because the gate may never treat one as the other.
+        self._check_runs = check_runs or {}
 
     def pr_view(self, repo: str, number: str, fields: str) -> dict[str, object] | None:
         return self._prs.get((repo, str(number)))
@@ -61,9 +71,16 @@ class FakeFetcher:
     def compare_status(self, repo: str, base: str, head_sha: str) -> str | None:
         return self._compare.get((base, head_sha))
 
+    def check_runs(self, repo: str, head_sha: str) -> list[dict[str, object]] | None:
+        return self._check_runs.get((repo, head_sha), [])
 
-def _product_pr(body: str, author: str = "jonahgabriel") -> dict[str, object]:
-    return {"body": body, "author": {"login": author}}
+
+def _product_pr(
+    body: str,
+    author: str = "jonahgabriel",
+    head_sha: str = "615219ec46868e2ebf09f8b35a9e6cfc6d743dea",
+) -> dict[str, object]:
+    return {"body": body, "author": {"login": author}, "headRefOid": head_sha}
 
 
 def _evaluate(fetcher: FakeFetcher, **kwargs: object):
@@ -353,3 +370,153 @@ class TestMainEntrypoint:
         )
         assert rc == EXIT_PASS
         assert "not a merge-gating event" in capsys.readouterr().out
+
+
+class TestAutobindOutcomeShortCircuit:
+    """OMN-18069 — the gate asks the producer instead of waiting it out.
+
+    Fixtures are the REAL 2026-09-09 records: omninode_infra#1266 at head
+    ``615219ec…`` (correlation ``d856d7ff-2044-4e3b-af1a-6d14ae892743``,
+    published to ``onex.cmd.omnimarket.occ-autobind.v1`` partition 0 offset
+    4508), whose autobind was consumed and then failed with
+    ``Could not parse the provided public key.`` — one of 37 identical
+    failures that each cost this gate its full 1500-second deadline.
+    """
+
+    HEAD = "615219ec46868e2ebf09f8b35a9e6cfc6d743dea"
+    REASON = "failed: Could not parse the provided public key."
+
+    def _outcome_run(
+        self,
+        outcome: str,
+        *,
+        name: str = AUTOBIND_OUTCOME_CHECK_NAME,
+        completed_at: str = "2026-09-09T04:20:29Z",
+        reason: str | None = None,
+    ) -> dict[str, object]:
+        summary = (
+            f"{AUTOBIND_OUTCOME_MARKER_PREFIX} {outcome} "
+            f"repo=OmniNode-ai/omninode_infra pr=1266 "
+            f"correlation_id=d856d7ff-2044-4e3b-af1a-6d14ae892743 "
+            f"reason={reason if reason is not None else self.REASON}\n\n"
+            "prose a human reads\n"
+        )
+        return {
+            "name": name,
+            "status": "completed",
+            "completed_at": completed_at,
+            "output": {"title": f"{outcome}: x", "summary": summary},
+        }
+
+    def _fetcher(self, runs: list[dict[str, object]] | None) -> FakeFetcher:
+        return FakeFetcher(
+            prs={
+                (PRODUCT_REPO, "2500"): _product_pr(
+                    "no evidence yet", head_sha=self.HEAD
+                )
+            },
+            check_runs={(PRODUCT_REPO, self.HEAD): runs},
+        )
+
+    def test_reported_error_fails_immediately_naming_the_reason(self) -> None:
+        verdict = _evaluate(self._fetcher([self._outcome_run("ERROR")]))
+        assert verdict.code == EXIT_FAIL
+        assert "Could not parse the provided public key." in verdict.reason
+        assert "will NOT appear" in verdict.reason
+
+    def test_no_outcome_posted_still_polls(self) -> None:
+        """The ordinary in-flight case is unchanged — this is additive."""
+        assert _evaluate(self._fetcher([])).code == EXIT_PENDING
+
+    def test_an_unreadable_check_run_list_never_fails_the_pr(self) -> None:
+        """Fail-OPEN here on purpose: the evidence is written by another repo's
+        runtime, and an outage there must not become an outage on this gate."""
+        assert _evaluate(self._fetcher(None)).code == EXIT_PENDING
+
+    def test_a_declined_outcome_still_polls(self) -> None:
+        """A DECLINED outcome (lease held, suppression) may still resolve —
+        another producer can be minting. Only ERROR is terminal."""
+        assert _evaluate(self._fetcher([self._outcome_run("DECLINED")])).code == (
+            EXIT_PENDING
+        )
+
+    def test_a_minted_outcome_still_polls_for_the_body_patch(self) -> None:
+        assert _evaluate(self._fetcher([self._outcome_run("MINTED")])).code == (
+            EXIT_PENDING
+        )
+
+    def test_a_check_run_with_another_name_is_ignored(self) -> None:
+        runs = [self._outcome_run("ERROR", name="occ-autobind / mint status")]
+        assert _evaluate(self._fetcher(runs)).code == EXIT_PENDING
+
+    def test_the_newest_outcome_wins(self) -> None:
+        """Offsets 4508 and 4510 are the same PR: two dispatches, two outcomes."""
+        runs = [
+            self._outcome_run("ERROR", completed_at="2026-09-09T04:20:29Z"),
+            self._outcome_run(
+                "MINTED",
+                completed_at="2026-09-09T04:45:17Z",
+                reason="authored OCC#8760",
+            ),
+        ]
+        assert _evaluate(self._fetcher(runs)).code == EXIT_PENDING
+
+    def test_an_incomplete_check_run_is_not_read(self) -> None:
+        run = self._outcome_run("ERROR")
+        run["status"] = "in_progress"
+        assert _evaluate(self._fetcher([run])).code == EXIT_PENDING
+
+    def test_a_present_evidence_source_bypasses_the_probe_entirely(self) -> None:
+        """The short-circuit only ever replaces a would-be timeout."""
+        fetcher = FakeFetcher(
+            prs={
+                (PRODUCT_REPO, "2500"): _product_pr(
+                    "Evidence-Source: OCC#8760", head_sha=self.HEAD
+                ),
+                (OCC_REPO, "8760"): {
+                    "state": "MERGED",
+                    "mergeCommit": {"oid": "a" * 40},
+                },
+            },
+            check_runs={(PRODUCT_REPO, self.HEAD): [self._outcome_run("ERROR")]},
+        )
+        assert _evaluate(fetcher).code == EXIT_PASS
+
+
+class TestReadAutobindOutcome:
+    def test_marker_line_is_parsed_off_the_summary(self) -> None:
+        summary = (
+            f"{AUTOBIND_OUTCOME_MARKER_PREFIX} ERROR repo=r pr=1 "
+            "correlation_id=c reason=boom happened\n\nprose\n"
+        )
+        parsed = read_autobind_outcome(
+            [
+                {
+                    "name": AUTOBIND_OUTCOME_CHECK_NAME,
+                    "status": "completed",
+                    "completed_at": "2026-09-09T00:00:00Z",
+                    "output": {"summary": summary},
+                }
+            ]
+        )
+        assert parsed == ("ERROR", "boom happened")
+
+    def test_a_summary_with_no_marker_yields_none(self) -> None:
+        assert (
+            read_autobind_outcome(
+                [
+                    {
+                        "name": AUTOBIND_OUTCOME_CHECK_NAME,
+                        "status": "completed",
+                        "output": {"summary": "just prose"},
+                    }
+                ]
+            )
+            is None
+        )
+
+    def test_an_empty_list_yields_none(self) -> None:
+        assert read_autobind_outcome([]) is None
+
+    def test_non_dict_entries_are_skipped(self) -> None:
+        assert read_autobind_outcome(["nonsense", 3]) is None  # type: ignore[list-item]

--- a/tests/unit/scripts/ci/test_check_occ_companion_merged.py
+++ b/tests/unit/scripts/ci/test_check_occ_companion_merged.py
@@ -78,7 +78,7 @@ class FakeFetcher:
 def _product_pr(
     body: str,
     author: str = "jonahgabriel",
-    head_sha: str = "615219ec46868e2ebf09f8b35a9e6cfc6d743dea",
+    head_sha: str = "615219ec46868e2ebf09f8b35a9e6cfc6d743dea",  # pragma: allowlist secret
 ) -> dict[str, object]:
     return {"body": body, "author": {"login": author}, "headRefOid": head_sha}
 


### PR DESCRIPTION
## What

Port of `omnibase_infra#3353` (merged `6f33161d`) into this repo's vendored copy of
`scripts/ci/check_occ_companion_merged.py`. Scope item 4 of OMN-18069, left undone when the
OMN-18073 lane closed.

When the gate finds no OCC evidence declaration on the product PR body, it now reads the autobind
producer's terminal outcome check-run (`occ-autobind / outcome`) on the PR's own head SHA before
concluding "still in flight". A terminal `ERROR` means the companion is not coming, so the gate
fails immediately naming the producer's own reason instead of burning its full 1500-second
deadline and then reporting only that a deadline passed.

The probe is fail-OPEN and only here: an unreadable check-run list, an absent head SHA, and every
non-`ERROR` outcome all leave the caller on its existing PENDING path. `check_runs()` returns
`None` for a failed read and `[]` for "nothing posted", and the two are never conflated
(rule 16 — an empty result is not evidence of absence). Both are pinned as separate test inputs.

## Port fidelity

`read_autobind_outcome`, `_terminal_autobind_error`, `GhFetcher.check_runs` and the three
constants are byte-identical to the merged omnibase_infra copy (verified by diff). This repo's
local divergence is preserved and NOT overwritten:

- this copy still parses the evidence declaration with its own `EVIDENCE_SOURCE_RE` module regex
  rather than the shared `scripts/ci/pr_trailers.py` helper (this repo never took OMN-17294), so
  the `TrailerConflictError` branch is deliberately absent here;
- the module docstring's registration paragraph — this repo's `GATE_JOBS` / `STRICT_SUCCESS_JOBS`
  entries and the 2026-07-25 `dev`-protection reconciliation note — is untouched.

One honest note: under this repo's own `mypy.ini` (`warn_unreachable = True`) the defensive
`isinstance(run, dict)` guard inside `read_autobind_outcome` reports one `unreachable` finding,
because the declared element type already says the entries are dicts. The guard is deliberate —
the list is untyped JSON from `gh api`, and a test feeds it `["nonsense", 3]` — and the path is
not in this repo's enforced mypy scope (`src/omnibase_core` plus four named validation scripts),
so the code is kept byte-identical to the merged omnibase_infra copy rather than diverged to
silence an unenforced warning. Stated rather than left for a reviewer to find.

## Evidence

- RED: with the short-circuit neutralised (`outcome = None`), the new terminal-error test fails
  and the other 37 pass — `1 failed, 37 passed`.
- GREEN: `uv run pytest tests/unit/scripts/ci/test_check_occ_companion_merged.py -q` → `38 passed`.
- `uv run ruff format` / `uv run ruff check` / `uv run mypy --strict` on both changed files: clean.
- Governed pre-push selector ran on push; `pre-commit` ran on the commit.

Ticket: OMN-18069
Evidence-Ticket: OMN-18069



Evidence-Source: OCC#8829