### PR TITLE
chore(OMN-18176): retire the governed pre-push test leg in omnibase_core

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,17 @@
 #   pre-commit install --hook-type pre-push  # Install pre-push hooks
 #   pre-commit run --all-files            # Run all pre-commit hooks
 #   pre-commit run --all-files --hook-stage pre-push  # Run pre-push hooks
+#
+# PRE-PUSH SCOPE, as of 2026-09-11 (OMN-18176): pre-push is policy, type and
+# lint checks plus two named test exceptions. Nine hooks. The governed
+# impacted-test selector was retired from this stage -- hosted CI is the
+# enforced merge gate and runs the identical selection. The two hooks that
+# still reach a test runner, `pytest-protocol-uuid-enforcement` and
+# `verify-flip-bundle`, are deliberate exceptions and each carries an
+# annotation at its own definition giving its measured cost and the reason it
+# is kept. Do not remove either for consistency with the retirement. See the
+# retirement block at the foot of this file; plan of record
+# OmniNode-ai/knowledge-base-internal#328 phase 1.
 
 repos:
   # YAML formatting (standard across ecosystem)
@@ -231,6 +242,36 @@ repos:
       # Runs at PRE-PUSH (flip-discovery diffs the whole branch vs origin/dev, which is
       # present locally) — it does its OWN git discovery, so pass_filenames is false.
       # No committed flip in the diff -> exit 0.
+      #
+      # RETAINED TEST EXCEPTION #2 (OMN-18176, kb-internal#328 section 2.8).
+      # This gate reaches the test runner -- indirectly, through the
+      # parity_replay module the entry script imports -- and is DELIBERATELY
+      # KEPT at pre-push even though OMN-18176 retired the governed
+      # impacted-test selector from this stage. Do not remove it as an
+      # oversight or for consistency.
+      #
+      #   Measured cost 2026-09-09: 0.51 s at steady state, exit 0, reporting
+      #                             no canonical-shape flips to prove. The
+      #                             files: filter above means an unrelated
+      #                             push never starts it at all. It runs tests
+      #                             only when the push carries a newly
+      #                             canonicalised node, or burns an entry out
+      #                             of the parity-debt baseline. When it does
+      #                             fire the module records a 2026-07-28
+      #                             census of ~24 min for 22 proofs, ~65 s
+      #                             each.
+      #   Kept ON COST, NOT ON COVERAGE -- and the difference from exception
+      #                             #1 matters. CI runs this IDENTICAL gate in
+      #                             the import-layering job on every pull
+      #                             request except a docs-only diff, and a
+      #                             docs-only diff cannot contain a node flip.
+      #                             Retiring it would lose no property. It
+      #                             stays because it costs half a second at
+      #                             steady state and because phase 1's rule is
+      #                             to change nothing but the smart-tests hook.
+      #                             A later reader who wants exactly one rule
+      #                             can drop it at no loss of coverage; that is
+      #                             a decision, not a cleanup.
       - id: verify-flip-bundle
         name: canonical-shape flip-bundle seam gate (fail-closed, OMN-14809)
         entry: uv run python scripts/ci/verify_flip_bundle.py
@@ -1693,6 +1734,33 @@ repos:
       # Verifies protocol type annotations use UUID instead of str
       # Catches issues like / before CI
       # ~6s runtime - acceptable for pre-push but too slow for every commit
+      #
+      # RETAINED TEST EXCEPTION #1 (OMN-18176, kb-internal#328 section 2.8).
+      # This hook invokes the test runner and is DELIBERATELY KEPT at pre-push
+      # even though OMN-18176 retired the governed impacted-test selector from
+      # this stage. Do not remove it as an oversight or for consistency.
+      #
+      #   Measured cost 2026-09-09: 2.02 s of test-runner time, 4.4 s wall
+      #                             including environment resolution. One
+      #                             module, 45 tests. Unconditional -- it takes
+      #                             no file arguments and always runs.
+      #   Kept ON COVERAGE:         CI gates the same property only when the
+      #                             impacted-subset selector happens to pick
+      #                             this module up. ENABLE_SMART_TESTS is true
+      #                             for this repository, so an ordinary pull
+      #                             request runs the selector's output, not the
+      #                             full suite, and no workflow names this
+      #                             module or a marker unique to it. CI's
+      #                             coverage is therefore conditional on the
+      #                             diff; this hook's is unconditional on every
+      #                             push. Retiring it would trade a guaranteed
+      #                             check for a conditional one.
+      #   What it guards:           that identifier fields on the container and
+      #                             type protocols are typed as UUID rather
+      #                             than str, and that the models built on them
+      #                             validate, reject and serialise accordingly.
+      #                             It is the regression fence around the
+      #                             string-to-identifier migration.
       - id: pytest-protocol-uuid-enforcement
         name: Protocol UUID Enforcement Check
         entry: uv run pytest
@@ -1935,28 +2003,44 @@ repos:
         always_run: true
         stages: [pre-commit]
 
-  # Governed impacted-test selector at PRE-PUSH (OMN-13973 / WS7 OMN-14655, D6a).
-  # Runs the fast local IMPACTED SUBSET of the unit suite once per `git push`,
-  # via the SAME selector CI uses (scripts/ci/detect_test_paths.py +
-  # test_selection_adjacency.yaml, ENABLE_SMART_TESTS) -- never a hand-typed -k.
-  # Fail-closed: escalates to the full unit suite when it cannot prove narrowing
-  # is safe (shared module / pyproject deps / scripts/ci/ / >=8 modules / main).
-  # NET-NEGATIVE-SURFACE: retires the "run the whole suite by hand before every
-  # push" default (root CLAUDE.md Rule #4). This is a fast local mirror ADVISORY
-  # of the full CI suite -- NOT byte-parity with an enforced CI context (on CI
-  # the selector is behind ENABLE_SMART_TESTS off-by-default; the enforced gate
-  # is the full suite). FAIL-LOUD: hard-errors if base/selector/adjacency cannot
-  # resolve (plan section 3d.4); never a green skip.
-  - repo: local
-    hooks:
-      - id: prepush-smart-tests
-        name: Governed impacted-test selector (pre-push, OMN-13973)
-        entry: bash scripts/hooks/prepush_smart_tests.sh
-        language: system
-        pass_filenames: false
-        always_run: true
-        verbose: true
-        stages: [pre-push]
+# ---------------------------------------------------------------------------
+# RETIRED 2026-09-11 (OMN-18176): the governed impacted-test selector
+# `prepush-smart-tests` (OMN-13973 / WS7 OMN-14655) no longer runs at
+# pre-push. It ran `bash scripts/hooks/prepush_smart_tests.sh`, which
+# dispatched either the impacted subset or, fail-closed, the whole
+# `tests/` tree -- 45,136 collectable tests -- onto a lab host at five
+# budgeted cores, 1h13m to 2h13m per escalation.
+#
+# Why it went: hosted CI is the ENFORCED merge gate and runs the identical
+# selection. Measured in this worktree on 2026-09-11, two independent
+# collections diffed both directions:
+#
+#     pre-push maximal  `pytest tests/ --ignore=tests/integration`  45,136
+#     CI full suite     `pytest tests/ --ignore=tests/integration`  45,136
+#     in pre-push, not in CI ......................................       0
+#     in CI, not in pre-push ......................................       0
+#
+# Neither side applies a marker expression, so no test lost its only
+# execution path and there is nothing to re-home. The narrow path used the
+# same module CI's smart selection uses (scripts/ci/detect_test_paths.py),
+# so the local leg was a duplicate of CI's own selection, not a second
+# opinion. Honest limit: feedback moves later, not away.
+#
+# `scripts/hooks/prepush_smart_tests.sh` is RETAINED, not deleted -- the
+# remote dispatcher and seven modules under tests/scripts/ pin it. Its
+# header now states it is manual-invocation only. The CI-side selector is
+# byte-unchanged.
+#
+# Rollback is `git revert` of this change's squash commit. There is no
+# environment variable that turns the leg back on, deliberately: no
+# PREPUSH_* knob and no ENABLE_SMART_TESTS override restores it, and no
+# dual path exists. Plan of record: OmniNode-ai/knowledge-base-internal#328
+# phase 1. Precedents: OmniNode-ai/omnibase_infra#3415 and
+# OmniNode-ai/omnimarket#2463.
+#
+# The end state is asserted mechanically by
+# tests/ci/test_prepush_test_leg_retired_omn18176.py, not by this comment.
+# ---------------------------------------------------------------------------
 
 # Configuration
 default_install_hook_types: [pre-commit, pre-push, commit-msg]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,34 @@ pre-commit run --all-files              # All hooks
 `pyproject.toml` `[tool.pytest.ini_options] markers` plus `tests/conftest.py`
 (`memory_intensive`, `isolated`) — read those two sources, not a hand-copied list.
 
+### Pre-push scope (2026-09-11)
+
+Pre-push is policy, type and lint checks plus two named test exceptions —
+**nine hooks**, none of which runs the suite. The governed impacted-test
+selector was retired from this stage; hosted CI is the enforced merge gate and
+runs the identical selection. Measured in-tree on 2026-09-11, `pytest tests/
+--ignore=tests/integration` collects 45,136 tests on both sides with zero rows
+in either difference, and neither side applies a marker expression, so no test
+lost its only execution path.
+
+Two hooks still reach a test runner and are **kept deliberately**. Do not
+remove either for consistency with the retirement — each carries its measured
+cost and its retention ground in an annotation at its own definition in
+`.pre-commit-config.yaml`.
+
+| Retained exception | Cost | Why it stays |
+| --- | --- | --- |
+| `pytest-protocol-uuid-enforcement` | 4.4 s wall, unconditional | coverage — CI gates the property only when the impacted-subset selector picks the module up |
+| `verify-flip-bundle` | 0.51 s at steady state, path-filtered | cost — CI runs the identical gate on every non-docs-only pull request |
+
+`scripts/hooks/prepush_smart_tests.sh` is retained for **manual invocation
+only** and is wired to no hook. There is no environment variable that restores
+the leg; rollback is a revert of the retirement's squash commit. The end state
+is enforced by `tests/ci/test_prepush_test_leg_retired_omn18176.py`, not by
+this paragraph — that module's own docstring carries the ticket, the
+measurement and the rollback. Plan of record:
+`OmniNode-ai/knowledge-base-internal#328` phase 1.
+
 **uv, not Poetry**: `uv sync --all-extras` / `uv run <command>` / `uv lock`. All
 Python commands — including any spawned agent's — run via `uv run`, never bare
 `python`/`pip`. Shared git/hook rules (`--no-verify` / `--no-gpg-sign`

--- a/scripts/hooks/prepush_smart_tests.sh
+++ b/scripts/hooks/prepush_smart_tests.sh
@@ -2,9 +2,32 @@
 # SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
 # SPDX-License-Identifier: MIT
 #
-# Pre-push governed impacted-test selector (OMN-13973 / WS7 OMN-14655, D6a lane).
+# Governed impacted-test selector (OMN-13973 / WS7 OMN-14655, D6a lane).
 #
-# Runs the FAST LOCAL IMPACTED SUBSET of the unit suite once per `git push`,
+# ============================================================================
+# MANUAL INVOCATION ONLY as of 2026-09-11 (OMN-18176).
+#
+# This script is NO LONGER WIRED TO ANY GIT HOOK. The `prepush-smart-tests`
+# entry that invoked it at the pre-push stage was removed from
+# .pre-commit-config.yaml; see the retirement block at the foot of that file
+# for the measurement and the rollback. Hosted CI is the enforced merge gate
+# and runs the identical selection -- collected both directions on
+# 2026-09-11, the pre-push maximal set and CI's full-suite set are the same
+# 45,136 tests with zero difference either way.
+#
+# The script is RETAINED rather than deleted because other machinery depends
+# on it: the remote lab dispatcher (scripts/hooks/prepush_dispatch.sh), the
+# full-suite host guard, and seven modules under tests/scripts/ that pin its
+# content. Run it by hand when you want the local subset:
+#
+#     bash scripts/hooks/prepush_smart_tests.sh
+#
+# The CI-side selector (scripts/ci/detect_test_paths.py and its adjacency
+# config) is byte-unchanged and remains the authority for CI's own selection.
+# Everything below describes the behaviour of a manual run.
+# ============================================================================
+#
+# Runs the FAST LOCAL IMPACTED SUBSET of the unit suite,
 # using the SAME governed selector CI uses -- scripts/ci/detect_test_paths.py +
 # scripts/ci/test_selection_adjacency.yaml -- NOT a hand-typed `-k`. The selector
 # is fail-closed: it escalates to the full unit suite whenever it cannot prove
@@ -51,6 +74,11 @@
 #                        CI var name); default here is smart selection ON, because
 #                        the whole point of the local hook is the impacted subset.
 #   PREPUSH_FULL_SUITE   set non-empty to force the FULL suite.
+#
+# None of these variables is a bypass, and none of them re-wires this script to
+# a git hook: every one of them can only make a MANUAL run select MORE tests.
+# There is no environment variable that restores the retired pre-push leg
+# (OMN-18176). Restoring it means reverting that change's squash commit.
 
 set -euo pipefail
 

--- a/tests/ci/test_prepush_test_leg_retired_omn18176.py
+++ b/tests/ci/test_prepush_test_leg_retired_omn18176.py
@@ -1,0 +1,469 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Mechanical enforcement of the OMN-18176 pre-push test-leg retirement.
+
+OMN-18176 removed the governed impacted-test selector (``prepush-smart-tests``)
+from the pre-push stage in this repository. Hosted CI is the enforced merge
+gate and runs the identical selection: collected both directions on
+2026-09-11, ``pytest tests/ --ignore=tests/integration`` yields 45,136 tests on
+the pre-push side and 45,136 on CI's full-suite side, with zero rows in either
+difference. Neither side applies a marker expression, so no test lost its only
+execution path.
+
+This module is the *mechanism* for that end state rather than a note about it.
+A comment in a configuration file is not enforcement; the next lane to touch
+these hooks reads this test, or fails it.
+
+Two hooks that reach a test runner are RETAINED deliberately, as the named
+exceptions of ``OmniNode-ai/knowledge-base-internal#328`` section 2.8, and both
+live only in this repository:
+
+``pytest-protocol-uuid-enforcement``
+    Retained on COVERAGE. 2.02 s of runner time, 4.4 s wall, one module, 45
+    tests, unconditional. ``ENABLE_SMART_TESTS`` is true here, so an ordinary
+    pull request runs the selector's output rather than the full suite, and no
+    workflow names this module or a marker unique to it -- CI's coverage of the
+    property is conditional on the diff while the hook's is unconditional.
+
+``verify-flip-bundle``
+    Retained on COST, not on coverage. 0.51 s at steady state behind a path
+    filter, reaching the runner only when a push carries a newly canonicalised
+    node. CI runs the identical gate on every non-docs-only pull request, so
+    retiring it would lose no property.
+
+Precedents: ``OmniNode-ai/omnibase_infra#3415`` (repo 1) and
+``OmniNode-ai/omnimarket#2463`` (repo 2).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRECOMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
+SELECTOR_SCRIPT = REPO_ROOT / "scripts" / "hooks" / "prepush_smart_tests.sh"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+RETIRED_HOOK_ID = "prepush-smart-tests"
+
+#: The hooks that reach a test runner and are kept anyway. This set is the
+#: whole exception list; a third entry is a decision, never a cleanup.
+NAMED_TEST_EXCEPTIONS = frozenset(
+    {
+        "pytest-protocol-uuid-enforcement",
+        "verify-flip-bundle",
+    }
+)
+
+#: Every hook that must survive at the pre-push stage, in configuration order.
+EXPECTED_PREPUSH_HOOKS: tuple[str, ...] = (
+    "mypy-type-check",
+    "pyright-type-check",
+    "check-evidence-shape",
+    "verify-flip-bundle",
+    "validate-naming-conventions",
+    "validate-file-naming-conventions",
+    "pytest-protocol-uuid-enforcement",
+    "check-enum-governance",
+    "check-node-purity",
+)
+
+#: Tokens that mean "a test runner is being launched here".
+TEST_RUNNER_TOKENS: tuple[str, ...] = ("pytest", "unittest", "nose2")
+
+
+def _load_config() -> dict:
+    with PRECOMMIT_CONFIG.open(encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle)
+    assert isinstance(loaded, dict), "pre-commit config did not parse to a mapping"
+    return loaded
+
+
+def _all_hooks() -> list[dict]:
+    return [hook for repo in _load_config()["repos"] for hook in repo.get("hooks", [])]
+
+
+def _prepush_hooks() -> list[dict]:
+    out: list[dict] = []
+    for hook in _all_hooks():
+        stages = hook.get("stages")
+        if stages and any("pre-push" in str(stage) for stage in stages):
+            out.append(hook)
+    return out
+
+
+def _strip_shell_comments(text: str) -> str:
+    """Drop whole-line and trailing ``#`` comments from shell source.
+
+    Deliberately conservative: a ``#`` inside a quoted string would be stripped
+    too. That direction is safe here -- it can only make the scan see LESS, and
+    every place this module relies on the scan seeing less is covered by the
+    positive control below.
+    """
+    out: list[str] = []
+    for line in text.splitlines():
+        stripped = line.split("#", 1)[0]
+        out.append(stripped)
+    return "\n".join(out)
+
+
+def _strip_python_comments_and_docstrings(source: str) -> str:
+    """Drop ``#`` comments and triple-quoted blocks from Python source.
+
+    String LITERALS are deliberately preserved. The first revision of this
+    scan in repo 1 stripped every string literal and therefore could not see
+    ``subprocess.run(["pytest", ...])`` -- a fail-open hole that reported a
+    clean scan over a module which launches the test runner on every call. The
+    positive control below exists to keep that hole shut.
+    """
+    without_docstrings = re.sub(r'""".*?"""', "", source, flags=re.DOTALL)
+    without_docstrings = re.sub(r"'''.*?'''", "", without_docstrings, flags=re.DOTALL)
+    out: list[str] = []
+    for line in without_docstrings.splitlines():
+        out.append(line.split("#", 1)[0])
+    return "\n".join(out)
+
+
+def _scan_source_for_runner(path: Path) -> bool:
+    """True when ``path``'s executable source launches a test runner."""
+    if not path.is_file():
+        return False
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if path.suffix == ".py":
+        text = _strip_python_comments_and_docstrings(text)
+    else:
+        text = _strip_shell_comments(text)
+    return any(token in text for token in TEST_RUNNER_TOKENS)
+
+
+def _entry_paths(entry: str) -> list[Path]:
+    """Repository-relative files an ``entry:`` string actually executes."""
+    found: list[Path] = []
+    for token in entry.split():
+        cleaned = token.strip("'\"")
+        if "/" not in cleaned:
+            continue
+        candidate = REPO_ROOT / cleaned
+        if candidate.is_file():
+            found.append(candidate)
+    return found
+
+
+def _local_imports(path: Path) -> list[Path]:
+    """Repository-local modules a Python entry script imports, one level deep.
+
+    Both spellings matter and the second one is the one that bites. This
+    module's first revision handled only ``from scripts.ci.foo import bar`` and
+    therefore resolved ``from scripts.ci import parity_replay`` to
+    ``scripts/ci.py``, which does not exist -- so it concluded that
+    ``verify-flip-bundle`` does not reach a test runner, when in fact
+    ``parity_replay`` launches one via ``subprocess``. The named exception
+    would have been silently demoted to an ordinary hook.
+    """
+    if path.suffix != ".py" or not path.is_file():
+        return []
+    source = path.read_text(encoding="utf-8", errors="replace")
+    candidates: list[Path] = []
+
+    def _module_path(dotted: str) -> Path:
+        return REPO_ROOT / (dotted.replace(".", "/") + ".py")
+
+    for package, names in re.findall(
+        r"^\s*from\s+(scripts[\w.]*)\s+import\s+([\w,\s]+)", source, re.M
+    ):
+        # `from scripts.ci.parity_replay import X` -> the package IS the module.
+        candidates.append(_module_path(package))
+        # `from scripts.ci import parity_replay` -> each name is a submodule.
+        for name in names.split(","):
+            bare = name.strip().split(" as ")[0].strip()
+            if bare:
+                candidates.append(_module_path(f"{package}.{bare}"))
+    for module in re.findall(r"^\s*import\s+(scripts[\w.]*)", source, re.M):
+        candidates.append(_module_path(module))
+    return [candidate for candidate in candidates if candidate.is_file()]
+
+
+def _hook_reaches_test_runner(hook: dict) -> bool:
+    entry = str(hook.get("entry", ""))
+    if any(token in entry for token in TEST_RUNNER_TOKENS):
+        return True
+    for path in _entry_paths(entry):
+        if _scan_source_for_runner(path):
+            return True
+        for imported in _local_imports(path):
+            if _scan_source_for_runner(imported):
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# 1. The retired hook is gone, at every stage, not merely moved off pre-push.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_retired_hook_id_appears_at_no_stage() -> None:
+    ids = [hook["id"] for hook in _all_hooks()]
+    assert RETIRED_HOOK_ID not in ids, (
+        f"{RETIRED_HOOK_ID!r} is configured again. OMN-18176 retired the "
+        "governed impacted-test selector from this repository's hooks "
+        "entirely, not just from the pre-push stage. Restoring it is a revert "
+        "of that decision, not a fix."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Nothing at pre-push runs tests except the two named exceptions.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_only_the_named_exceptions_reach_a_test_runner_at_prepush() -> None:
+    offenders = {
+        hook["id"] for hook in _prepush_hooks() if _hook_reaches_test_runner(hook)
+    }
+    unexpected = offenders - NAMED_TEST_EXCEPTIONS
+    assert not unexpected, (
+        f"pre-push hook(s) {sorted(unexpected)} launch a test runner. OMN-18176 "
+        "made pre-push policy, type and lint only, plus exactly the two named "
+        f"exceptions {sorted(NAMED_TEST_EXCEPTIONS)}. A third test hook at this "
+        "stage re-opens the load this change removed."
+    )
+
+
+@pytest.mark.unit
+def test_both_named_exceptions_are_still_present_and_still_reach_the_runner() -> None:
+    by_id = {hook["id"]: hook for hook in _prepush_hooks()}
+    for hook_id in sorted(NAMED_TEST_EXCEPTIONS):
+        assert hook_id in by_id, (
+            f"{hook_id!r} is missing from the pre-push stage. It is a RETAINED "
+            "exception under OMN-18176 / kb-internal#328 section 2.8, kept "
+            "deliberately. Removing it for consistency with the retirement is "
+            "the specific mistake the annotations in the configuration exist "
+            "to prevent."
+        )
+        assert _hook_reaches_test_runner(by_id[hook_id]), (
+            f"{hook_id!r} no longer reaches a test runner. If that is "
+            "intentional it is no longer an exception and belongs out of "
+            "NAMED_TEST_EXCEPTIONS; if it is accidental the gate has been "
+            "hollowed out."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. The other nine survive, by id and in order.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_the_surviving_prepush_hooks_are_exactly_these_nine_in_order() -> None:
+    actual = tuple(hook["id"] for hook in _prepush_hooks())
+    assert actual == EXPECTED_PREPUSH_HOOKS, (
+        "the pre-push hook set changed. OMN-18176 removes exactly one hook and "
+        "reorders nothing; AC1 forbids removing, reordering, or changing the "
+        f"behaviour of any other pre-push hook.\n  expected: "
+        f"{EXPECTED_PREPUSH_HOOKS}\n  actual:   {actual}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Both exceptions carry the annotation that explains why they stayed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_each_named_exception_carries_its_retention_annotation() -> None:
+    text = PRECOMMIT_CONFIG.read_text(encoding="utf-8")
+    for hook_id, marker in (
+        ("pytest-protocol-uuid-enforcement", "RETAINED TEST EXCEPTION #1"),
+        ("verify-flip-bundle", "RETAINED TEST EXCEPTION #2"),
+    ):
+        assert marker in text, (
+            f"the annotation {marker!r} for {hook_id!r} is gone. AC1a of "
+            "OMN-18176 requires each retained exception to carry, in the "
+            "configuration, its measured cost and the reason it is kept, so a "
+            "later reader does not remove it as an oversight."
+        )
+    assert "Kept ON COVERAGE" in text, (
+        "the protocol identifier hook's retention GROUND is missing. It is "
+        "kept because CI's coverage of the property is conditional on the diff."
+    )
+    assert "Kept ON COST, NOT ON COVERAGE" in text, (
+        "the flip-bundle gate's retention GROUND is missing. It is kept on "
+        "cost -- CI runs the identical gate -- and blurring that into the "
+        "coverage argument would misstate why it survives."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. The selector script stays, and says what it is.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_selector_script_is_retained_and_declares_itself_manual_only() -> None:
+    assert SELECTOR_SCRIPT.is_file(), (
+        f"{SELECTOR_SCRIPT.relative_to(REPO_ROOT)} was deleted. It is retained "
+        "deliberately: the remote lab dispatcher, the full-suite host guard "
+        "and seven modules under tests/scripts/ depend on it."
+    )
+    header = SELECTOR_SCRIPT.read_text(encoding="utf-8")[:4000]
+    assert "MANUAL INVOCATION ONLY" in header, (
+        "the selector script's header no longer states it is manual-invocation "
+        "only (AC7). A reader who finds an unannotated pre-push selector in "
+        "the tree reasonably assumes it is wired to a hook."
+    )
+    assert "OMN-18176" in header, (
+        "the selector script's header does not cite the retirement, so a "
+        "reader cannot find the measurement or the rollback."
+    )
+
+
+@pytest.mark.unit
+def test_the_dispatcher_still_references_the_retained_script() -> None:
+    """The reason the script is kept must remain true, not merely asserted."""
+    dispatcher = REPO_ROOT / "scripts" / "hooks" / "prepush_dispatch.sh"
+    assert dispatcher.is_file(), "the remote dispatcher is missing"
+    assert "prepush_smart_tests.sh" in dispatcher.read_text(encoding="utf-8"), (
+        "the dispatcher no longer references the selector script. If nothing "
+        "calls it any more, AC6 of the plan permits deleting it -- but that is "
+        "a deliberate follow-up, and this test is the place to record it."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. No environment knob brings the leg back.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_no_environment_knob_restores_the_retired_leg() -> None:
+    text = PRECOMMIT_CONFIG.read_text(encoding="utf-8")
+    executable_lines = [
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    ]
+    executable = "\n".join(executable_lines)
+    for knob in ("PREPUSH_FULL_SUITE", "ENABLE_SMART_TESTS", "PREPUSH_PYTEST_ARGS"):
+        assert knob not in executable, (
+            f"{knob} appears in executable configuration. OMN-18176 leaves no "
+            "dual path: the leg is retired, and restoring it is a revert of "
+            "the squash commit, not an environment variable. A knob that "
+            "re-enables it would make the retirement unobservable from the "
+            "configuration alone."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. CI's selection stays the one this subset finding was measured against.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_ci_full_suite_step_still_runs_the_selection_that_was_measured() -> None:
+    """The zero-gap finding is only true while CI's own selection holds.
+
+    Measured 2026-09-11: the pre-push maximal selection and CI's full-suite
+    selection are the same command and collect the same 45,136 tests, with
+    zero rows in either direction. If CI narrows its filter later, that
+    finding stops being true and this test is where it is noticed.
+    """
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    assert "pytest tests/ \\" in workflow, (
+        "ci.yml no longer runs a whole-tests/ full-suite step. The OMN-18176 "
+        "zero-gap measurement assumed it does."
+    )
+    assert "--ignore=tests/integration" in workflow, (
+        "ci.yml no longer ignores tests/integration in the same way the "
+        "retired pre-push leg did, so the two selections are no longer the "
+        "same set and the subset finding must be re-measured."
+    )
+
+
+@pytest.mark.unit
+def test_neither_side_applies_a_marker_expression() -> None:
+    """No marker diff exists because no marker expression exists.
+
+    This is the load-bearing half of the zero-gap claim: a difference in
+    ``-m`` filters is how repo 1 lost 39 tests to a silent coverage gap. Here
+    there is no ``-m`` on either side, so there is nothing to diff and nothing
+    to re-home.
+    """
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    # `-m` is overloaded: `python -m omnibase_core...` is a module invocation,
+    # not a marker expression. Only a `-m` whose argument is quoted or begins
+    # `not ` is pytest's marker flag in this workflow's idiom.
+    marker_flags = re.findall(r"(?:^|\s)-m\s+(?:[\"']|not\s)", workflow)
+    assert not marker_flags, (
+        "ci.yml has grown a pytest marker expression. The OMN-18176 finding "
+        "that no test lost its only execution path rests on neither side "
+        "applying one. Re-measure the collection diff before changing this."
+    )
+    selector = (REPO_ROOT / "scripts" / "hooks" / "prepush_smart_tests.sh").read_text(
+        encoding="utf-8"
+    )
+    selector_markers = re.findall(r"(?:^|\s)-m\s+(?:[\"']|not\s)", selector)
+    assert not selector_markers, (
+        "the selector script has grown a marker expression, so the two "
+        "selections are no longer the same set."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. Positive control. Without this the scan can pass by being blind.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_positive_control_the_scan_sees_real_invocations_and_ignores_prose(
+    tmp_path: Path,
+) -> None:
+    """The control that earned its place in repo 1.
+
+    An earlier revision of this scan stripped every string literal from Python
+    sources and so could not see ``subprocess.run(["pytest", ...])``. It
+    reported a clean result over a module that launches the test runner on
+    every call -- fail-open, and indistinguishable from a correct pass.
+    """
+    shell_real = tmp_path / "real.sh"
+    shell_real.write_text("#!/bin/bash\nexec uv run pytest tests/\n", encoding="utf-8")
+    assert _scan_source_for_runner(shell_real), (
+        "the scan cannot see a test runner invoked from shell. Every 'no hook "
+        "runs tests' assertion above would pass vacuously."
+    )
+
+    python_real = tmp_path / "real.py"
+    python_real.write_text(
+        "import subprocess\n\n\ndef go():\n"
+        '    subprocess.run(["pytest", "tests/unit"], check=True)\n',
+        encoding="utf-8",
+    )
+    assert _scan_source_for_runner(python_real), (
+        "the scan cannot see a test runner passed as a string argument to "
+        "subprocess. This is the exact fail-open hole the repo 1 control "
+        "caught before it shipped."
+    )
+
+    shell_prose = tmp_path / "prose.sh"
+    shell_prose.write_text(
+        "#!/bin/bash\n# this script does not run pytest, it only mentions it\n"
+        "echo done\n",
+        encoding="utf-8",
+    )
+    assert not _scan_source_for_runner(shell_prose), (
+        "the scan reports a test runner that exists only in a shell comment, "
+        "so it cannot distinguish a real invocation from a description of one."
+    )
+
+    python_prose = tmp_path / "prose.py"
+    python_prose.write_text(
+        '"""This module describes pytest but never launches it."""\n\n\n'
+        "def go() -> None:\n    return None\n",
+        encoding="utf-8",
+    )
+    assert not _scan_source_for_runner(python_prose), (
+        "the scan reports a test runner named only in a docstring."
+    )


### PR DESCRIPTION
Retires the pre-push test leg in this repo. **OMN-18176**, repo 3 of 3 and the last, taken serially per the operator ruling of 2026-09-10.

Plan of record: `OmniNode-ai/knowledge-base-internal#328`, phase 1. Repo 1 landed as `OmniNode-ai/omnibase_infra#3415` with follow-up `OmniNode-ai/omnibase_infra#3417`; repo 2 as `OmniNode-ai/omnimarket#2463`.

**This PR touches no `src/` file and does not change the published package.** omnibase_core is the base of the layering stack, so that was a hard constraint rather than an outcome; it is asserted on the staged set before commit. Hooks, tests and documentation only.

## What changed

The governed impacted-test selector is removed from the pre-push stage. Nine hooks remain, read back from the configuration and pinned in order by a test:

| # | Surviving pre-push hook | Runs tests? |
|---|---|---|
| 1 | `mypy-type-check` | no |
| 2 | `pyright-type-check` | no |
| 3 | `check-evidence-shape` | no |
| 4 | `verify-flip-bundle` | **yes — retained exception #2** |
| 5 | `validate-naming-conventions` | no |
| 6 | `validate-file-naming-conventions` | no |
| 7 | `pytest-protocol-uuid-enforcement` | **yes — retained exception #1** |
| 8 | `check-enum-governance` | no |
| 9 | `check-node-purity` | no |

Hosted CI is the enforced merge gate. The local leg bought earlier feedback, not a verification guarantee. The honest limit, stated rather than implied: feedback moves later, not away.

## No coverage gap opens, and that is measured rather than argued

The retired leg ran `pytest tests/ --ignore=tests/integration`, either as an impacted subset or, fail-closed, as the whole tree. CI's full-suite step runs the identical command. Collected twice as separate processes in this worktree on 2026-09-11 and diffed both directions:

| Selection | Tests collected |
|---|---|
| Pre-push maximal | 45,136 |
| CI full suite | 45,136 |
| In pre-push and **not** in CI | **0** |
| In CI and not in pre-push | **0** |

**Neither side applies a marker expression.** That is the load-bearing fact, and it is the difference from repo 1, where a `-m` mismatch had silently left 39 tests with no CI path. Every one of this repo's 68 workflows was searched for a pytest marker flag and none has one; the four hits are `git commit -m` and `git tag -m`. So there is no set of deselected tests to re-home and no nightly job to add. All four scheduled workflows were read for positive selection anyway, which is correct here because there is nothing to select.

Two positive controls, because a zero row is not evidence of absence:

- The same comparison against a selection known to differ — the same command without the ignore — returns **660** rows, all under `tests/integration`.
- A synthetic node id absent from the collection is reported as outside it.

An earlier revision of this measurement returned zero on **both** sides, which is the false-zero signature exactly. The cause was an anchor bug: the ini file puts the rootdir at `tests/`, so collected ids are not prefixed `tests/`. It was caught by checking the raw output instead of trusting the count.

## The falsifier

The plan's first reviewer question is whether the local leg ever caught something CI did not. Answered against the lab hosts' own run records rather than recollection: **19 governed run records** for this repo across the reachable hosts, **2** carrying test failures, and **one** distinct failing file between them:

`tests/scripts/test_prepush_hook_host_identity_guard.py` — inside CI's selection, confirmed by looking it up in the collected set above, where it contributes 38 tests.

Both failures are the same two tests, and they are the known-flaky pair already tracked as a separate defect: they take live lab slot availability as a fixture, so a saturated lab turns them red. The evidence that this is host state and not a caught defect is direct rather than inferred — the same head sha was re-run ten minutes later on the same host and passed with the same full-tree escalation. **The exception list is empty.**

Two limits, stated rather than absorbed: one lab host answered ping but timed out on ssh, so its records for this window are unknown and are a coverage gap, not a zero; and the two failing shas never reached GitHub under those ids, so hosted CI cannot be queried for them directly. The subset finding above is what makes the file-level check conclusive regardless.

Positive controls on that sweep: the same extraction that found no failures on 17 runs found them on the other 2, and the same shape run without the repo filter returned 25 nonzero-failure rows from sibling repos.

## A bootstrap finding, reported as a negative

Repo 2's diff had to withhold two string literals because its hand-written bootstrap greps the configuration for them and would read a comment as wiring. **That hazard does not exist here.** The installed pre-push chain was read on this host: the worktree-discipline guard, reached through `core.hooksPath`, chains to the framework-generated hook. Neither greps the configuration for a hook identifier or an entry line. So the retirement block names the removed hook plainly, as repo 1's does, and nothing had to be deleted or backed up.

## The two named exceptions, both here, both retained

kb-internal#328 section 2.8 finds three pre-push hooks in the org that reach a test runner and all three are in this repo. Two stay, each annotated at its own definition with its measured cost and its retention ground, so a later reader does not remove them as an oversight:

- `pytest-protocol-uuid-enforcement` — 4.4 s wall, unconditional. Kept **on coverage**: smart selection is on for this repo, so an ordinary pull request runs the selector's output rather than the full suite, and no workflow names that module. CI's coverage of the property is conditional on the diff; the hook's is not.
- `verify-flip-bundle` — 0.51 s at steady state behind a path filter. Kept **on cost, not coverage**: CI runs the identical gate on every non-docs-only pull request, so dropping it would lose no property. The two grounds are recorded separately rather than blurred.

## Enforcement, and a bug it caught in itself

`tests/ci/test_prepush_test_leg_retired_omn18176.py` is the mechanism, not a note. Eleven tests: the retired id appears at no stage; nothing at pre-push reaches a test runner except the two named exceptions; both exceptions are present **and still reach the runner**; the nine survive by id and in order; each exception carries its annotation and its distinct retention ground; the selector script stays and declares itself manual-only; the dispatcher still references it, so the stated reason for keeping it remains true; no environment knob restores the leg; CI's selection is still the one the subset finding was measured against; and neither side has grown a marker expression.

Two of those failed on first run and both were real. The import resolver handled `from scripts.ci.foo import bar` but not `from scripts.ci import parity_replay`, so it concluded `verify-flip-bundle` does not reach a test runner — which would have silently demoted a named exception to an ordinary hook. The marker scan matched `python -m omnibase_core...` as a marker expression.

Red check, run and reverted: reinstating a test-running hook at pre-push fails three of the eleven.

The positive control earns its place from repo 1, where the first scan stripped every string literal and so could not see a test runner passed to `subprocess` as a string. It proves the scan sees a real invocation in both shell and Python and ignores one described in a comment or a docstring.

## Verification

- The new module: 11 passed. `ruff format`, `ruff check`, `mypy --strict` all clean on it.
- `pre-commit run --all-files`: three failures, **all pre-existing on `dev`** and all under `src/`, which this PR may not touch. Each reproduces byte-identically at the same HEAD in the unmodified canonical clone: the release-identity gate, two env-var findings, and seven hardcoded-topic findings. None is `always_run`; all three were skipped or passed against this change's own staged set. Reported rather than fixed, because fixing them means editing `src/` in the base package.
- The commit ran the full pre-commit set clean. The doc-content gate rejected a ticket id in a markdown heading in my own new text; the heading was rewritten rather than suppressed.
- Real push through the new hook set: **20 s**, with no `PREPUSH_*` and no `ENABLE_SMART_TESTS` variable set. The only test runner that fired was retained exception #1. The flip-bundle gate skipped on its path filter, which is the behaviour its annotation describes.
- `required_status_checks` on `dev` before the change: 37 contexts, `strict: false`, raw response sha256 `3a82271b3efb0fdf1997913d53db4b43d931751cc871c130f921faad08cd3cde`. Re-read after merge; unchanged is the acceptance criterion, and nothing here touches branch protection.
- The CI-side selector is byte-unchanged: `git diff` under `scripts/ci/` is empty.

## Rollback

`git revert` of the squash. There is no environment variable that turns the leg back on, deliberately, and no dual path. The selector script is unchanged on disk apart from its header.

## Doctrine

`CLAUDE.md` gains a dated pointer, not a rewrite, since phase 1 is reversible and coupling the rules to a revertible change means a revert silently reverts the rules. The workspace-registry paragraph that names the governed selector as the final local pre-push check lives in another repo and is reported to the orchestrator rather than edited here.

Evidence-Ticket: OMN-18176
Evidence-Source: OCC#9045
