### PR TITLE
fix(ci): bind Contract Compliance evidence to Evidence-Source (OMN-18157)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3977,7 +3977,7 @@ jobs:
           # scripts/ci/run_contract_compliance_check.py in working order.
           # Re-pinned to OCC dev HEAD at the time of this change.
           ref: 91f5b69104366c2d86e4bb21de67c3c497702111
-          path: onex_change_control
+          path: onex_change_control_checker
           token: ${{ steps.app-token.outputs.token || github.token }}
 
       - uses: astral-sh/setup-uv@v7
@@ -3987,7 +3987,7 @@ jobs:
 
       - name: Install onex_change_control
         if: steps.dep-scope.outputs.exempt != 'true'
-        working-directory: onex_change_control
+        working-directory: onex_change_control_checker
         run: |
           set -euo pipefail
           export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-600}"
@@ -4005,82 +4005,51 @@ jobs:
             attempt=$((attempt + 1))
           done
 
-      # OMN-14887: EXECUTE the DoD check_values against the PRODUCT tree.
-      #
-      # What was here before -- `uv run validate-yaml $CONTRACTS` -- never ran a
-      # single check_value. It only parsed OCC's YAML, so a green
-      # "Contract Compliance Check" meant exactly "OCC's contract files are
-      # valid YAML" and nothing about this PR. The DoD gate has been dead here
-      # since the OMN-14436 fix (core#1435) documented that lie without
-      # replacing the executor -- fan-out was deliberately deferred until
-      # omnibase_infra (OMN-14454) burned in the pattern first.
-      #
-      # --workspace is the load-bearing argument. It must be the PRODUCT
-      # checkout ($GITHUB_WORKSPACE), not the OCC clone -- pointing it at OCC
-      # is the original OMN-14436 defect.
-      #
-      # Landmine specific to this repo (see quality-gate job above): this job
-      # used to be a `needs:` predecessor of quality-gate, whose downstream
-      # (detect-changes, test-parallel) skip when quality-gate != success, and
-      # tests-gate treats a skipped test-parallel as PASSED. Turning on a real
-      # executor here without first decoupling would have let a single BLOCK
-      # cascade to "tests-gate: PASSED" on zero tests run -- strictly worse than
-      # infra's failure mode. contract-compliance is no longer in quality-gate's
-      # needs; ci-summary's independent GATE_JOBS entry keeps this required and
-      # merge-blocking without the cascade.
-      - name: Run DoD contract compliance against the product tree (OMN-14887)
+      # OMN-18157: the checker code stays at its audited immutable pin while
+      # contracts are checked out at the exact Evidence-Source SHA from this PR.
+      # A missing or malformed source is a hard failure; it never falls back to
+      # the checker pin or OCC default branch.
+      - name: Resolve contract-compliance evidence data (OMN-18157)
+        id: resolve_contract_compliance_evidence
         if: steps.dep-scope.outputs.exempt != 'true'
-        working-directory: onex_change_control
-        run: |
-          set -euo pipefail
-          # OMN-16346: the job-level `if:` above deliberately admits
-          # pull_request, merge_group, AND push (it cannot be narrowed to
-          # pull_request -- see that comment), so this branch is NOT an
-          # invariant-broke escape hatch, it is the normal path on every dev
-          # push. Prior text here claimed the job "now only runs on
-          # pull_request" and unconditionally exited 1; that made
-          # push-event runs (i.e. every post-merge dev commit) fail closed
-          # by construction, permanently reddening dev's post-merge signal
-          # (OMN-16013 / OMN-16055 / OMN-16346).
-          #
-          # Push-path fix: resolve the PR that produced this push's commit
-          # and validate against IT, instead of failing blind. GitHub
-          # associates a squash-merge commit with its originating PR (the
-          # documented "List pull requests associated with a commit" API),
-          # so for the ordinary squash-merge-to-dev case this evaluates the
-          # exact same check_values the PR's own pull_request run already
-          # evaluated -- not a vacuous pass, not a skip, and not a second
-          # independent judgment that could disagree with the PR verdict.
-          if [ -z "${PR_NUMBER:-}" ] && [ "${{ github.event_name }}" = "push" ]; then
-            RESOLVED_PR="$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
-              --jq '[.[] | select(.merged_at != null)] | sort_by(.merged_at) | last | .number // empty' \
-              2>/dev/null || true)"
-            if [ -n "$RESOLVED_PR" ]; then
-              echo "::notice::event=push, no PR in event payload -- resolved merged PR #${RESOLVED_PR} from commit ${{ github.sha }} via the associated-PR API"
-              PR_NUMBER="$RESOLVED_PR"
-            fi
-          fi
-          if [ -z "${PR_NUMBER:-}" ]; then
-            # Still unresolved: a pull_request run missing PR_NUMBER (the
-            # invariant above broke some other way), a merge_group run (no
-            # live dev merge queue today; this repo has no merge_group
-            # associated-PR resolution yet -- see OMN-16346 follow-up if one
-            # is ever enabled), or a push whose commit genuinely has no
-            # associated PR (direct push, rebase merge, force push). Fail
-            # closed (exit 1), never vacuously pass a DoD check that did not
-            # actually run a single check_value.
-            echo "::error::No PR number (event=${{ github.event_name }}); DoD check_values are PR-scoped and could not be resolved for this event. Failing closed."
-            exit 1
-          fi
-          uv run python scripts/ci/run_contract_compliance_check.py \
-            --pr "$PR_NUMBER" \
-            --repo "${{ github.repository }}" \
-            --contracts-dir "$GITHUB_WORKSPACE/onex_change_control/contracts" \
-            --workspace "$GITHUB_WORKSPACE" \
-            --legacy-allowlist "$GITHUB_WORKSPACE/onex_change_control/scripts/ci/dod_runner_legacy_allowlist.txt"
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/resolve_contract_compliance_evidence.py \
+            --repo "${{ github.repository }}" \
+            --event-name "${{ github.event_name }}" \
+            --commit-sha "${{ github.sha }}" \
+            --pr-number "${PR_NUMBER:-}" \
+            --merge-group-head-ref "${MERGE_GROUP_HEAD_REF:-}"
+
+      - name: Checkout contract-compliance evidence data (OMN-18157)
+        if: steps.dep-scope.outputs.exempt != 'true'
+        uses: actions/checkout@v7
+        with:
+          repository: OmniNode-ai/onex_change_control
+          ref: ${{ steps.resolve_contract_compliance_evidence.outputs.occ_sha }}
+          path: onex_change_control_evidence
+          token: ${{ steps.app-token.outputs.token || github.token }}
+
+      # The preflight calls the same pinned runner resolver used by the runner
+      # itself, then requires that exact ticket's data contract before ``uv``
+      # can execute any check_value against the product workspace.
+      - name: Run DoD contract compliance against the product tree (OMN-14887)
+        if: steps.dep-scope.outputs.exempt != 'true'
+        run: |
+          set -euo pipefail
+          uv run python scripts/ci/run_contract_compliance_with_evidence.py \
+            --pr "${{ steps.resolve_contract_compliance_evidence.outputs.pr_number }}" \
+            --repo "${{ github.repository }}" \
+            --checker-dir "$GITHUB_WORKSPACE/onex_change_control_checker" \
+            --evidence-contracts-dir "$GITHUB_WORKSPACE/onex_change_control_evidence/contracts" \
+            --workspace "$GITHUB_WORKSPACE" \
+            --legacy-allowlist "$GITHUB_WORKSPACE/onex_change_control_checker/scripts/ci/dod_runner_legacy_allowlist.txt"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Record dependency-bot workflow-only contract compliance decision
         if: steps.dep-scope.outputs.exempt == 'true'
         run: |

--- a/.github/workflows/receipt-gate.yml
+++ b/.github/workflows/receipt-gate.yml
@@ -276,9 +276,12 @@ jobs:
             if [ "$occ_state" = "MERGED" ]; then
               occ_sha="$(printf '%s' "$occ_json" | jq -r '.mergeCommit.oid // ""' 2>/dev/null || true)"
               occ_source_kind="merged"
-            else
+            elif [ "$occ_state" = "OPEN" ]; then
               occ_sha="$(printf '%s' "$occ_json" | jq -r '.headRefOid // ""' 2>/dev/null || true)"
               occ_source_kind="open-pr"
+            else
+              echo "::error::RECEIPT GATE FAILED: OCC PR #${occ_pr_num} is ${occ_state:-unavailable}; Evidence-Source OCC# references require OPEN or MERGED."
+              exit 1
             fi
             if [ -z "$occ_sha" ]; then
               echo "::error::RECEIPT GATE FAILED: OCC PR #${occ_pr_num} could not be resolved — OCC unavailable or PR not found. Cannot verify evidence (OMN-10419 invariant I8)."

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -216,7 +212,7 @@
         "filename": "scripts/validation/validate-secrets.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 62
       }
     ],
     "src/omnibase_core/backends/cache/backend_cache_redis.py": [
@@ -1407,6 +1403,15 @@
         "line_number": 1208
       }
     ],
+    "tests/unit/scripts/ci/test_contract_compliance_evidence_binding.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/scripts/ci/test_contract_compliance_evidence_binding.py",
+        "hashed_secret": "3ee39c044e44ef1c0434be4a7537cbe9d39b3278",
+        "is_verified": false,
+        "line_number": 245
+      }
+    ],
     "tests/unit/scripts/test_regenerate_fingerprints.py": [
       {
         "type": "Hex High Entropy String",
@@ -1481,7 +1486,7 @@
         "filename": "tests/unit/validation/test_validate_hardcoded_env_vars.py",
         "hashed_secret": "33eafeb967e2f62c6da67fa985f48bc181c4b3cb",
         "is_verified": false,
-        "line_number": 402
+        "line_number": 401
       }
     ],
     "tests/unit/validation/test_validate_secrets.py": [
@@ -1956,7 +1961,30 @@
         "is_verified": false,
         "line_number": 312
       }
+    ],
+    "tests/validators/test_bypass_token_blocklist.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/validators/test_bypass_token_blocklist.py",
+        "hashed_secret": "47a84809f1c2317f0db700d42dba81658d043b6b",
+        "is_verified": false,
+        "line_number": 177
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/validators/test_bypass_token_blocklist.py",
+        "hashed_secret": "51cff3c1f0bc59f6187e7040cc12a4e9b1eca7aa",
+        "is_verified": false,
+        "line_number": 180
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/validators/test_bypass_token_blocklist.py",
+        "hashed_secret": "8cb78fd137d1eea5cfbca6373d4b08ae954c769e",
+        "is_verified": false,
+        "line_number": 195
+      }
     ]
   },
-  "generated_at": "2026-09-07T05:36:45Z"
+  "generated_at": "2026-09-11T01:18:12Z"
 }

--- a/scripts/ci/resolve_contract_compliance_evidence.py
+++ b/scripts/ci/resolve_contract_compliance_evidence.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Resolve the immutable OCC evidence data checkout for contract compliance."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_OCC_REPO = "OmniNode-ai/onex_change_control"
+_OCC_PR_RE = re.compile(r"^OCC#(\d+)$", re.IGNORECASE)
+_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
+_EVIDENCE_SOURCE_RE = re.compile(
+    r"^Evidence-Source: ([^\r\n]+)$", re.IGNORECASE | re.MULTILINE
+)
+_MERGE_GROUP_PR_RE = re.compile(r"/pr-(\d+)-")
+
+
+def _gh(*args: str) -> str:
+    """Run a fixed ``gh`` argv and fail with its diagnostic."""
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=False, timeout=60
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic"
+        raise RuntimeError(f"gh {' '.join(args[:4])} failed: {detail}")
+    return result.stdout
+
+
+def _json_gh(*args: str) -> dict[str, object]:
+    raw = _gh(*args)
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("gh returned malformed JSON") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("gh returned a non-object JSON response")
+    return payload
+
+
+def _resolve_pr_number(
+    *,
+    event_name: str,
+    pr_number: str,
+    merge_group_head_ref: str,
+    repo: str,
+    commit_sha: str,
+) -> str:
+    if pr_number:
+        return pr_number
+    if event_name == "push":
+        resolved = _gh(
+            "api",
+            f"repos/{repo}/commits/{commit_sha}/pulls",
+            "--jq",
+            "[.[] | select(.merged_at != null)] | sort_by(.merged_at) | last | .number // empty",
+        ).strip()
+        if resolved:
+            return resolved
+    elif event_name == "merge_group":
+        match = _MERGE_GROUP_PR_RE.search(merge_group_head_ref)
+        if match:
+            return match.group(1)
+    raise RuntimeError(f"No PR number could be resolved for event={event_name}")
+
+
+def _evidence_source(body: str) -> str:
+    match = _EVIDENCE_SOURCE_RE.search(body)
+    if match is None:
+        raise RuntimeError("PR body is missing required 'Evidence-Source:' line")
+    source = match.group(1).strip()
+    if not source:
+        raise RuntimeError("PR body has an empty Evidence-Source value")
+    return source
+
+
+def _resolve_occ_sha(source: str) -> str:
+    if pr_match := _OCC_PR_RE.fullmatch(source):
+        occ_pr = pr_match.group(1)
+        payload = _json_gh(
+            "pr",
+            "view",
+            occ_pr,
+            "--repo",
+            _OCC_REPO,
+            "--json",
+            "state,headRefOid,mergeCommit",
+        )
+        state = payload.get("state")
+        if state == "MERGED":
+            merge_commit = payload.get("mergeCommit")
+            if isinstance(merge_commit, dict):
+                sha = merge_commit.get("oid")
+            else:
+                sha = None
+        elif state == "OPEN":
+            sha = payload.get("headRefOid")
+        else:
+            raise RuntimeError(
+                f"OCC PR #{occ_pr} is {state!r}; Evidence-Source OCC# references require OPEN or MERGED"
+            )
+        if not isinstance(sha, str) or not sha:
+            raise RuntimeError(
+                f"OCC PR #{occ_pr} did not resolve to an immutable commit SHA"
+            )
+        return sha
+
+    if not _SHA_RE.fullmatch(source):
+        raise RuntimeError(
+            f"Evidence-Source value {source!r} is not OCC#<number> or a hexadecimal SHA"
+        )
+
+    status = _gh(
+        "api", f"repos/{_OCC_REPO}/compare/HEAD...{source}", "--jq", ".status"
+    ).strip()
+    if status in {"behind", "identical"}:
+        sha = _gh("api", f"repos/{_OCC_REPO}/commits/{source}", "--jq", ".sha").strip()
+        if sha:
+            return sha
+        raise RuntimeError("Evidence-Source SHA could not be canonicalized")
+
+    matched_head = _gh(
+        "pr",
+        "list",
+        "--repo",
+        _OCC_REPO,
+        "--state",
+        "open",
+        "--json",
+        "headRefOid",
+        "--jq",
+        f'.[] | select(.headRefOid | startswith("{source}")) | .headRefOid',
+    ).splitlines()
+    if matched_head and matched_head[0].strip():
+        return matched_head[0].strip()
+    raise RuntimeError(
+        "Evidence-Source SHA is neither an OCC durable-branch ancestor nor an open OCC PR head"
+    )
+
+
+def resolve(args: argparse.Namespace) -> tuple[str, str]:
+    """Return the PR number and immutable OCC evidence SHA, or raise."""
+    pr_number = _resolve_pr_number(
+        event_name=args.event_name,
+        pr_number=args.pr_number,
+        merge_group_head_ref=args.merge_group_head_ref,
+        repo=args.repo,
+        commit_sha=args.commit_sha,
+    )
+    pr = _json_gh("pr", "view", pr_number, "--repo", args.repo, "--json", "body")
+    body = pr.get("body")
+    if not isinstance(body, str):
+        raise RuntimeError(f"PR #{pr_number} did not return a string body")
+    return pr_number, _resolve_occ_sha(_evidence_source(body))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--commit-sha", required=True)
+    parser.add_argument("--pr-number", default="")
+    parser.add_argument("--merge-group-head-ref", default="")
+    args = parser.parse_args()
+    try:
+        pr_number, occ_sha = resolve(args)
+    except (RuntimeError, subprocess.TimeoutExpired, OSError) as exc:
+        sys.stderr.write(
+            f"::error::Contract Compliance evidence resolution failed: {exc}\n"
+        )
+        return 1
+
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with Path(output_path).open("a", encoding="utf-8") as output:
+            output.write(f"pr_number={pr_number}\nocc_sha={occ_sha}\n")
+    else:
+        sys.stdout.write(f"pr_number={pr_number}\nocc_sha={occ_sha}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_contract_compliance_with_evidence.py
+++ b/scripts/ci/run_contract_compliance_with_evidence.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Fail closed before invoking the pinned OCC contract-compliance runner."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _extract_ticket_id(*, checker_dir: Path, pr_number: int, repo: str) -> str | None:
+    """Use the pinned runner's own ticket precedence for preflight and execution."""
+    source_root = checker_dir / "src"
+    if not source_root.is_dir():
+        raise RuntimeError(f"Pinned checker source is unavailable: {source_root}")
+    sys.path.insert(0, str(source_root))
+    try:
+        checker = importlib.import_module(
+            "onex_change_control.scripts.contract_compliance_check"
+        )
+        extract = getattr(checker, "_extract_ticket_id", None)
+        if not callable(extract):
+            raise RuntimeError("Pinned checker does not expose its ticket resolver")
+        result = extract(pr_number, repo)
+    finally:
+        sys.path.pop(0)
+    return result if isinstance(result, str) else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr", required=True, type=int)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--checker-dir", required=True, type=Path)
+    parser.add_argument("--evidence-contracts-dir", required=True, type=Path)
+    parser.add_argument("--workspace", required=True, type=Path)
+    parser.add_argument("--legacy-allowlist", required=True, type=Path)
+    args = parser.parse_args()
+
+    try:
+        ticket_id = _extract_ticket_id(
+            checker_dir=args.checker_dir, pr_number=args.pr, repo=args.repo
+        )
+    except (ImportError, OSError, RuntimeError) as exc:
+        sys.stderr.write(
+            f"::error::Contract Compliance ticket resolution failed: {exc}\n"
+        )
+        return 1
+    if ticket_id is None:
+        sys.stderr.write(
+            "::error::Contract Compliance could not resolve an OMN ticket using the pinned "
+            "runner's title, branch, body precedence.\n"
+        )
+        return 1
+
+    contract_path = args.evidence_contracts_dir / f"{ticket_id}.yaml"
+    if not contract_path.is_file():
+        sys.stderr.write(
+            "::error::Contract Compliance evidence data lacks the resolved ticket contract: "
+            f"{contract_path}\n"
+        )
+        return 1
+
+    runner = args.checker_dir / "scripts" / "ci" / "run_contract_compliance_check.py"
+    if not runner.is_file():
+        sys.stderr.write(
+            f"::error::Pinned contract-compliance runner is unavailable: {runner}\n"
+        )
+        return 1
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            str(runner),
+            "--pr",
+            str(args.pr),
+            "--repo",
+            args.repo,
+            "--contracts-dir",
+            str(args.evidence_contracts_dir),
+            "--workspace",
+            str(args.workspace),
+            "--legacy-allowlist",
+            str(args.legacy_allowlist),
+        ],
+        cwd=args.checker_dir,
+        check=False,
+    )
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/ci/test_ci_summary_gate.py
+++ b/tests/unit/scripts/ci/test_ci_summary_gate.py
@@ -555,21 +555,25 @@ class TestContractComplianceFailClosed:
         for event in ("pull_request", "merge_group", "push"):
             assert f"github.event_name == '{event}'" in condition, condition
 
-    def test_empty_pr_number_branch_fails_closed_not_open(self) -> None:
-        text = CI_YML.read_text(encoding="utf-8")
-        marker = 'if [ -z "${PR_NUMBER:-}" ]; then'
-        idx = text.index(marker)
-        # OMN-16346: bound the branch by its own terminator only. This used to
-        # slice a fixed `text[idx : idx + 400]` window first, which silently
-        # made the pin depend on how many COMMENT characters happen to sit
-        # between the `if` and the `exit 1` -- adding an explanatory comment
-        # inside the branch pushed `exit 1` past offset 400 and failed this
-        # test while the fail-closed property it guards was fully intact. The
-        # `\n          fi` split already bounds the branch exactly, so the
-        # character cap was never load-bearing, only brittle.
-        branch = text[idx:].split("\n          fi", 1)[0]
-        assert "exit 1" in branch, branch
-        assert "exit 0" not in branch, branch
+    def test_pr_resolution_is_delegated_to_the_fail_closed_evidence_resolver(
+        self,
+    ) -> None:
+        """The resolver owns push/merge-group PR admission after OMN-18157."""
+        workflow = yaml.safe_load(CI_YML.read_text(encoding="utf-8"))
+        steps = workflow["jobs"]["contract-compliance"]["steps"]
+        resolver = next(
+            step
+            for step in steps
+            if step.get("id") == "resolve_contract_compliance_evidence"
+        )
+        assert "resolve_contract_compliance_evidence.py" in resolver["run"]
+        assert '--event-name "${{ github.event_name }}"' in resolver["run"]
+        assert '--commit-sha "${{ github.sha }}"' in resolver["run"]
+        resolver_source = (
+            REPO_ROOT / "scripts/ci/resolve_contract_compliance_evidence.py"
+        ).read_text(encoding="utf-8")
+        assert "No PR number could be resolved" in resolver_source
+        assert "return 1" in resolver_source
 
 
 class TestContractComplianceNameDistinction:

--- a/tests/unit/scripts/ci/test_contract_compliance_evidence_binding.py
+++ b/tests/unit/scripts/ci/test_contract_compliance_evidence_binding.py
@@ -1,0 +1,271 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Executable fail-closed coverage for OMN-18157's two-checkout CI binding."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+RESOLVER = REPO_ROOT / "scripts/ci/resolve_contract_compliance_evidence.py"
+RUNNER = REPO_ROOT / "scripts/ci/run_contract_compliance_with_evidence.py"
+CI_YML = REPO_ROOT / ".github/workflows/ci.yml"
+
+
+@pytest.fixture
+def fake_bin(tmp_path: Path) -> Path:
+    """A deterministic gh stub; its behavior is selected through GH_CASE."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    gh = bindir / "gh"
+    gh.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+args="$*"
+case "${GH_CASE:-}" in
+  valid)
+    if [[ "$args" == *"pr view 7 --repo OmniNode-ai/omnibase_core --json body"* ]]; then
+      printf '%s\\n' '{"body":"Evidence-Source: OCC#99"}'
+    elif [[ "$args" == *"pr view 99 --repo OmniNode-ai/onex_change_control"* ]]; then
+      printf '%s\\n' '{"state":"OPEN","headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","mergeCommit":null}'
+    else
+      echo "unexpected gh invocation: $args" >&2; exit 8
+    fi
+    ;;
+  missing)
+    printf '%s\\n' '{"body":"No evidence source"}'
+    ;;
+  malformed)
+    printf '%s\\n' '{"body":"Evidence-Source: not-a-reference!"}'
+    ;;
+  closed)
+    if [[ "$args" == *"--json body"* ]]; then
+      printf '%s\\n' '{"body":"Evidence-Source: OCC#99"}'
+    else
+      printf '%s\\n' '{"state":"CLOSED","headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","mergeCommit":null}'
+    fi
+    ;;
+  unresolved-push)
+    echo 'gh unavailable' >&2; exit 1
+    ;;
+  *)
+    echo "unknown GH_CASE=${GH_CASE:-}" >&2; exit 9
+    ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    return bindir
+
+
+def _env(fake_bin: Path, **values: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env.update(values)
+    return env
+
+
+def _resolve(
+    tmp_path: Path, fake_bin: Path, *, case: str, event: str = "pull_request"
+) -> subprocess.CompletedProcess[str]:
+    output = tmp_path / "github-output"
+    return subprocess.run(
+        [
+            sys.executable,
+            str(RESOLVER),
+            "--repo",
+            "OmniNode-ai/omnibase_core",
+            "--event-name",
+            event,
+            "--commit-sha",
+            "b" * 40,
+            "--pr-number",
+            "7" if event == "pull_request" else "",
+        ],
+        env=_env(fake_bin, GH_CASE=case, GITHUB_OUTPUT=str(output)),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_valid_evidence_source_resolves_an_immutable_data_sha(
+    tmp_path: Path, fake_bin: Path
+) -> None:
+    result = _resolve(tmp_path, fake_bin, case="valid")
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "github-output").read_text(encoding="utf-8") == (
+        "pr_number=7\nocc_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+    )
+
+
+def test_missing_or_malformed_evidence_source_fails_without_fallback(
+    tmp_path: Path, fake_bin: Path
+) -> None:
+    for case in ("missing", "malformed"):
+        result = _resolve(tmp_path, fake_bin, case=case)
+        assert result.returncode == 1
+        assert "evidence" in result.stderr.lower()
+
+
+def test_closed_unmerged_occ_reference_fails(tmp_path: Path, fake_bin: Path) -> None:
+    result = _resolve(tmp_path, fake_bin, case="closed")
+    assert result.returncode == 1
+    assert "require OPEN or MERGED" in result.stderr
+
+
+def test_unavailable_push_and_merge_group_pr_resolution_fail(
+    tmp_path: Path, fake_bin: Path
+) -> None:
+    for event in ("push", "merge_group"):
+        result = _resolve(tmp_path, fake_bin, case="unresolved-push", event=event)
+        assert result.returncode == 1
+        assert "resolution failed" in result.stderr
+
+
+def _make_checker(tmp_path: Path) -> Path:
+    checker = tmp_path / "checker"
+    module = checker / "src/onex_change_control/scripts"
+    module.mkdir(parents=True)
+    for package in (
+        checker / "src/onex_change_control/__init__.py",
+        checker / "src/onex_change_control/scripts/__init__.py",
+    ):
+        package.write_text("", encoding="utf-8")
+    (module / "contract_compliance_check.py").write_text(
+        "def _extract_ticket_id(pr_number, repo):\n    return 'OMN-18157'\n",
+        encoding="utf-8",
+    )
+    script = checker / "scripts/ci/run_contract_compliance_check.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("", encoding="utf-8")
+    allowlist = checker / "scripts/ci/dod_runner_legacy_allowlist.txt"
+    allowlist.write_text("", encoding="utf-8")
+    return checker
+
+
+def _runner_command(checker: Path, evidence: Path, workspace: Path) -> list[str]:
+    return [
+        sys.executable,
+        str(RUNNER),
+        "--pr",
+        "7",
+        "--repo",
+        "OmniNode-ai/omnibase_core",
+        "--checker-dir",
+        str(checker),
+        "--evidence-contracts-dir",
+        str(evidence),
+        "--workspace",
+        str(workspace),
+        "--legacy-allowlist",
+        str(checker / "scripts/ci/dod_runner_legacy_allowlist.txt"),
+    ]
+
+
+def test_missing_data_contract_fails_before_uv_runner(
+    tmp_path: Path, fake_bin: Path
+) -> None:
+    checker = _make_checker(tmp_path)
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    log = tmp_path / "uv.log"
+    uv = fake_bin / "uv"
+    uv.write_text(f"#!/usr/bin/env bash\nprintf invoked > {log}\n", encoding="utf-8")
+    uv.chmod(0o755)
+    result = subprocess.run(
+        _runner_command(checker, evidence, tmp_path),
+        env=_env(fake_bin),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "lacks the resolved ticket contract" in result.stderr
+    assert not log.exists()
+
+
+def test_valid_evidence_invokes_pinned_runner_with_data_and_workspace(
+    tmp_path: Path, fake_bin: Path
+) -> None:
+    checker = _make_checker(tmp_path)
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    (evidence / "OMN-18157.yaml").write_text("schema_version: '1'\n", encoding="utf-8")
+    log = tmp_path / "uv.log"
+    uv = fake_bin / "uv"
+    uv.write_text(
+        f"#!/usr/bin/env bash\nprintf '%s\\n' \"$PWD|$*\" > {log}\n",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+    workspace = tmp_path / "product"
+    workspace.mkdir()
+    result = subprocess.run(
+        _runner_command(checker, evidence, workspace),
+        env=_env(fake_bin),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    invocation = log.read_text(encoding="utf-8")
+    assert str(checker) in invocation
+    assert f"--contracts-dir {evidence}" in invocation
+    assert f"--workspace {workspace}" in invocation
+
+
+def test_workflow_keeps_checker_pin_and_uses_separate_evidence_checkout() -> None:
+    workflow = yaml.safe_load(CI_YML.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["contract-compliance"]["steps"]
+    checkouts = [
+        step
+        for step in steps
+        if step.get("uses") == "actions/checkout@v7" and "with" in step
+    ]
+    checker = next(
+        step
+        for step in checkouts
+        if step["with"].get("path") == "onex_change_control_checker"
+    )
+    evidence = next(
+        step
+        for step in checkouts
+        if step["with"].get("path") == "onex_change_control_evidence"
+    )
+    assert checker["with"]["ref"] == "91f5b69104366c2d86e4bb21de67c3c497702111"
+    assert (
+        evidence["with"]["ref"]
+        == "${{ steps.resolve_contract_compliance_evidence.outputs.occ_sha }}"
+    )
+    run_step = next(
+        step
+        for step in steps
+        if step.get("name")
+        == "Run DoD contract compliance against the product tree (OMN-14887)"
+    )
+    assert "run_contract_compliance_with_evidence.py" in run_step["run"]
+    assert (
+        "steps.resolve_contract_compliance_evidence.outputs.pr_number"
+        in run_step["run"]
+    )
+    assert "$GITHUB_WORKSPACE/onex_change_control_evidence/contracts" in run_step["run"]
+    assert '--workspace "$GITHUB_WORKSPACE"' in run_step["run"]
+    assert (
+        "onex_change_control_checker/scripts/ci/dod_runner_legacy_allowlist.txt"
+        in run_step["run"]
+    )
+    receipt_gate = (REPO_ROOT / ".github/workflows/receipt-gate.yml").read_text(
+        encoding="utf-8"
+    )
+    assert 'elif [ "$occ_state" = "OPEN" ]; then' in receipt_gate
+    assert "references require OPEN or MERGED" in receipt_gate


### PR DESCRIPTION
Evidence-Source: OCC#9012
Evidence-Ticket: OMN-18157

## OMN-18157 — Contract Compliance Evidence-Source binding

This stacked draft targets `jonah/omn-16992-prereq-composition-currentdev-20260910` at `16eb93428d8422e3f01cfea9daad9624906f3d3b` and contains seven paths:

- CI workflow and receipt-gate binding updates;
- Contract Compliance evidence resolution and execution changes;
- focused CI/evidence-binding regressions; and
- the reviewed `.secrets.baseline` refresh required by hosted Detect Secrets.

The CI change is commit `e646654c7659d705cfe01e5d06979754ae860525`; the final branch head is `b11d3e37e792a280432e53eff7da4e5fecead5d4`. The baseline commit changes no code. The full code-suite proof belongs to `e646` and is historical evidence for that included commit, not a claim that `b11` independently ran a new local full suite.

Verification for `b11`:

- Hosted-equivalent `detect-secrets==1.5.0` scan: pass, 216s.
- `pre-commit run --all-files`: pass, 634s.
- Normal commit hooks: pass, 82s.
- Governed normal pre-push: pass. h101.2 ran 45,112 passed, 59 skipped, 3 xpassed (45,174 collected), bound to `b11`; receipt log SHA-256 `e7a82f838795f6914906ae4ab85ab23afba6b1be47c58306a0f1b14939d22332`.

The baseline refresh retains scanner rules, exclusions, and test inputs. It records two stale line moves and four reviewed test-only false positives.

OCC companion [#9012](https://github.com/OmniNode-ai/onex_change_control/pull/9012) is bound to this final head and remains open while its hosted checks run. This PR remains draft and does not close OMN-16992.

Related parent PR: #1674.
