### PR TITLE
feat(OMN-18116): record the causal edge on the envelope the bus carries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.7"
+version = "0.47.8"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/scripts/validation/validate-string-versions.py
+++ b/scripts/validation/validate-string-versions.py
@@ -271,6 +271,9 @@ class PythonASTValidator(ast.NodeVisitor):
             # These represent serialize() output - UUIDs and versions become strings in JSON
             "option_id",  # TypedDict CLI command option ID (serialized UUID)
             "envelope_id",  # TypedDict event envelope ID (serialized UUID)
+            # OMN-18116: the causal edge references envelope_id, so it sits at
+            # the same serialized-UUID boundary as the line above.
+            "parent_envelope_id",  # TypedDict causal-edge parent (serialized UUID)
             "action_id",  # TypedDict CLI action ID (serialized UUID)
             "command_name_id",  # TypedDict CLI command name ID (serialized UUID)
             "target_node_id",  # TypedDict CLI target node ID (serialized UUID)

--- a/src/omnibase_core/models/events/model_event_envelope.py
+++ b/src/omnibase_core/models/events/model_event_envelope.py
@@ -18,7 +18,7 @@ from typing import cast
 from uuid import UUID, uuid4
 
 # Third-party imports (alphabetized)
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 # Local imports (alphabetized)
 from omnibase_core.decorators import allow_dict_any
@@ -55,6 +55,8 @@ class ModelEventEnvelope[T](BaseModel, MixinLazyEvaluation):
         envelope_id: Unique identifier for this envelope instance
         envelope_timestamp: When this envelope was created
         correlation_id: Optional correlation ID for request tracing
+        parent_envelope_id: Optional envelope_id of the envelope whose
+            consumption caused this one; None means this hop is a chain head
         source_tool: Optional identifier of the tool that created this event
         target_tool: Optional identifier of the intended recipient tool
         metadata: Additional envelope metadata (tool version, environment, etc.)
@@ -102,6 +104,48 @@ class ModelEventEnvelope[T](BaseModel, MixinLazyEvaluation):
     )
     correlation_id: UUID | None = Field(
         default=None, description="Correlation ID for request tracing"
+    )
+    # OMN-18116: the CAUSAL EDGE -- the identity of the envelope whose
+    # consumption caused this one to be published.
+    #
+    # `correlation_id` says these hops belong to the same request. It does not
+    # say what caused what, so a chain read back by correlation alone is a SET,
+    # not a sequence, and any "replay green" verdict derived from it is a claim
+    # rather than a re-derivation. This field is the recorded half of that
+    # re-derivation: a verifier recomputes hop N-1's `envelope_id` independently
+    # and compares it to what hop N recorded here.
+    #
+    # It references `envelope_id`, not `span_id`. `envelope_id` is the only
+    # per-hop identity the platform already originates on every envelope (it has
+    # a default factory, and the runtime's dispatch-result applier sets it
+    # deterministically). Measured read-only on the dev lane over a two-hour
+    # `event_ledger` window: 4920 rows, `envelope_id` populated on 4920,
+    # `correlation_id` on 4920, `span_id` on 0, `parent_span_id` on 0. Reusing
+    # the span pair would mean originating two things, a span and its edge, to
+    # record one -- and would overload a distributed-tracing field whose
+    # semantics change the day a real trace exporter is wired. `span_id` and
+    # `parent_span_id` are deliberately left exactly as they are.
+    #
+    # `None` is a statement, not an omission: this hop consumed nothing, so it
+    # is a chain HEAD. That is checkable. A hop that should have an edge and
+    # carries none is a broken chain, which is precisely what this field lets a
+    # verifier fail on.
+    #
+    # Origination is ONE site -- the runtime dispatch-result applier, which
+    # already holds the consumed envelope. No handler sets this: the canonical
+    # handler signature is `handle(request: ModelX) -> ModelY` and never sees an
+    # envelope, which is the architecture working rather than a gap.
+    #
+    # WIRE COMPATIBILITY: this model is `extra="forbid"` (see above), so a
+    # consumer pinned to a core release that predates this field REFUSES an
+    # envelope carrying it rather than ignoring it. `envelope_version` moves to
+    # 2.2.0 for that reason; a reader must be on a core that declares the field.
+    parent_envelope_id: UUID | None = Field(
+        default=None,
+        description=(
+            "envelope_id of the envelope whose consumption caused this one. "
+            "None means this hop is a chain head."
+        ),
     )
     source_tool: str | None = Field(
         default=None, description="Identifier of the tool that created this event"
@@ -203,9 +247,35 @@ class ModelEventEnvelope[T](BaseModel, MixinLazyEvaluation):
         return value
 
     envelope_version: ModelSemVer = Field(
-        default_factory=lambda: ModelSemVer(major=2, minor=1, patch=0),
+        # 2.1.0 -> 2.2.0 (OMN-18116): the schema gained the declared
+        # `parent_envelope_id` field. Additive, but not silently so -- this
+        # model is `extra="forbid"`, so an older reader rejects the new key
+        # instead of dropping it. The minor bump is the signal for that.
+        default_factory=lambda: ModelSemVer(major=2, minor=2, patch=0),
         description="Envelope schema version",
     )
+
+    @model_validator(mode="after")
+    def _parent_edge_is_not_self_referential(self) -> "ModelEventEnvelope[T]":
+        """Refuse an envelope that records itself as its own cause.
+
+        ``ModelEnvelope.validate_no_self_reference`` proves the same shape for
+        ``causation_id``. The consequence is sharper here: a verifier
+        re-derives the expected parent and compares it against what was
+        recorded. A self-edge closes that comparison against the hop itself, so
+        a chain with no real predecessor would read as a valid one-hop chain --
+        a verdict-from-claim of exactly the kind this edge exists to prevent.
+        """
+        if (
+            self.parent_envelope_id is not None
+            and self.parent_envelope_id == self.envelope_id
+        ):
+            raise ValueError(
+                "parent_envelope_id cannot equal envelope_id (self-reference): "
+                "an envelope cannot be its own cause, and a self-edge would let "
+                "a broken chain re-derive as a valid one"
+            )
+        return self
 
     def __init__(self, **data: object) -> None:
         """Initialize envelope with lazy evaluation capabilities."""
@@ -513,6 +583,13 @@ class ModelEventEnvelope[T](BaseModel, MixinLazyEvaluation):
             "envelope_id": str(self.envelope_id),
             "envelope_timestamp": self.envelope_timestamp.isoformat(),
             "correlation_id": str(self.correlation_id) if self.correlation_id else None,
+            # OMN-18116: enumerated explicitly, because this projection is
+            # hand-written -- a field added to the model is not carried here
+            # automatically, which is how a recorded edge gets silently dropped
+            # on the way to a reader.
+            "parent_envelope_id": (
+                str(self.parent_envelope_id) if self.parent_envelope_id else None
+            ),
             "source_tool": self.source_tool,
             "target_tool": self.target_tool,
             "event_type": self.event_type,

--- a/src/omnibase_core/types/typed_dict_event_envelope.py
+++ b/src/omnibase_core/types/typed_dict_event_envelope.py
@@ -26,6 +26,8 @@ class TypedDictEventEnvelopeDict(TypedDict, total=False):
         envelope_id: Unique envelope identifier (converted to string)
         envelope_timestamp: Envelope creation timestamp (ISO format string)
         correlation_id: Correlation ID for request tracing (converted to string, or None)
+        parent_envelope_id: envelope_id of the causing envelope (converted to
+            string, or None when this hop is a chain head)
         source_tool: Identifier of source tool (or None)
         target_tool: Identifier of target tool (or None)
         event_type: Dot-path routing key (or None)
@@ -48,6 +50,7 @@ class TypedDictEventEnvelopeDict(TypedDict, total=False):
     envelope_id: str
     envelope_timestamp: str
     correlation_id: str | None
+    parent_envelope_id: str | None
     source_tool: str | None
     target_tool: str | None
     event_type: str | None

--- a/src/omnibase_core/validation/scripts/python_ast_validator.py
+++ b/src/omnibase_core/validation/scripts/python_ast_validator.py
@@ -152,6 +152,9 @@ class PythonASTValidator(ast.NodeVisitor):
             # These represent serialize() output - UUIDs and versions become strings in JSON
             "option_id",  # TypedDict CLI command option ID (serialized UUID)
             "envelope_id",  # TypedDict event envelope ID (serialized UUID)
+            # OMN-18116: the causal edge references envelope_id, so it is the
+            # same serialized-UUID boundary as the line above.
+            "parent_envelope_id",  # TypedDict causal-edge parent (serialized UUID)
             "action_id",  # TypedDict CLI action ID (serialized UUID)
             "command_name_id",  # TypedDict CLI command name ID (serialized UUID)
             "target_node_id",  # TypedDict CLI target node ID (serialized UUID)

--- a/tests/unit/models/events/test_model_event_envelope.py
+++ b/tests/unit/models/events/test_model_event_envelope.py
@@ -71,8 +71,12 @@ class TestModelEventEnvelopeInstantiation:
         assert envelope.request_id is None
         assert envelope.trace_id is None
         assert envelope.span_id is None
+        # OMN-18116: absent by default, which is the checkable statement that
+        # this envelope is a chain head rather than a hop with a lost edge.
+        assert envelope.parent_envelope_id is None
         assert envelope.onex_version == ModelSemVer(major=1, minor=0, patch=0)
-        assert envelope.envelope_version == ModelSemVer(major=2, minor=1, patch=0)
+        # 2.1.0 -> 2.2.0 (OMN-18116): the schema gained `parent_envelope_id`.
+        assert envelope.envelope_version == ModelSemVer(major=2, minor=2, patch=0)
 
     def test_instantiation_with_all_fields(self):
         """Test envelope creation with all fields provided."""

--- a/tests/unit/models/events/test_model_event_envelope_parent_edge.py
+++ b/tests/unit/models/events/test_model_event_envelope_parent_edge.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""The causal edge on the envelope the bus actually carries (OMN-18116).
+
+A replay is a re-derivation compared against a record. For an event chain the
+thing re-derived is the causal edge: hop N's recorded parent must re-derive to
+hop N-1's own identity. Before this field existed the edge was recorded nowhere,
+so a ``replay_green`` verdict could only ever be a claim.
+
+Measured on the dev lane before the field was added, two-hour window of
+``event_ledger``: 4920 rows, ``envelope_id`` populated on 4920, ``correlation_id``
+populated on 4920, ``span_id`` populated on 0, ``parent_span_id`` populated on 0.
+That is why the edge references ``envelope_id`` -- the only per-hop identity the
+platform already originates on every envelope -- and not the declared-but-dead
+span pair. The decision is recorded in the approved plan
+``beta/plans/2026-09-10-causal-edge-origination-proposal.md`` (option A).
+
+These tests pin four properties:
+
+1. The field exists on ``ModelEventEnvelope`` and round-trips.
+2. It is optional, and its absence is the checkable statement "this hop is a
+   chain head" rather than an accident.
+3. A self-referencing edge is refused. An envelope cannot be caused by itself,
+   and a self-edge would let a verifier's re-derivation close against nothing.
+4. The edge survives serialization, so a reader downstream of the wire can see
+   it. An edge that exists only in memory is the ``ModelEnvelope.causation_id``
+   failure shape this design exists to avoid.
+"""
+
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from omnibase_core.models.events.model_event_envelope import ModelEventEnvelope
+
+
+class _Payload(BaseModel):
+    """Minimal payload; the edge is an envelope property, not a payload one."""
+
+    message: str
+
+
+@pytest.mark.unit
+class TestParentEnvelopeIdField:
+    """The causal edge is declared, optional, and carried."""
+
+    def test_parent_envelope_id_round_trips(self) -> None:
+        """A hop records the identity of the envelope it consumed."""
+        parent_id = uuid4()
+        envelope = ModelEventEnvelope[_Payload](
+            payload=_Payload(message="child"),
+            parent_envelope_id=parent_id,
+        )
+        assert envelope.parent_envelope_id == parent_id
+        assert isinstance(envelope.parent_envelope_id, UUID)
+
+    def test_absent_parent_is_the_chain_head_statement(self) -> None:
+        """No parent means chain head, and it is the default."""
+        envelope = ModelEventEnvelope[_Payload](payload=_Payload(message="head"))
+        assert envelope.parent_envelope_id is None
+
+    def test_self_reference_is_refused(self) -> None:
+        """An envelope cannot be its own cause.
+
+        ``ModelEnvelope`` already proves this shape for ``causation_id``. The
+        reason it matters here is sharper: a verifier re-derives the expected
+        parent and compares. A self-edge closes the comparison against the hop
+        itself, so a broken chain would read as a valid one-hop chain.
+        """
+        envelope_id = uuid4()
+        with pytest.raises(ValidationError) as exc_info:
+            ModelEventEnvelope[_Payload](
+                payload=_Payload(message="ouroboros"),
+                envelope_id=envelope_id,
+                parent_envelope_id=envelope_id,
+            )
+        message = str(exc_info.value)
+        assert "parent_envelope_id" in message
+        # Named explicitly so the assertion cannot be satisfied by the
+        # ``extra="forbid"`` refusal that fires before the field exists.
+        assert "self-reference" in message
+
+    def test_distinct_parent_is_accepted(self) -> None:
+        """The negative control for the self-reference test.
+
+        Without this, a validator that refused every parent would pass the
+        test above while breaking the feature.
+        """
+        envelope = ModelEventEnvelope[_Payload](
+            payload=_Payload(message="child"),
+            envelope_id=uuid4(),
+            parent_envelope_id=uuid4(),
+        )
+        assert envelope.parent_envelope_id is not None
+        assert envelope.parent_envelope_id != envelope.envelope_id
+
+    def test_edge_survives_model_dump(self) -> None:
+        """The edge reaches a reader, not only the constructing process."""
+        parent_id = uuid4()
+        envelope = ModelEventEnvelope[_Payload](
+            payload=_Payload(message="child"),
+            parent_envelope_id=parent_id,
+        )
+        dumped = envelope.model_dump(mode="json")
+        assert dumped["parent_envelope_id"] == str(parent_id)
+
+        revived = ModelEventEnvelope[_Payload].model_validate(dumped)
+        assert revived.parent_envelope_id == parent_id
+
+    def test_edge_survives_to_dict_lazy(self) -> None:
+        """The lazy dict form is a separate hand-written projection.
+
+        It enumerates fields explicitly, so a field added to the model is NOT
+        automatically present here. That is exactly how a recorded edge gets
+        silently dropped on the way to a consumer.
+        """
+        parent_id = uuid4()
+        envelope = ModelEventEnvelope[_Payload](
+            payload=_Payload(message="child"),
+            parent_envelope_id=parent_id,
+        )
+        lazy = envelope.to_dict_lazy()
+        assert lazy["parent_envelope_id"] == str(parent_id)
+
+    def test_chain_head_lazy_dict_records_absence_explicitly(self) -> None:
+        """A head's absent edge is present-and-null, not missing."""
+        envelope = ModelEventEnvelope[_Payload](payload=_Payload(message="head"))
+        lazy = envelope.to_dict_lazy()
+        assert "parent_envelope_id" in lazy
+        assert lazy["parent_envelope_id"] is None
+
+    def test_envelope_version_records_the_added_field(self) -> None:
+        """The schema gained a declared field, so its version moves.
+
+        This matters more here than for an ordinary additive field: the model
+        is ``extra="forbid"`` (OMN-16831), so a consumer pinned to an older
+        core REFUSES an envelope carrying this key rather than ignoring it. The
+        version is the signal that a reader must be on a core that declares it.
+        """
+        envelope = ModelEventEnvelope[_Payload](payload=_Payload(message="x"))
+        assert (envelope.envelope_version.major, envelope.envelope_version.minor) == (
+            2,
+            2,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.7"
+version = "0.47.8"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## OMN-18116 — record the causal edge on the envelope the bus carries

A chain replay re-derives what caused what and compares it to a record. Nothing in the platform ever wrote that record, so the fifth link of the chain canary could not be built honestly and any `replay_green` verdict would have been a claim.

Approved design: `beta/plans/2026-09-10-causal-edge-origination-proposal.md` (option A), merged at squash `e91826e7ba023ac9e9b34fcd603066f717d8902e`.

### The measurement that gates this change

Read-only on the dev lane, `event_ledger`, two-hour window ending 2026-09-10T06:06:27Z:

| Fact | Value |
| -- | -- |
| Rows in window | 4920 |
| `envelope_id` populated | 4920 |
| `correlation_id` populated | 4920 |
| `span_id` populated | 0 |
| `parent_span_id` populated | 0 |
| Positive control (same predicate) | 4920 rows over 4 topics |
| Negative control (impossible header key) | 0 |

The declared tracing pair is propagated and never originated, on every row. `envelope_id` is the only per-hop identity the platform already originates, and at the runtime applier it is a deterministic `uuid5`, so a verifier can recompute the expected parent independently of the record. That is what turns the verdict from stored into derived.

### What changes

- `ModelEventEnvelope` gains one optional `parent_envelope_id`, referencing the parent envelope's `envelope_id`. `None` is a statement, not an omission: the hop consumed nothing and is a chain head.
- A model validator refuses a self-referential edge. A self-edge would let a broken chain re-derive as a valid one-hop chain, which is the verdict-from-claim defect this edge exists to prevent.
- `to_dict_lazy` and `TypedDictEventEnvelopeDict` enumerate fields by hand, so both carry the edge explicitly. Otherwise a recorded edge is dropped silently between the model and a reader.
- `envelope_version` moves 2.1.0 to 2.2.0. This model is strict about undeclared fields, so a reader on an older core release **refuses** an envelope carrying this key rather than ignoring it. The minor bump is that signal, not decoration.
- `pyproject` 0.47.7 to 0.47.8, and the serialized-UUID allowlist in both copies of the string-version validator gains the new field name.

`span_id` and `parent_span_id` are deliberately untouched. Reusing them would mean originating two things, a span and its edge, to record one, and would overload a distributed-tracing field whose semantics belong to a tracing vendor.

Nothing originates the edge in this PR. Origination is one site in the runtime dispatch-result applier and lands in omnibase_infra once this is released. No handler participates: the canonical handler signature is `handle(request: ModelX) -> ModelY` and never sees an envelope.

### Red first

`tests/unit/models/events/test_model_event_envelope_parent_edge.py`, 8 tests.

- At the parent commit: **7 failed, 1 passed** — the field refused as undeclared, an attribute error on the default read, the lazy-dict key absent, and the version assertion reading `(2, 1)`.
- After the change: **8 passed**.

The self-reference test asserts the error message names self-reference, so it cannot be satisfied by the undeclared-field refusal that fires before the field exists. Each positive assertion has a negative control beside it: a distinct parent is accepted, and a chain head's absent edge is present-and-null rather than missing.

### Verification

| Check | Result |
| -- | -- |
| `tests/unit/models/events/` + `tests/unit/validation/test_envelope_validator.py` | 847 passed |
| Formatter, linter | clean |
| Strict type check, both changed source files | clean |
| Every pre-commit hook on the changed files | passed |
| Governed pre-push selector | passed (escalated to the full suite; no override of any kind) |

Strict type checking over the entire source tree reports 14 errors across 7 files, none of them touched here. They are pre-existing on `dev` and are recorded rather than inherited.

### dod_evidence

- The red-to-green transition above is the behaviour proof, reproducible by checking out the parent commit and running the same file.
- The dev-lane measurement is reproducible read-only against `event_ledger` with the positive and negative controls stated.

Evidence-Ticket: OMN-18116
Evidence-Source: OCC#8914
