### PR TITLE
feat(OMN-18172): add typed delegation provenance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.9"
+version = "0.47.10"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/enums/enum_delegation_traffic_class.py
+++ b/src/omnibase_core/enums/enum_delegation_traffic_class.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Traffic classification for delegation request provenance."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumDelegationTrafficClass(StrEnum):
+    """Declared origin class of a delegation request.
+
+    ``UNCLASSIFIED`` is intentionally distinct from ``ORGANIC``. Older callers
+    and callers without an authoritative classifier must not be relabelled as
+    organic merely because they are not known to be synthetic.
+    """
+
+    UNCLASSIFIED = "unclassified"
+    ORGANIC = "organic"
+    SYNTHETIC = "synthetic"
+
+
+__all__ = ["EnumDelegationTrafficClass"]

--- a/src/omnibase_core/models/delegation/wire/__init__.py
+++ b/src/omnibase_core/models/delegation/wire/__init__.py
@@ -22,6 +22,10 @@ from omnibase_core.models.delegation.wire.model_delegation_completed import (
 from omnibase_core.models.delegation.wire.model_delegation_failed import (
     ModelDelegationFailed,
 )
+from omnibase_core.models.delegation.wire.model_delegation_provenance import (
+    EnumDelegationTrafficClass,
+    ModelDelegationProvenance,
+)
 from omnibase_core.models.delegation.wire.model_delegation_result import (
     EnumDelegationTerminalFailureCause,
     EnumQualityScoreComparison,
@@ -83,6 +87,7 @@ __all__: list[str] = [
     "TASK_DELEGATED_TOPIC_V1",
     "EnumBudgetAction",
     "EnumDelegationTerminalFailureCause",
+    "EnumDelegationTrafficClass",
     "EnumDelegationRoutingDisposition",
     "EnumDelegationTerminalOutcome",
     "EnumDelegationUnroutedReason",
@@ -105,6 +110,7 @@ __all__: list[str] = [
     "ModelDelegationRequest",
     "ModelDelegationResult",
     "ModelDelegationProviderFailureCause",
+    "ModelDelegationProvenance",
     "ModelDelegationQualityGateRejection",
     "ModelDelegationTerminalCompletedV2",
     "ModelDelegationTerminalFailedRoutedV2",

--- a/src/omnibase_core/models/delegation/wire/model_delegation_provenance.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_provenance.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Typed, durable provenance for a delegation request and its terminal."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from omnibase_core.enums.enum_delegation_traffic_class import (
+    EnumDelegationTrafficClass,
+)
+
+
+class ModelDelegationProvenance(BaseModel):
+    """Canonical provenance carried unchanged from request to terminal.
+
+    This model is the single classification surface. Consumers classify
+    synthetic traffic from ``traffic_class`` and may use ``source_surface`` and
+    ``requested_by`` for attribution; they must not infer provenance from prompt
+    text or treat an absent model as synthetic.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    source: Literal["claude-code", "codex", "external-client"] = Field(
+        ...,
+        description="Registered adapter source at delegation ingress.",
+    )
+    traffic_class: EnumDelegationTrafficClass = Field(
+        default=EnumDelegationTrafficClass.UNCLASSIFIED,
+        description=(
+            "Authoritative traffic classification. Unclassified is unknown, not "
+            "synthetic or organic."
+        ),
+    )
+    source_surface: str | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description="Named producer surface, when one was declared at ingress.",
+    )
+    requested_by: str | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description="Named request initiator, when one was declared at ingress.",
+    )
+
+    @field_validator("source_surface", "requested_by")
+    @classmethod
+    def validate_optional_identifier(cls, value: str | None) -> str | None:
+        """Reject blank or padded identifiers so stored values are query-stable."""
+        if value is not None and (not value.strip() or value != value.strip()):
+            raise ValueError("provenance identifiers must be nonblank and unpadded")
+        return value
+
+    @model_validator(mode="after")
+    def validate_synthetic_surface(self) -> Self:
+        """Require synthetic claims to name the producer surface that made them."""
+        if (
+            self.traffic_class is EnumDelegationTrafficClass.SYNTHETIC
+            and self.source_surface is None
+        ):
+            raise ValueError("synthetic delegation provenance requires source_surface")
+        return self
+
+
+__all__ = ["EnumDelegationTrafficClass", "ModelDelegationProvenance"]

--- a/src/omnibase_core/models/delegation/wire/model_delegation_result.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_result.py
@@ -16,6 +16,9 @@ from omnibase_core.enums.enum_delegation_terminal_failure_cause import (
 from omnibase_core.enums.enum_quality_score_comparison import (
     EnumQualityScoreComparison,
 )
+from omnibase_core.models.delegation.wire.model_delegation_provenance import (
+    ModelDelegationProvenance,
+)
 
 
 class ModelDelegationResult(BaseModel):
@@ -49,6 +52,14 @@ class ModelDelegationResult(BaseModel):
         description=(
             "Declared provider identity for the selected route. Never inferred "
             "from a post-terminal tenant overlay."
+        ),
+    )
+    provenance: ModelDelegationProvenance | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Typed request provenance copied unchanged from delegation acceptance. "
+            "None is explicit legacy/unclassified provenance."
         ),
     )
     content: str = Field(..., description="The LLM-generated response content.")

--- a/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_wire_request.py
@@ -14,6 +14,9 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from omnibase_core.models.delegation.wire.model_budget import ModelBudgetLimits
+from omnibase_core.models.delegation.wire.model_delegation_provenance import (
+    ModelDelegationProvenance,
+)
 
 EnumQualityContractMode = Literal["extend_task_class", "replace_task_class"]
 
@@ -158,6 +161,14 @@ class ModelDelegationRequest(BaseModel):
     source_file_path: str | None = Field(
         default=None,
         description="File context for the delegation, if any.",
+    )
+    provenance: ModelDelegationProvenance | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Typed ingress provenance carried unchanged into durable workflow state "
+            "and terminal evidence. None is explicit legacy/unclassified provenance."
+        ),
     )
     context_pack: str = Field(
         default="",

--- a/tests/unit/models/delegation/wire/test_delegation_wire_models.py
+++ b/tests/unit/models/delegation/wire/test_delegation_wire_models.py
@@ -16,6 +16,7 @@ from omnibase_core.models.delegation.wire import (
     TASK_DELEGATED_TOPIC_V1,
     EnumBudgetAction,
     EnumDelegationTerminalFailureCause,
+    EnumDelegationTrafficClass,
     EnumQualityScoreComparison,
     EnumTierCostType,
     ModelBaselineIntent,
@@ -28,6 +29,7 @@ from omnibase_core.models.delegation.wire import (
     ModelDelegationEventEnvelope,
     ModelDelegationFailed,
     ModelDelegationFallbackPolicy,
+    ModelDelegationProvenance,
     ModelDelegationRequest,
     ModelDelegationResult,
     ModelDelegationRoutingRule,
@@ -98,6 +100,22 @@ class TestModelDelegationRequest:
     def test_basic_construction(self) -> None:
         r = self._make()
         assert r.task_type == "test"
+
+    def test_provenance_is_optional_and_round_trips_when_declared(self) -> None:
+        legacy = self._make()
+        assert legacy.provenance is None
+        assert "provenance" not in legacy.model_dump()
+
+        provenance = ModelDelegationProvenance(
+            source="external-client",
+            traffic_class=EnumDelegationTrafficClass.SYNTHETIC,
+            source_surface="scheduled-chain-canary",
+            requested_by="chain-canary",
+        )
+        request = self._make(provenance=provenance)
+
+        assert request.provenance == provenance
+        assert ModelDelegationRequest.model_validate(request.model_dump()) == request
 
     def test_cloud_completion_shaping_defaults_are_backward_compatible(self) -> None:
         request = self._make()
@@ -375,6 +393,29 @@ class TestModelDelegationResult:
         )
         assert r.quality_passed is True
         assert r.escalation_count == 0
+
+    def test_terminal_preserves_typed_request_provenance(self) -> None:
+        provenance = ModelDelegationProvenance(
+            source="external-client",
+            traffic_class=EnumDelegationTrafficClass.SYNTHETIC,
+            source_surface="scheduled-chain-canary",
+            requested_by="chain-canary",
+        )
+        result = ModelDelegationResult(
+            correlation_id=uuid.uuid4(),
+            task_type="test",
+            model_used="qwen3",
+            endpoint_url="http://localhost:8000",
+            content="result",
+            quality_passed=True,
+            quality_score=0.9,
+            latency_ms=100,
+            fallback_to_claude=False,
+            provenance=provenance,
+        )
+
+        assert result.provenance == provenance
+        assert ModelDelegationResult.model_validate(result.model_dump()) == result
 
     def test_escalation_fields_default(self) -> None:
         r = ModelDelegationResult(
@@ -954,6 +995,28 @@ class TestModelDelegationResult:
                 total_tokens=6,
                 fallback_to_claude=False,
             )
+
+
+@pytest.mark.unit
+class TestModelDelegationProvenance:
+    def test_unclassified_is_distinct_from_organic_and_synthetic(self) -> None:
+        provenance = ModelDelegationProvenance(source="codex")
+
+        assert provenance.traffic_class is EnumDelegationTrafficClass.UNCLASSIFIED
+        assert provenance.traffic_class is not EnumDelegationTrafficClass.ORGANIC
+        assert provenance.traffic_class is not EnumDelegationTrafficClass.SYNTHETIC
+
+    def test_synthetic_requires_queryable_source_surface(self) -> None:
+        with pytest.raises(ValidationError, match="requires source_surface"):
+            ModelDelegationProvenance(
+                source="external-client",
+                traffic_class=EnumDelegationTrafficClass.SYNTHETIC,
+            )
+
+    @pytest.mark.parametrize("field_name", ["source_surface", "requested_by"])
+    def test_identifiers_reject_blank_or_padded_values(self, field_name: str) -> None:
+        with pytest.raises(ValidationError, match="nonblank and unpadded"):
+            ModelDelegationProvenance(source="codex", **{field_name: " "})
 
 
 @pytest.mark.unit

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.9"
+version = "0.47.10"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
Core schema leg for OMN-18172.

Adds one governed ModelDelegationProvenance object to the shared delegation request and terminal-result DTOs. The object carries registered source, explicit unclassified/organic/synthetic traffic class, source surface, and requester. Legacy callers remain compatible: missing provenance is unclassified and is never interpreted as canary. Arbitrary request metadata is not copied, and no parallel boolean flag is introduced.

This PR intentionally stops at the shared core boundary. After the core version lands, downstream work must propagate the typed object through omnimarket dispatch and durable projection, then update the scheduled chain-canary producer and prove canary plus negative-control readback.

Verification on rebased head b2d0aa9a:
- delegation wire suite: 181 passed
- Ruff: passed
- mypy: passed across 4,300 source files
- Pyright: 0 errors and 0 warnings
- diff-scoped repository pre-commit policy: passed
- current pre-push policy: passed during dry run and actual push
- signed commit and clean final diff verified

Evidence-Ticket: OMN-18172
Evidence-Source: OCC#9057
