### PR TITLE
feat(OMN-18079): carry delegation receipt provenance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.8"
+version = "0.47.9"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/models/delegation/wire/model_delegation_result.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_result.py
@@ -35,6 +35,22 @@ class ModelDelegationResult(BaseModel):
         description="Name of the LLM model that produced the response.",
     )
     endpoint_url: str = Field(..., description="URL of the LLM endpoint used.")
+    route: str | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Selected backend route that produced this terminal result. Paired "
+            "with provider; absent is explicit legacy or pre-backend unknown."
+        ),
+    )
+    provider: str | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Declared provider identity for the selected route. Never inferred "
+            "from a post-terminal tenant overlay."
+        ),
+    )
     content: str = Field(..., description="The LLM-generated response content.")
     quality_passed: bool = Field(
         ...,
@@ -195,6 +211,19 @@ class ModelDelegationResult(BaseModel):
         if self.total_tokens != expected_total:
             msg = "total_tokens must equal prompt_tokens + completion_tokens"
             raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def validate_receipt_provenance_pair(self) -> Self:
+        """Require terminal route/provider provenance to be complete when present."""
+        if (self.route is None) != (self.provider is None):
+            msg = "route and provider must be provided together"
+            raise ValueError(msg)
+        if self.route is not None:
+            assert self.provider is not None
+            if not self.route.strip() or not self.provider.strip():
+                msg = "route and provider must be nonblank when provided"
+                raise ValueError(msg)
         return self
 
     @model_validator(mode="after")

--- a/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
+++ b/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
@@ -5,10 +5,10 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, Self
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from omnibase_core.enums.enum_budget_action import EnumBudgetAction
 from omnibase_core.models.delegation.wire.model_delegation_wire_request import (
@@ -84,6 +84,23 @@ class ModelInferenceIntent(BaseModel):
             "orchestrator can reject a late response from an earlier route."
         ),
     )
+    route: str | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Selected backend route that the inference effect is to execute. "
+            "Paired with provider; both are absent for legacy or pre-backend "
+            "events."
+        ),
+    )
+    provider: str | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Declared provider identity for the selected backend route. Paired "
+            "with route and never inferred after execution."
+        ),
+    )
     api_key_ref: str | None = Field(
         default=None,
         description=(
@@ -141,6 +158,19 @@ class ModelInferenceIntent(BaseModel):
         cls, response_format: dict[str, object] | None
     ) -> dict[str, object] | None:
         return validate_response_format(response_format)
+
+    @model_validator(mode="after")
+    def _validate_receipt_provenance_pair(self) -> Self:
+        """Require route/provider provenance to be complete when present."""
+        if (self.route is None) != (self.provider is None):
+            msg = "route and provider must be provided together"
+            raise ValueError(msg)
+        if self.route is not None:
+            assert self.provider is not None
+            if not self.route.strip() or not self.provider.strip():
+                msg = "route and provider must be nonblank when provided"
+                raise ValueError(msg)
+        return self
 
 
 class ModelQualityGateIntent(BaseModel):
@@ -209,6 +239,22 @@ class ModelInferenceResponseData(BaseModel):
         default="",
         description="Failure reason when inference could not produce content.",
     )
+    route: str | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Route actually selected for this inference response. Paired with "
+            "provider; absent is explicit unknown provenance."
+        ),
+    )
+    provider: str | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Declared provider for the route that produced this response. Never "
+            "reconstructed from tenant configuration after execution."
+        ),
+    )
     # string-id-ok: tenant identity is a named slug (e.g. "omninode"), not a UUID.
     # OMN-14280 (OMN-14208 slice-2 A-now): round-tripped from ModelInferenceIntent
     # by the inference effect so the tenant that owned the call is auditable on
@@ -224,6 +270,19 @@ class ModelInferenceResponseData(BaseModel):
             ),
         )
     )
+
+    @model_validator(mode="after")
+    def _validate_receipt_provenance_pair(self) -> Self:
+        """Require route/provider provenance to be complete when present."""
+        if (self.route is None) != (self.provider is None):
+            msg = "route and provider must be provided together"
+            raise ValueError(msg)
+        if self.route is not None:
+            assert self.provider is not None
+            if not self.route.strip() or not self.provider.strip():
+                msg = "route and provider must be nonblank when provided"
+                raise ValueError(msg)
+        return self
 
 
 class ModelComplianceLoopResult(BaseModel):

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -392,6 +392,96 @@ class TestModelDelegationResult:
         assert r.terminal_failure_reason is None
         assert r.attempts_count == 1
 
+    def test_receipt_provenance_is_optional_and_complete_when_set(self) -> None:
+        legacy = ModelDelegationResult(
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            model_used="qwen3",
+            endpoint_url="http://localhost:8000",
+            content="result",
+            quality_passed=True,
+            quality_score=0.9,
+            latency_ms=100,
+            fallback_to_claude=False,
+        )
+        assert legacy.route is None
+        assert legacy.provider is None
+        assert "route" not in legacy.model_dump()
+        assert "provider" not in legacy.model_dump()
+
+        provenanced = legacy.model_copy(
+            update={"route": "byok-openrouter", "provider": "openrouter"}
+        )
+        assert (
+            ModelDelegationResult.model_validate(provenanced.model_dump())
+            == provenanced
+        )
+
+    @pytest.mark.parametrize(
+        ("route", "provider"),
+        [("byok-openrouter", None), (None, "openrouter"), (" ", "openrouter")],
+    )
+    def test_receipt_provenance_rejects_partial_or_blank_pair(
+        self, route: str | None, provider: str | None
+    ) -> None:
+        with pytest.raises(ValidationError, match="route and provider"):
+            ModelDelegationResult(
+                correlation_id=uuid.uuid4(),
+                task_type="test",
+                model_used="qwen3",
+                endpoint_url="http://localhost:8000",
+                content="result",
+                quality_passed=True,
+                quality_score=0.9,
+                latency_ms=100,
+                fallback_to_claude=False,
+                route=route,
+                provider=provider,
+            )
+
+    def test_completed_and_failed_terminals_inherit_provenance_validation(self) -> None:
+        completed = ModelDelegationCompleted(
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            model_used="qwen3",
+            endpoint_url="http://localhost:8000",
+            content="result",
+            quality_passed=True,
+            quality_score=0.9,
+            latency_ms=100,
+            fallback_to_claude=False,
+            route="byok-openrouter",
+            provider="openrouter",
+        )
+        assert completed.route == "byok-openrouter"
+
+        failed = ModelDelegationFailed(
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            model_used="qwen3",
+            endpoint_url="http://localhost:8000",
+            content="",
+            quality_passed=False,
+            quality_score=0.0,
+            latency_ms=100,
+            fallback_to_claude=False,
+        )
+        assert failed.route is None
+
+        with pytest.raises(ValidationError, match="route and provider"):
+            ModelDelegationCompleted(
+                correlation_id=uuid.uuid4(),
+                task_type="test",
+                model_used="qwen3",
+                endpoint_url="http://localhost:8000",
+                content="result",
+                quality_passed=True,
+                quality_score=0.9,
+                latency_ms=100,
+                fallback_to_claude=False,
+                route="byok-openrouter",
+            )
+
     def test_structured_quality_evidence_defaults_for_release_compatibility(
         self,
     ) -> None:
@@ -1006,6 +1096,49 @@ class TestModelInferenceIntent:
         assert tenant_intent.tenant_id == "tenant-alpha"
         assert tenant_intent.model_dump()["tenant_id"] == "tenant-alpha"
 
+    def test_receipt_provenance_is_optional_and_complete_when_set(self) -> None:
+        legacy = ModelInferenceIntent(
+            base_url="http://localhost:8000",
+            model="qwen3",
+            system_prompt="You are helpful.",
+            prompt="Write a test",
+            max_tokens=512,
+            correlation_id=uuid.uuid4(),
+        )
+        assert legacy.route is None
+        assert legacy.provider is None
+        assert "route" not in legacy.model_dump()
+        assert "provider" not in legacy.model_dump()
+
+        provenanced = ModelInferenceIntent.model_validate(
+            {
+                **legacy.model_dump(),
+                "route": "byok-openrouter",
+                "provider": "openrouter",
+            }
+        )
+        assert provenanced.route == "byok-openrouter"
+        assert provenanced.provider == "openrouter"
+
+    @pytest.mark.parametrize(
+        ("route", "provider"),
+        [("byok-openrouter", None), (None, "openrouter"), ("", "openrouter")],
+    )
+    def test_receipt_provenance_rejects_partial_or_blank_pair(
+        self, route: str | None, provider: str | None
+    ) -> None:
+        with pytest.raises(ValidationError, match="route and provider"):
+            ModelInferenceIntent(
+                base_url="http://localhost:8000",
+                model="qwen3",
+                system_prompt="You are helpful.",
+                prompt="Write a test",
+                max_tokens=512,
+                correlation_id=uuid.uuid4(),
+                route=route,
+                provider=provider,
+            )
+
     def test_inference_attempt_id_is_optional_and_round_trips_as_uuid(self) -> None:
         correlation_id = uuid.uuid4()
         default_intent = ModelInferenceIntent(
@@ -1580,6 +1713,43 @@ class TestModelInferenceResponseData:
             tenant_id="tenant-alpha",
         )
         assert tenant_resp.tenant_id == "tenant-alpha"
+
+    def test_receipt_provenance_is_optional_and_round_trips_when_complete(self) -> None:
+        legacy = ModelInferenceResponseData(
+            correlation_id=uuid.uuid4(),
+            content="Generated response.",
+            model_used="qwen3-14b",
+        )
+        assert legacy.route is None
+        assert legacy.provider is None
+        assert "route" not in legacy.model_dump()
+        assert "provider" not in legacy.model_dump()
+
+        provenanced = ModelInferenceResponseData(
+            correlation_id=uuid.uuid4(),
+            content="Generated response.",
+            model_used="nvidia/nemotron-3-ultra-550b-a55b:free",
+            route="byok-openrouter",
+            provider="openrouter",
+        )
+        assert provenanced.route == "byok-openrouter"
+        assert provenanced.provider == "openrouter"
+
+    @pytest.mark.parametrize(
+        ("route", "provider"),
+        [("byok-openrouter", None), (None, "openrouter"), ("", "openrouter")],
+    )
+    def test_receipt_provenance_rejects_partial_or_blank_pair(
+        self, route: str | None, provider: str | None
+    ) -> None:
+        with pytest.raises(ValidationError, match="route and provider"):
+            ModelInferenceResponseData(
+                correlation_id=uuid.uuid4(),
+                content="Generated response.",
+                model_used="qwen3-14b",
+                route=route,
+                provider=provider,
+            )
 
     def test_inference_attempt_id_is_optional_and_round_trips_as_uuid(self) -> None:
         default_resp = ModelInferenceResponseData(

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.8"
+version = "0.47.9"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

Add paired nullable route/provider provenance to Core delegation wire DTOs for receipt provenance.

## Changes

- Add the fields to inference intent, inference response, and delegation terminal result.
- Preserve legacy payload compatibility when both values are absent.
- Reject partial or blank provenance pairs.
- Add focused wire-model regression coverage.
- Bump the Core package version to 0.47.9.

## Test plan

- Focused delegation-wire model regressions were added with the change.
- The remote branch is at commit 6bb3c71c3d438f659d41a5e1be62c20c6b76b88d.
- PR checks are pending observation.

## Type safety checklist

- [x] No new metadata string-literal access on Pydantic model fields
- [x] No new untyped metadata dictionary fields
- [x] No new bare exception handlers
- [x] No metadata dictionary keys added

## Related issues

OMN-18079

Evidence-Ticket: OMN-18079
Evidence-Source: OCC#9002
