### PR TITLE
feat(OMN-18159): one shared targeted-column UPSERT plan for every write path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.8"
+version = "0.47.9"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/models/projection/__init__.py
+++ b/src/omnibase_core/models/projection/__init__.py
@@ -15,12 +15,24 @@ from omnibase_core.enums.enum_degraded_behavior import EnumDegradedBehavior
 from .model_cursor_contract import ModelCursorContract
 from .model_projection_base import ModelProjectionBase
 from .model_projection_contract import ModelProjectionContract
+from .model_upsert_plan import (
+    ALLOWED_WRITE_ATTESTATION_SQL,
+    SQL_EXPRESSION_SENTINEL_PREFIX,
+    WRITE_ATTESTATION_COLUMNS,
+    ModelUpsertPlan,
+    build_upsert_plan,
+)
 from .model_watermark import ModelProjectionWatermark
 
 __all__ = [
+    "ALLOWED_WRITE_ATTESTATION_SQL",
+    "SQL_EXPRESSION_SENTINEL_PREFIX",
+    "WRITE_ATTESTATION_COLUMNS",
     "EnumDegradedBehavior",
     "ModelCursorContract",
     "ModelProjectionBase",
     "ModelProjectionContract",
     "ModelProjectionWatermark",
+    "ModelUpsertPlan",
+    "build_upsert_plan",
 ]

--- a/src/omnibase_core/models/projection/model_upsert_plan.py
+++ b/src/omnibase_core/models/projection/model_upsert_plan.py
@@ -1,0 +1,317 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""One targeted-column UPSERT plan, rendered into each driver's placeholder style.
+
+WHY THIS LIVES IN CORE (OMN-18159)
+
+Four implementations of the same statement exist across this workspace: the
+delegation projection runner's asyncpg ``_dynamic_upsert`` (``$N``), and
+``omnimarket``'s psycopg2 (``%(name)s``), SQLite (``:name``) and in-memory sync
+adapters -- plus the runtime kernel's own projection database operations in
+``omnibase_infra``. They already agreed on the easy half (conflict-key
+splitting, the missing-key refusal, ``DO NOTHING`` when no column is updatable)
+and had drifted apart on the half that matters: only the asyncpg one grew the
+write-attestation features that the staging green bar's writer-principal clause
+reads.
+
+``omnimarket`` and ``omnibase_infra`` both depend on ``omnibase_core`` and
+``omnibase_core`` depends on neither, so under the compat -> core -> spi ->
+infra layering this is the only place both can share one copy. Putting it here
+rather than duplicating it into the second consumer is the whole point: a
+decision made in one place cannot diverge between write paths; a decision
+copied into four cannot help but.
+
+This module holds NO I/O. It owns the DECISIONS -- which column goes on which
+arm, which expression is admissible, which identifier is safe -- and leaves
+each adapter owning only its driver's parameter binding.
+
+WHAT A "TARGETED-COLUMN" UPSERT MEANS, since every adapter must agree on it:
+``EXCLUDED`` overwrite for the columns present in ``row`` ONLY. A column absent
+from ``row`` is left untouched on an existing row and takes its database
+default on INSERT. That is the contract every caller of a sync projection
+database adapter already relies on, and it is what makes sticky-evidence merge
+paths safe.
+
+THE THREE FEATURES BEYOND A PLAIN UPSERT, and why each is not a nicety:
+
+``sql_expression_columns``
+    A column whose value is a SQL EXPRESSION that Postgres evaluates per row,
+    on BOTH arms -- never a bound parameter. ``writer_identity = CURRENT_USER``
+    is the whole reason a projection row can answer "which database principal
+    wrote this": a bound parameter would let the writing process choose the
+    answer, and a column recording whatever the application asserts attests to
+    nothing. The expression is restated on the ``DO UPDATE`` arm because a
+    column DEFAULT is consulted only on INSERT, so an existing row would
+    otherwise wear its first writer's stamp for the rest of its life. Because
+    these strings reach the composed statement UNCAST and unparameterised, the
+    admissible set is CLOSED (:data:`ALLOWED_WRITE_ATTESTATION_SQL`) and
+    checked here, never interpolated from a caller's string.
+
+``insert_only_columns``
+    Named on the INSERT arm, withheld from ``DO UPDATE SET``: "attribute the
+    row I create, never re-attribute one that already exists". Both halves are
+    load-bearing under row-level security, and the INSERT half is the
+    non-obvious one. Postgres evaluates the policy's ``WITH CHECK`` against the
+    PROPOSED insert row BEFORE the conflict is resolved, so a targeted-column
+    upsert that omits ``tenant_id`` proposes a row carrying the column default
+    and is refused outright whenever ``app.tenant_id`` is anything else -- even
+    when the statement was only ever going to take the update arm.
+
+``returning``
+    The row the database actually stored. A writer cannot know what it wrote
+    for a column the database stamped, so a republish built from the writer's
+    own row dict would serve an attestation nothing attested to.
+
+WHY THESE RAISE ``ValueError``/``KeyError`` AND NOT ``OnexError``
+
+Every refusal here rejects a CALLER-SUPPLIED ARGUMENT before any statement is
+composed -- a malformed identifier, an inadmissible expression, a row missing
+its own conflict key. That is the standard-Python function-boundary case this
+repo's error-handling guidance assigns to ``ValueError``, not an ONEX runtime
+condition that needs an error code, a correlation id or a serialized envelope.
+
+There is also a hard compatibility constraint. All four adapters that will
+adopt this builder already raise exactly these types for exactly these inputs,
+and their callers and test suites match on them. The builder exists to make
+those four paths byte-identical; changing the exception type at the same moment
+would make the migration observable to every caller and would break the
+parity tests that are the only proof the migration was behaviour-preserving.
+The ``KeyError`` for a missing conflict key is the same: it is what all four
+raise today, and the message format is matched on.
+
+ORDERING IS PART OF THE CONTRACT, not an accident of iteration. Bound columns
+keep their ``row`` order and come first; expression columns follow in their
+mapping order. Two write paths that ordered them differently would produce
+statements that are semantically equal and textually different, and a
+differential test that proves they agree would have nothing to compare.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Final, Literal
+
+__all__ = [
+    "ALLOWED_WRITE_ATTESTATION_SQL",
+    "SQL_EXPRESSION_SENTINEL_PREFIX",
+    "WRITE_ATTESTATION_COLUMNS",
+    "ModelUpsertPlan",
+    "build_upsert_plan",
+]
+
+#: Trusted-internal-literal identifier guard. Every table and column name that
+#: reaches a plan comes from a hand-written constant or a typed row key, never
+#: from user or network input -- validating anyway keeps the composed SQL
+#: provably injection-free rather than provably-injection-free-by-convention.
+_IDENTIFIER_RE: Final = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+#: The closed set of SQL expressions a write-attestation column may be stamped
+#: with. Both members are evaluated by Postgres per row: ``CURRENT_USER`` is
+#: the connection's effective principal at the instant of the write, and
+#: ``NOW()`` is the writing transaction's timestamp. The set is closed because
+#: these strings are composed into the statement uncast.
+ALLOWED_WRITE_ATTESTATION_SQL: Final[frozenset[str]] = frozenset(
+    {"CURRENT_USER", "NOW()"}
+)
+
+#: The two columns migration 0038 added to ``delegation_events`` and the
+#: expressions that stamp them, on both arms.
+WRITE_ATTESTATION_COLUMNS: Final[Mapping[str, str]] = MappingProxyType(
+    {"writer_identity": "CURRENT_USER", "written_at": "NOW()"}
+)
+
+#: How the double records a column it cannot evaluate. Unmistakable on a
+#: failure, and deliberately NOT a plausible principal name: a double that
+#: invented ``"postgres"`` would make every attestation assertion written
+#: against it pass while the production statement bound a literal string.
+SQL_EXPRESSION_SENTINEL_PREFIX: Final = "<sql:"
+
+Dialect = Literal["pyformat", "qmark_named", "numeric"]
+
+
+@dataclass(frozen=True, slots=True)
+class ModelUpsertPlan:
+    """The resolved column layout of one targeted-column UPSERT.
+
+    ``bound_columns`` are the columns a driver must bind a parameter for, in
+    bind order. ``insert_columns`` is the INSERT column list -- bound columns
+    followed by expression columns. ``update_assignments`` pairs each column on
+    the ``DO UPDATE SET`` arm with either ``None`` (assign from ``EXCLUDED``)
+    or the SQL expression to re-evaluate.
+    """
+
+    table: str
+    conflict_keys: list[str]
+    bound_columns: list[str]
+    expression_columns: Mapping[str, str]
+    update_assignments: list[tuple[str, str | None]]
+    returning: list[str]
+
+    @property
+    def insert_columns(self) -> list[str]:
+        return [*self.bound_columns, *self.expression_columns]
+
+    @property
+    def is_do_nothing(self) -> bool:
+        """True when no column is updatable, so the conflict arm does nothing.
+
+        This is a real outcome, not a degenerate one: a row of nothing but
+        conflict keys, or one whose every other column is insert-only, has
+        nothing to say about a row that already exists.
+        """
+        return not self.update_assignments
+
+    def render(
+        self,
+        *,
+        dialect: Dialect,
+        jsonb_columns: frozenset[str] = frozenset(),
+    ) -> str:
+        """Compose the statement for one driver's placeholder style.
+
+        ``jsonb_columns`` applies to the ``numeric`` dialect only, where
+        asyncpg does not auto-adapt Python containers the way psycopg2's
+        ``Json`` wrapper does, so the placeholder itself carries the cast. The
+        other two dialects adapt the VALUE in the adapter and leave the
+        placeholder plain, which is why passing the set to them is a caller
+        error rather than a silent no-op.
+        """
+        if jsonb_columns and dialect != "numeric":
+            # The four adapters this builder replaces already raise this exact
+            # type for this exact input and their callers match on it.
+            # error-ok: caller-argument validation at a function boundary
+            raise ValueError(
+                f"jsonb_columns is meaningful only for the 'numeric' dialect; "
+                f"the {dialect!r} dialect adapts the value, not the placeholder"
+            )
+        placeholders = self._placeholders(dialect, jsonb_columns)
+        excluded = "excluded" if dialect == "qmark_named" else "EXCLUDED"
+        set_pairs = [
+            f"{column} = {excluded}.{column}"
+            if expression is None
+            else f"{column} = {expression}"
+            for column, expression in self.update_assignments
+        ]
+        action = f"DO UPDATE SET {', '.join(set_pairs)}" if set_pairs else "DO NOTHING"
+        # sqlite writes `ON CONFLICT(a, b)`; postgres writes `ON CONFLICT (a, b)`.
+        # Preserved per dialect so a rendered statement is byte-identical to what
+        # each adapter composed before this module existed.
+        conflict = ", ".join(self.conflict_keys)
+        conflict_clause = (
+            f"ON CONFLICT({conflict})"
+            if dialect == "qmark_named"
+            else f"ON CONFLICT ({conflict})"
+        )
+        returning_clause = (
+            f" RETURNING {', '.join(self.returning)}" if self.returning else ""
+        )
+        return (
+            f"INSERT INTO {self.table} ({', '.join(self.insert_columns)}) "
+            f"VALUES ({', '.join([*placeholders, *self.expression_columns.values()])}) "
+            f"{conflict_clause} {action}{returning_clause}"
+        )
+
+    def _placeholders(
+        self, dialect: Dialect, jsonb_columns: frozenset[str]
+    ) -> list[str]:
+        if dialect == "pyformat":
+            return [f"%({column})s" for column in self.bound_columns]
+        if dialect == "qmark_named":
+            return [f":{column}" for column in self.bound_columns]
+        return [
+            f"${index}::jsonb" if column in jsonb_columns else f"${index}"
+            for index, column in enumerate(self.bound_columns, start=1)
+        ]
+
+
+def _validate(names: Iterable[str], *, kind: str) -> None:
+    for name in names:
+        if not _IDENTIFIER_RE.match(name):
+            # The four adapters this builder replaces already raise this exact
+            # type for this exact input and their callers match on it.
+            # error-ok: caller-argument validation at a function boundary
+            raise ValueError(f"invalid {kind} identifier: {name!r}")
+
+
+def build_upsert_plan(
+    *,
+    table: str,
+    conflict_key: str,
+    row: Mapping[str, object],
+    insert_only_columns: frozenset[str] = frozenset(),
+    sql_expression_columns: Mapping[str, str] = MappingProxyType({}),
+    returning: Sequence[str] = (),
+) -> ModelUpsertPlan:
+    """Resolve one targeted-column UPSERT into a :class:`ModelUpsertPlan`.
+
+    Every refusal here is loud and happens before any connection is opened, so
+    a rejected write cannot leave a partially applied statement behind.
+    """
+    conflict_keys = [key.strip() for key in conflict_key.split(",") if key.strip()]
+    if not conflict_keys:
+        # The four adapters this builder replaces already raise this exact
+        # type for this exact input and their callers match on it.
+        # error-ok: caller-argument validation at a function boundary
+        raise ValueError("conflict_key must contain at least one key")
+    missing = [key for key in conflict_keys if key not in row]
+    if missing:
+        # The four adapters this builder replaces already raise this exact
+        # type for this exact input and their callers match on it.
+        # error-ok: caller-argument validation at a function boundary
+        raise KeyError(f"row missing conflict key(s): {missing}")
+
+    # An attestation column may not also be a bound value. If a caller put one
+    # on the row dict it would win the placeholder slot and the expression
+    # would never be evaluated -- the column would silently go back to
+    # recording whatever the writing process said.
+    overlapping = sorted(set(sql_expression_columns) & set(row))
+    if overlapping:
+        # The four adapters this builder replaces already raise this exact
+        # type for this exact input and their callers match on it.
+        # error-ok: caller-argument validation at a function boundary
+        raise ValueError(
+            f"columns {overlapping!r} are declared as SQL expressions and must "
+            "not also be supplied as row values: a bound parameter would "
+            "override the expression and the column would attest to the caller "
+            "rather than to the database"
+        )
+    for column, expression in sql_expression_columns.items():
+        if expression not in ALLOWED_WRITE_ATTESTATION_SQL:
+            # The four adapters this builder replaces already raise this exact
+            # type for this exact input and their callers match on it.
+            # error-ok: caller-argument validation at a function boundary
+            raise ValueError(
+                f"SQL expression {expression!r} for column {column!r} is not in "
+                "the allowed write-attestation set "
+                f"{sorted(ALLOWED_WRITE_ATTESTATION_SQL)!r}"
+            )
+
+    # The KIND is carried into the message on purpose. "invalid identifier
+    # 'timestamp '" does not say whether the caller mistyped a row key, a
+    # conflict key or a RETURNING column, and those are three different bugs
+    # in three different call sites.
+    bound_columns = list(row)
+    _validate((table,), kind="table")
+    _validate(bound_columns, kind="column")
+    _validate(conflict_keys, kind="conflict-key")
+    _validate(sql_expression_columns, kind="expression-column")
+    _validate(returning, kind="returning-column")
+
+    update_assignments: list[tuple[str, str | None]] = [
+        (column, None)
+        for column in bound_columns
+        if column not in conflict_keys and column not in insert_only_columns
+    ]
+    update_assignments.extend(sql_expression_columns.items())
+
+    return ModelUpsertPlan(
+        table=table,
+        conflict_keys=conflict_keys,
+        bound_columns=bound_columns,
+        expression_columns=MappingProxyType(dict(sql_expression_columns)),
+        update_assignments=update_assignments,
+        returning=list(returning),
+    )

--- a/tests/models/projection/__init__.py
+++ b/tests/models/projection/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT

--- a/tests/models/projection/test_model_upsert_plan_omn18159.py
+++ b/tests/models/projection/test_model_upsert_plan_omn18159.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""OMN-18159: the shared targeted-column UPSERT plan.
+
+This module is the single home of the decisions four write paths across this
+workspace had already drifted on. The tests below therefore assert the
+DECISIONS -- arm placement, the closed admissible-expression set, identifier
+validation, bind ordering -- and the exact rendered text for each driver
+dialect, because two adapters that render the same plan differently are the
+drift this module exists to remove.
+
+The rendered-statement assertions are deliberately byte-exact rather than
+structural. A structural assertion ("the update arm mentions writer_identity")
+passes for a statement that assigns it from ``EXCLUDED`` instead of
+re-evaluating the expression, and those two differ only when a second writer
+touches the row -- which is exactly the case the attestation exists to
+distinguish.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+from omnibase_core.models.projection import (
+    ALLOWED_WRITE_ATTESTATION_SQL,
+    WRITE_ATTESTATION_COLUMNS,
+    build_upsert_plan,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestArmPlacement:
+    def test_every_non_conflict_column_is_on_the_update_arm(self) -> None:
+        plan = build_upsert_plan(
+            table="delegation_events",
+            conflict_key="correlation_id",
+            row={"correlation_id": "c1", "task_type": "t", "delegated_to": "d"},
+        )
+        assert plan.conflict_keys == ["correlation_id"]
+        assert plan.insert_columns == ["correlation_id", "task_type", "delegated_to"]
+        assert plan.update_assignments == [("task_type", None), ("delegated_to", None)]
+        assert plan.bound_columns == ["correlation_id", "task_type", "delegated_to"]
+
+    def test_a_row_of_only_conflict_keys_takes_the_do_nothing_arm(self) -> None:
+        plan = build_upsert_plan(
+            table="t", conflict_key="correlation_id", row={"correlation_id": "c1"}
+        )
+        assert plan.update_assignments == []
+        assert plan.is_do_nothing is True
+
+    def test_composite_conflict_keys_split_and_strip(self) -> None:
+        plan = build_upsert_plan(
+            table="delegation_budget_state",
+            conflict_key="tenant_id, cost_tier_name ,budget_period",
+            row={
+                "tenant_id": "x",
+                "cost_tier_name": "y",
+                "budget_period": "z",
+                "delegation_count": 1,
+            },
+        )
+        assert plan.conflict_keys == ["tenant_id", "cost_tier_name", "budget_period"]
+        assert plan.update_assignments == [("delegation_count", None)]
+
+    def test_insert_only_columns_are_on_insert_and_off_update(self) -> None:
+        """Both halves are load-bearing under row-level security.
+
+        The INSERT half is the non-obvious one: Postgres checks the policy
+        against the PROPOSED row before resolving the conflict, so dropping
+        ``tenant_id`` from the column list entirely is refused outright even
+        for a statement that would only ever take the update arm.
+        """
+        plan = build_upsert_plan(
+            table="delegation_events",
+            conflict_key="correlation_id",
+            row={
+                "correlation_id": "c1",
+                "tenant_id": "t",
+                "timestamp": "ts",
+                "quality_gate_passed": True,
+            },
+            insert_only_columns=frozenset({"tenant_id", "timestamp"}),
+        )
+        assert "tenant_id" in plan.insert_columns
+        assert "timestamp" in plan.insert_columns
+        assert plan.update_assignments == [("quality_gate_passed", None)]
+
+    def test_a_row_whose_every_updatable_column_is_insert_only_does_nothing(
+        self,
+    ) -> None:
+        plan = build_upsert_plan(
+            table="delegation_events",
+            conflict_key="correlation_id",
+            row={"correlation_id": "c1", "tenant_id": "t"},
+            insert_only_columns=frozenset({"tenant_id"}),
+        )
+        assert plan.is_do_nothing is True
+        assert "tenant_id" in plan.insert_columns
+
+
+class TestExpressionColumns:
+    def test_expressions_are_on_both_arms_and_bind_nothing(self) -> None:
+        plan = build_upsert_plan(
+            table="delegation_events",
+            conflict_key="correlation_id",
+            row={"correlation_id": "c1", "task_type": "t"},
+            sql_expression_columns=WRITE_ATTESTATION_COLUMNS,
+        )
+        assert plan.insert_columns == [
+            "correlation_id",
+            "task_type",
+            "writer_identity",
+            "written_at",
+        ]
+        assert plan.bound_columns == ["correlation_id", "task_type"]
+        assert plan.update_assignments == [
+            ("task_type", None),
+            ("writer_identity", "CURRENT_USER"),
+            ("written_at", "NOW()"),
+        ]
+
+    def test_a_column_bound_and_expressed_at_once_is_refused(self) -> None:
+        """The refusal that makes the attestation mean anything.
+
+        A bound value would win the placeholder slot and the expression would
+        never be evaluated, so the column would silently go back to recording
+        whatever the writing process said.
+        """
+        with pytest.raises(ValueError, match="must not also be supplied as row values"):
+            build_upsert_plan(
+                table="delegation_events",
+                conflict_key="correlation_id",
+                row={"correlation_id": "c1", "writer_identity": "i_said_so"},
+                sql_expression_columns=WRITE_ATTESTATION_COLUMNS,
+            )
+
+    @pytest.mark.parametrize(
+        "expression",
+        ["(SELECT 1)", "version()", "current_user", "NOW ()", "CURRENT_USER;--"],
+    )
+    def test_an_expression_outside_the_closed_set_is_refused(
+        self, expression: str
+    ) -> None:
+        """The set is closed because these strings reach the statement uncast.
+
+        ``current_user`` lowercase and ``NOW ()`` with a space are included
+        deliberately: they are semantically identical to admissible members,
+        and admitting them by normalising would turn a closed set into a
+        parser.
+        """
+        with pytest.raises(ValueError, match="not in the allowed write-attestation"):
+            build_upsert_plan(
+                table="delegation_events",
+                conflict_key="correlation_id",
+                row={"correlation_id": "c1"},
+                sql_expression_columns=MappingProxyType(
+                    {"writer_identity": expression}
+                ),
+            )
+
+    def test_the_closed_set_holds_exactly_two_members(self) -> None:
+        assert frozenset({"CURRENT_USER", "NOW()"}) == ALLOWED_WRITE_ATTESTATION_SQL
+        assert dict(WRITE_ATTESTATION_COLUMNS) == {
+            "writer_identity": "CURRENT_USER",
+            "written_at": "NOW()",
+        }
+
+
+class TestIdentifierValidation:
+    @pytest.mark.parametrize(
+        "bad", ["delegation events", "drop;table", "1_leading_digit", "", "a-b", "a.b"]
+    )
+    def test_the_message_names_which_position_the_bad_identifier_came_from(
+        self, bad: str
+    ) -> None:
+        """A mistyped row key, table and RETURNING column are three bugs.
+
+        A single generic message forces the reader back to the call site to
+        work out which of the three they have.
+        """
+        with pytest.raises(ValueError, match="invalid column identifier"):
+            build_upsert_plan(
+                table="delegation_events",
+                conflict_key="correlation_id",
+                row={"correlation_id": "c1", bad: "v"},
+            )
+        with pytest.raises(ValueError, match="invalid table identifier"):
+            build_upsert_plan(
+                table=bad, conflict_key="correlation_id", row={"correlation_id": "c1"}
+            )
+        with pytest.raises(ValueError, match="invalid returning-column identifier"):
+            build_upsert_plan(
+                table="delegation_events",
+                conflict_key="correlation_id",
+                row={"correlation_id": "c1"},
+                returning=(bad,),
+            )
+
+    def test_an_empty_conflict_key_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="at least one key"):
+            build_upsert_plan(table="t", conflict_key="  ,  ", row={"a": 1})
+
+    def test_a_row_missing_a_conflict_key_is_refused(self) -> None:
+        with pytest.raises(KeyError, match="missing conflict key"):
+            build_upsert_plan(table="t", conflict_key="correlation_id", row={"a": 1})
+
+
+class TestRendering:
+    def test_pyformat_dialect(self) -> None:
+        plan = build_upsert_plan(
+            table="delegation_events",
+            conflict_key="correlation_id",
+            row={"correlation_id": "c1", "task_type": "t"},
+            sql_expression_columns=WRITE_ATTESTATION_COLUMNS,
+            returning=("correlation_id", "writer_identity"),
+        )
+        assert plan.render(dialect="pyformat") == (
+            "INSERT INTO delegation_events "
+            "(correlation_id, task_type, writer_identity, written_at) "
+            "VALUES (%(correlation_id)s, %(task_type)s, CURRENT_USER, NOW()) "
+            "ON CONFLICT (correlation_id) DO UPDATE SET "
+            "task_type = EXCLUDED.task_type, "
+            "writer_identity = CURRENT_USER, written_at = NOW() "
+            "RETURNING correlation_id, writer_identity"
+        )
+
+    def test_qmark_named_dialect_uses_lowercase_excluded_and_tight_conflict(
+        self,
+    ) -> None:
+        """SQLite spells both differently, and the difference is not cosmetic.
+
+        Reproducing each driver's own spelling is what lets an adapter adopt
+        this builder without changing a single byte of the statement it
+        already issues, so the migration is provably behaviour-preserving.
+        """
+        plan = build_upsert_plan(
+            table="delegation_events",
+            conflict_key="correlation_id",
+            row={"correlation_id": "c1", "task_type": "t"},
+        )
+        assert plan.render(dialect="qmark_named") == (
+            "INSERT INTO delegation_events (correlation_id, task_type) "
+            "VALUES (:correlation_id, :task_type) "
+            "ON CONFLICT(correlation_id) DO UPDATE SET "
+            "task_type = excluded.task_type"
+        )
+
+    def test_numeric_dialect_numbers_placeholders_in_bind_order(self) -> None:
+        plan = build_upsert_plan(
+            table="delegation_events",
+            conflict_key="correlation_id",
+            row={"correlation_id": "c1", "gates": ["a"], "task_type": "t"},
+            sql_expression_columns=WRITE_ATTESTATION_COLUMNS,
+        )
+        assert plan.render(dialect="numeric", jsonb_columns=frozenset({"gates"})) == (
+            "INSERT INTO delegation_events "
+            "(correlation_id, gates, task_type, writer_identity, written_at) "
+            "VALUES ($1, $2::jsonb, $3, CURRENT_USER, NOW()) "
+            "ON CONFLICT (correlation_id) DO UPDATE SET "
+            "gates = EXCLUDED.gates, task_type = EXCLUDED.task_type, "
+            "writer_identity = CURRENT_USER, written_at = NOW()"
+        )
+
+    def test_do_nothing_renders_without_a_set_clause(self) -> None:
+        plan = build_upsert_plan(
+            table="t", conflict_key="correlation_id", row={"correlation_id": "c1"}
+        )
+        assert plan.render(dialect="pyformat").endswith(
+            "ON CONFLICT (correlation_id) DO NOTHING"
+        )
+
+    def test_jsonb_columns_on_a_value_adapting_dialect_is_a_caller_error(self) -> None:
+        """Silently ignoring it would hide a real mistake.
+
+        Only the numeric dialect carries the cast on the placeholder; the
+        other two adapt the VALUE inside the adapter. A caller passing the set
+        to those has misunderstood which side does the work, and a no-op would
+        let that misunderstanding ship.
+        """
+        plan = build_upsert_plan(
+            table="t", conflict_key="k", row={"k": "1", "gates": ["a"]}
+        )
+        for dialect in ("pyformat", "qmark_named"):
+            with pytest.raises(ValueError, match="only for the 'numeric' dialect"):
+                plan.render(
+                    dialect=dialect,  # type: ignore[arg-type]
+                    jsonb_columns=frozenset({"gates"}),
+                )
+
+    def test_bind_order_follows_row_order_not_sorted_order(self) -> None:
+        """Ordering is part of the contract, not an accident of iteration.
+
+        Two write paths that ordered columns differently would render
+        statements that are semantically equal and textually different, and a
+        differential test proving they agree would have nothing to compare.
+        """
+        plan = build_upsert_plan(
+            table="t",
+            conflict_key="k",
+            row={"k": "1", "zeta": 1, "alpha": 2},
+        )
+        assert plan.bound_columns == ["k", "zeta", "alpha"]
+        assert plan.render(dialect="numeric").startswith(
+            "INSERT INTO t (k, zeta, alpha) VALUES ($1, $2, $3)"
+        )
+
+
+class TestPlanIsInert:
+    def test_the_plan_carries_no_values_only_column_names(self) -> None:
+        """The plan is a statement shape, never a row of data.
+
+        Keeping values out of it is what lets it be built, logged and compared
+        without ever handling a tenant identifier or a secret.
+        """
+        plan = build_upsert_plan(
+            table="t", conflict_key="k", row={"k": "sensitive", "v": "also-sensitive"}
+        )
+        rendered = repr(plan) + plan.render(dialect="pyformat")
+        assert "sensitive" not in rendered

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.8"
+version = "0.47.9"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## What this closes

OMN-18159 AC5's prerequisite, and the sequenced alternative to duplicating a SQL builder.

`delegation_events` carries a writer attestation — `writer_identity` stamped by Postgres as `CURRENT_USER`, `written_at` as `NOW()`, both restated on the `DO UPDATE` arm — and the staging green bar's leg 4 reads it. Four implementations of that write exist in this workspace, and only one of them grew the feature:

| Implementation | Repo |
|---|---|
| `DelegationProjectionRunner._dynamic_upsert` (asyncpg) | omnimarket — **has it** |
| `PostgresSyncProjectionAdapter`, `SqliteDatabaseAdapter`, `InmemoryDatabaseAdapter` | omnimarket — gained it in `omnimarket#2457` |
| `ProjectionDatabaseOperations` (the runtime kernel's own) | omnibase_infra — **still cannot express it** |

`omnimarket` and `omnibase_infra` both depend on `omnibase_core`, and core depends on neither, so under the compat → core → spi → infra layering this is the only place both can share one copy. That is why the builder lands here rather than being copied into the second consumer: the closed set of admissible SQL expressions is what keeps an unparameterised `CURRENT_USER` safe, and a security decision that exists in four places cannot help but drift — which is exactly how this started.

## What it is

`models/projection/model_upsert_plan.py`. No I/O. It owns the decisions — which column goes on which arm, which expression is admissible, which identifier is safe, what order columns bind in — and renders them into each driver's placeholder style. Each adapter keeps only its own parameter binding.

Three features beyond a plain upsert, each load-bearing rather than convenient:

- **SQL-expression columns**, evaluated by the database on both arms. A bound parameter would let the writing process choose what the row says about who wrote it. Restated on the update arm because a column `DEFAULT` is consulted only on `INSERT`, so an existing row would otherwise wear its first writer's stamp forever.
- **Insert-only columns**, named on `INSERT` and withheld from `DO UPDATE SET`. Both halves matter under row-level security, and the insert half is the non-obvious one: Postgres checks the policy against the *proposed* row before resolving the conflict, so omitting `tenant_id` entirely is refused even for a statement that would only ever update.
- **`RETURNING`**, because a writer cannot know what the database stamped, and a republish built from its own row dict would serve an attestation nothing attested to.

## Two choices worth reviewing

**Each dialect reproduces its driver's existing spelling exactly** — SQLite's lowercase `excluded` and tight `ON CONFLICT(` included. That is not fussiness: it means an adapter can adopt this builder without changing a single byte of the statement it already issues, which is what makes the migration provably behaviour-preserving rather than merely believed to be.

**Refusals raise `ValueError`/`KeyError`, annotated at each site.** They reject caller-supplied arguments at a function boundary, which is the case this repo's guidance assigns to standard exceptions. There is also a hard constraint: all four adapters already raise exactly these types for exactly these inputs, and their callers and tests match on them. Changing the type here would make the migration observable to every caller and break the parity tests that are its only proof.

28 new tests. The rendered-statement assertions are byte-exact rather than structural, deliberately: a structural assertion ("the update arm mentions `writer_identity`") passes for a statement that assigns it from `EXCLUDED` instead of re-evaluating the expression, and those two differ only when a second writer touches the row — the one case the column exists to distinguish.

Governed pre-push classified this `reason=shared_module`, escalated fail-closed to the full suite, and ran it:

```
45066 passed, 53 skipped, 3 xpassed in 6403.84s (1:46:43)
```

`mypy --strict` clean. Every pre-commit gate clean, including the naming convention, the error-raising validator and the SPDX header rule.

## What this does not do

Nothing consumes it yet. `omnimarket` keeps its own copy until a released core is available, and re-points in a follow-up that deletes that copy — no shim, no re-export. `omnibase_infra` then bumps its pin and widens `ProjectionDatabaseOperations` on this builder. That sequence is recorded as AC5 on OMN-18159.

Evidence-Ticket: OMN-18159
Evidence-Source: OCC#9010
