### PR TITLE
fix(OMN-18179): stop auto-merge re-arming a PR whose auto-merge a human turned off

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -264,7 +264,106 @@ jobs:
       # instead of re-running its own resolution. The Python/uv setup steps
       # that only existed to run that duplicate check are removed with it.
 
+      # OMN-18179: this job used to arm auto-merge with no check for whether a
+      # human had already turned it off. It fires on `pull_request: opened` and
+      # again on `check_suite: completed` -- 57 of this repo's last 100 runs
+      # came from check_suite -- so an explicit `gh pr merge --disable-auto`
+      # could be undone by the next completing check suite and the PR would
+      # merge as soon as its checks went green. Converting to draft was the only
+      # durable pause. omnibase_core#1678 was armed on open at
+      # 2026-09-11T10:40:33Z, before the authorization ruling for that change
+      # reached the lane, and merged at 11:17:57Z; on the sibling repo
+      # omninode_infra#1310, a prod scale-down taking 13 Deployments to zero
+      # replicas, the same shape needed a manual draft conversion to contain.
+      #
+      # The rule is small: the most recent human decision wins. Re-arming by
+      # hand writes a fresh enable event after the disable, so automation
+      # resumes with no special case. The decision logic is pure and unit-tested
+      # in scripts/ci/check_auto_merge_hold.py.
+      - name: Check for a previously disabled auto-merge (OMN-18179)
+        id: hold_gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ needs.pre-check.outputs.pr }}
+        run: |
+          set -euo pipefail
+          owner="${GH_REPO%/*}"
+          name="${GH_REPO#*/}"
+          # Two measured API details this query depends on (2026-09-11):
+          #
+          # 1. itemTypes MUST list all three enable variants. Arming with an
+          #    explicit method -- `--squash --auto`, which is what this repo
+          #    uses -- emits AutoSquashEnabledEvent, NOT AutoMergeEnabledEvent.
+          #    A filter naming only the latter returns an empty enable history
+          #    for every PR this workflow has ever armed.
+          # 2. Do NOT read timelineItems.totalCount. It ignores the itemTypes
+          #    filter and returns the unfiltered timeline length: the query that
+          #    returned 2 filtered nodes for omninode_infra#1310 reported
+          #    totalCount 7, and 2 nodes / totalCount 13 for #1313.
+          #
+          # tests/unit/scripts/ci/test_auto_merge_hold_omn18179.py asserts this
+          # filter and the helper's event tuples stay in lockstep, and that the
+          # query never reads totalCount.
+          # shellcheck disable=SC2016 # GraphQL variables are interpreted by GitHub, not this shell.
+          if ! payload="$(gh api graphql \
+            -f query='
+              query($owner:String!,$name:String!,$pr:Int!){
+                repository(owner:$owner,name:$name){
+                  pullRequest(number:$pr){
+                    labels(first:100){nodes{name}}
+                    timelineItems(last:100, itemTypes:[
+                      AUTO_MERGE_ENABLED_EVENT,
+                      AUTO_SQUASH_ENABLED_EVENT,
+                      AUTO_REBASE_ENABLED_EVENT,
+                      AUTO_MERGE_DISABLED_EVENT
+                    ]){
+                      nodes{
+                        __typename
+                        ... on AutoMergeEnabledEvent{createdAt}
+                        ... on AutoSquashEnabledEvent{createdAt}
+                        ... on AutoRebaseEnabledEvent{createdAt}
+                        ... on AutoMergeDisabledEvent{createdAt reason}
+                      }
+                    }
+                  }
+                }
+              }' \
+            -f owner="$owner" \
+            -f name="$name" \
+            -F pr="$PR")"; then
+            echo "::warning::Could not read the auto-merge timeline for PR #${PR}; holding (OMN-18179)."
+            payload=""
+          fi
+
+          # A response whose shape is anything other than the expected array is
+          # "undetermined", never "empty and therefore safe" -- the helper
+          # distinguishes the two and fails closed on the former.
+          if [ -n "$payload" ]; then
+            pr_json="$(printf '%s' "$payload" | jq -c '.data.repository.pullRequest // {}')"
+            timeline_json="$(printf '%s' "$pr_json" | jq -c 'if (.timelineItems.nodes | type) == "array" then .timelineItems.nodes else null end')"
+            labels_json="$(printf '%s' "$pr_json" | jq -c 'if (.labels.nodes | type) == "array" then [.labels.nodes[].name] else null end')"
+          else
+            timeline_json="null"
+            labels_json="null"
+          fi
+
+          verdict="$(python3 scripts/ci/check_auto_merge_hold.py hold \
+            --timeline-json "$timeline_json" \
+            --labels-json "$labels_json")"
+          echo "auto-merge hold check for PR #${PR}: ${verdict}"
+
+          if [ "$verdict" = "hold" ]; then
+            echo "::warning::PR #${PR}: not arming auto-merge (OMN-18179)."
+            echo "Cause: a previous disable, the pause label, or a state that could not be read."
+            echo "Re-arm by hand to resume automatic arming."
+            echo "hold=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "hold=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Enable auto-merge
+        if: steps.hold_gate.outputs.hold != 'true'
         env:
           # OMN-17875: MUST be CROSS_REPO_PAT. GitHub completes an armed
           # auto-merge as the arming identity, and GITHUB_TOKEN-authored
@@ -318,6 +417,7 @@ jobs:
           fi
 
       - name: Enqueue armed PR and verify it entered the queue
+        if: steps.hold_gate.outputs.hold != 'true'
         env:
           # OMN-17875: this step MUTATES merge state twice — `gh pr
           # update-branch` pushes a merge commit onto the PR head branch, and

--- a/scripts/ci/check_auto_merge_hold.py
+++ b/scripts/ci/check_auto_merge_hold.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Respect a human's auto-merge decision before re-arming (OMN-18179).
+
+Why this exists
+----------------
+`auto-merge.yml`'s "Enable Auto-Merge" job arms GitHub native auto-merge
+with no check for whether somebody already turned it off. The job fires on
+`pull_request: opened`, and again on `pull_request_review` and
+`check_suite: completed` in the repos where those events are delivered, so
+an explicit `gh pr merge --disable-auto` can be undone by the next trigger
+and the PR merges the moment its checks go green. Converting the PR to
+draft was the only durable pause available.
+
+Three instances inside 24 hours, all read back live from the GraphQL
+timeline:
+
+* `omninode_infra#1310` -- a prod scale-down manifest taking 13 Deployments
+  to zero replicas -- armed 2026-09-10T17:15:29Z on open, disabled
+  18:50:55Z, and had to be converted to draft at 18:52:35Z to contain it.
+* `omninode_infra#1313` armed 22:48:54Z, disabled 22:50:41Z.
+* `omnibase_core#1678` armed 10:40:33Z on open, before the authorization
+  ruling for that change had reached the lane.
+
+The rule this module implements is deliberately small: **the most recent
+human decision wins.** If the latest auto-merge state-change event on the
+PR is a disable, do not re-arm. Re-arming by hand writes a fresh enable
+event after that disable, so automation resumes with no special case and no
+label to clean up. A PR can also be held pre-emptively -- before any arming
+has happened at all, which is the `#1678` shape -- by applying the
+deliberate-pause label named in `HOLD_LABELS`.
+
+Two GitHub API details this depends on, both measured 2026-09-11
+---------------------------------------------------------------
+1. **The enable event is not always `AutoMergeEnabledEvent`.** Arming with
+   an explicit method (`gh pr merge --auto --squash`, which is what every
+   no-queue repo in this org uses) emits `AutoSquashEnabledEvent`. A
+   detector matching only `AutoMergeEnabledEvent` sees an empty enable
+   history and misreads every squash-armed PR. All three enable variants
+   are in `ENABLE_EVENT_TYPES`, and the workflow's GraphQL `itemTypes`
+   filter must list the same three.
+
+       omninode_infra#1310 ->
+         AutoSquashEnabledEvent   2026-09-10T17:15:29Z jonahgabriel
+         AutoMergeDisabledEvent   2026-09-10T18:50:55Z jonahgabriel
+                                  reason "Manually disabled by user"
+
+2. **`timelineItems.totalCount` ignores the `itemTypes` filter.** The same
+   query that returned 2 filtered nodes for `#1310` reported
+   `totalCount: 7`, and 2 nodes / `totalCount: 13` for `#1313` -- the
+   unfiltered timeline length in both cases. Only `nodes` may be read. The
+   workflow does not pass a count to this module at all, which is the point.
+
+Fail-closed semantics
+----------------------
+Every form of "we don't know" resolves to HOLD, because an undetermined
+timeline and a genuinely never-armed PR are indistinguishable from here and
+must not be conflated:
+
+* timeline undetermined (API error, unparseable, flag omitted) -> HOLD
+* label set undetermined -> HOLD
+* a relevant event carries no usable `createdAt`, so the events cannot be
+  ordered -> HOLD
+* an event type appears that is in neither `ENABLE_EVENT_TYPES` nor
+  `DISABLE_EVENT_TYPES` -> HOLD. Unknown types cannot reach this module
+  unless the workflow's `itemTypes` filter was widened without updating
+  these tuples, and silently ignoring one would mean arming over a decision
+  this module could not read.
+
+A disable is honoured whatever its `reason`. GitHub also disables
+auto-merge on its own (for example when the base branch changes), and
+holding on those too is the conservative direction: the cost of an
+unnecessary hold is one manual merge, while the cost of a missed hold is an
+unintended merge of whatever the PR happens to contain.
+
+This module performs **no** network I/O. The workflow fetches the timeline
+and labels with `gh api` and passes them in; this module only classifies --
+the same separation of concerns as `scripts/ci/merge_queue_enqueue.py`
+(OMN-13214) and `check_governance_paths.py` (OMN-16117).
+
+Usage
+-----
+    # Latest event is an enable -- safe to arm:
+    python3 scripts/ci/check_auto_merge_hold.py hold \
+        --timeline-json '[{"__typename":"AutoSquashEnabledEvent",
+                           "createdAt":"2026-09-10T17:15:29Z"}]' \
+        --labels-json '[]'
+
+    # Latest event is a disable -- hold:
+    python3 scripts/ci/check_auto_merge_hold.py hold \
+        --timeline-json '[{"__typename":"AutoSquashEnabledEvent",
+                           "createdAt":"2026-09-10T17:15:29Z"},
+                          {"__typename":"AutoMergeDisabledEvent",
+                           "createdAt":"2026-09-10T18:50:55Z"}]' \
+        --labels-json '[]'
+
+    # Timeline could not be resolved -- hold (fail closed):
+    python3 scripts/ci/check_auto_merge_hold.py hold \
+        --timeline-json 'null' --labels-json '[]'
+
+Exit status
+-----------
+Always 0 on a successful classification; the verdict is the single word
+written to stdout, either ``hold`` or ``arm``. A non-zero exit means this
+module itself failed, which under the workflow's `set -euo pipefail` aborts
+the step and therefore also declines to arm -- fail closed by construction.
+Deliberately unlike `check_governance_paths.py`, which exits 1 to signal its
+own "exclude" verdict and so reds the job it is only trying to skip a step
+in.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# ---------------------------------------------------------------------------
+# Policy constants. The two event tuples must stay in lockstep with the
+# `itemTypes` filter in auto-merge.yml's GraphQL query: an event type present
+# in the query but missing here is an unknown type and fails closed (which is
+# loud), while one present here but missing from the query is simply never
+# delivered (which is silent, and is the failure this module is guarding).
+# ---------------------------------------------------------------------------
+
+ENABLE_EVENT_TYPES: tuple[str, ...] = (
+    "AutoMergeEnabledEvent",
+    "AutoSquashEnabledEvent",
+    "AutoRebaseEnabledEvent",
+)
+
+DISABLE_EVENT_TYPES: tuple[str, ...] = ("AutoMergeDisabledEvent",)
+
+HOLD_LABELS: tuple[str, ...] = ("hold:auto-merge",)
+
+_VERDICT_HOLD = "hold"
+_VERDICT_ARM = "arm"
+
+
+# ---------------------------------------------------------------------------
+# Pure decision logic — no I/O, directly unit-testable.
+# ---------------------------------------------------------------------------
+
+
+def _event_sort_key(event: dict[str, Any]) -> str:
+    """Return the ISO-8601 `createdAt` an event is ordered by.
+
+    Raises ``ValueError`` when the value is missing or not a non-empty
+    string, because two auto-merge events that cannot be ordered relative to
+    each other cannot answer "which decision was most recent".
+    """
+    created_at = event.get("createdAt")
+    if not isinstance(created_at, str) or created_at.strip() == "":
+        msg = f"auto-merge timeline event has no usable createdAt: {event!r}"
+        raise ValueError(msg)
+    return created_at
+
+
+def latest_auto_merge_decision(
+    timeline: Sequence[dict[str, Any]] | None,
+) -> str | None:
+    """Return ``"enable"``, ``"disable"``, or ``None`` for no decision yet.
+
+    ``timeline`` is the ``nodes`` list of the PR's auto-merge timeline
+    items, already filtered by the caller's ``itemTypes`` query, or ``None``
+    when it could not be resolved. ``None`` is NOT the same as an empty list:
+    an empty list means the query succeeded and the PR has genuinely never
+    been armed or disabled.
+
+    Raises ``ValueError`` on an unknown event type or an unorderable event.
+    """
+    if timeline is None:
+        msg = "timeline is undetermined"
+        raise ValueError(msg)
+
+    decisions: list[tuple[str, str]] = []
+    for event in timeline:
+        typename = event.get("__typename")
+        if typename in ENABLE_EVENT_TYPES:
+            decisions.append((_event_sort_key(event), "enable"))
+        elif typename in DISABLE_EVENT_TYPES:
+            decisions.append((_event_sort_key(event), "disable"))
+        else:
+            msg = (
+                f"unknown auto-merge timeline event type {typename!r}; "
+                "ENABLE_EVENT_TYPES/DISABLE_EVENT_TYPES and the workflow's "
+                "GraphQL itemTypes filter have drifted apart"
+            )
+            raise ValueError(msg)
+
+    if not decisions:
+        return None
+
+    # ISO-8601 UTC timestamps from the GitHub API sort correctly as strings.
+    decisions.sort(key=lambda pair: pair[0])
+    return decisions[-1][1]
+
+
+def should_hold(
+    timeline: Sequence[dict[str, Any]] | None,
+    labels: Sequence[str] | None,
+) -> bool:
+    """Decide whether auto-merge arming must be skipped for this PR.
+
+    Returns ``True`` (hold) when the deliberate-pause label is present, when
+    the most recent auto-merge decision on the PR was a disable, or when
+    either input is undetermined or unreadable.
+    """
+    if labels is None:
+        return True
+    if any(_normalize_label(label) in HOLD_LABELS for label in labels):
+        return True
+
+    try:
+        decision = latest_auto_merge_decision(timeline)
+    except ValueError:
+        return True
+
+    return decision == "disable"
+
+
+def _normalize_label(label: str) -> str:
+    return label.strip().lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI surface — the workflow shells out to this.
+# ---------------------------------------------------------------------------
+
+
+def _load_json_list(raw: str | None, what: str) -> list[Any] | None:
+    """Parse a CLI JSON value into a resolved list, or ``None`` if undetermined.
+
+    ``raw`` is the JSON text the workflow captured from ``gh api``, the
+    literal string ``"null"`` when its own fetch failed, or ``None``/empty
+    when the flag was omitted. Every one of those collapses to ``None``
+    rather than being silently treated as an empty (and therefore
+    permissive) list.
+    """
+    if raw is None or raw.strip() == "":
+        return None
+
+    parsed = json.loads(raw)  # raises json.JSONDecodeError on malformed input
+    if parsed is None:
+        return None
+    if not isinstance(parsed, list):
+        msg = f"{what} must be a JSON array or the literal null"
+        raise TypeError(msg)
+    return parsed
+
+
+def _load_timeline(raw: str | None) -> list[dict[str, Any]] | None:
+    parsed = _load_json_list(raw, "timeline-json")
+    if parsed is None:
+        return None
+    for item in parsed:
+        if not isinstance(item, dict):
+            msg = "timeline-json entries must be JSON objects"
+            raise TypeError(msg)
+    return parsed
+
+
+def _load_labels(raw: str | None) -> list[str] | None:
+    parsed = _load_json_list(raw, "labels-json")
+    if parsed is None:
+        return None
+    return [str(item) for item in parsed]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI surface for the workflow.
+
+    Subcommand:
+        hold --timeline-json <json|null> --labels-json <json|null>
+            Prints ``hold`` or ``arm``. Exits 0 either way.
+    """
+    parser = argparse.ArgumentParser(
+        description="Auto-merge arming hold check (OMN-18179)"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_hold = sub.add_parser(
+        "hold", help="Decide whether auto-merge arming must be skipped"
+    )
+    p_hold.add_argument(
+        "--timeline-json",
+        default=None,
+        help=(
+            "JSON array of the PR's auto-merge timeline item nodes, or the "
+            "literal 'null' (or omit this flag) when the timeline could not "
+            "be resolved -- fails closed to 'hold'."
+        ),
+    )
+    p_hold.add_argument(
+        "--labels-json",
+        default=None,
+        help=(
+            "JSON array of the PR's label names, or the literal 'null' (or "
+            "omit this flag) when the labels could not be resolved -- fails "
+            "closed to 'hold'."
+        ),
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "hold":
+        try:
+            timeline = _load_timeline(args.timeline_json)
+            labels = _load_labels(args.labels_json)
+        except (json.JSONDecodeError, TypeError) as exc:
+            sys.stderr.write(f"could not parse auto-merge inputs: {exc}; holding\n")
+            sys.stdout.write(f"{_VERDICT_HOLD}\n")
+            return 0
+
+        verdict = _VERDICT_HOLD if should_hold(timeline, labels) else _VERDICT_ARM
+        sys.stdout.write(f"{verdict}\n")
+        return 0
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/ci/test_auto_merge_hold_omn18179.py
+++ b/tests/unit/scripts/ci/test_auto_merge_hold_omn18179.py
@@ -1,0 +1,289 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""Tests for the auto-merge arming hold decision (OMN-18179).
+
+These pin the exact shapes measured on the three PRs that were armed over a
+human decision inside 24 hours (omninode_infra#1310 and #1313, and
+omnibase_core#1678), plus the two GitHub API details the detector depends
+on:
+
+* the enable event emitted by an explicit-method arm is
+  ``AutoSquashEnabledEvent``, not ``AutoMergeEnabledEvent``;
+* every "we don't know" input resolves to hold rather than to arm.
+
+The last test asserts the workflow's GraphQL ``itemTypes`` filter and the
+module's event tuples have not drifted apart, which is the one way this
+gate could silently stop seeing the events it exists to read.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_SCRIPT = _REPO_ROOT / "scripts" / "ci" / "check_auto_merge_hold.py"
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "auto-merge.yml"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_auto_merge_hold", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module()
+
+
+def _event(typename: str, created_at: str) -> dict[str, object]:
+    return {"__typename": typename, "createdAt": created_at}
+
+
+# The verbatim timeline read back from omninode_infra#1310 on 2026-09-11.
+_PR_1310_TIMELINE = [
+    _event("AutoSquashEnabledEvent", "2026-09-10T17:15:29Z"),
+    _event("AutoMergeDisabledEvent", "2026-09-10T18:50:55Z"),
+]
+
+# The verbatim timeline read back from omnibase_core#1678 on 2026-09-11:
+# armed on open, never disabled.
+_PR_1678_TIMELINE = [_event("AutoSquashEnabledEvent", "2026-09-11T10:40:33Z")]
+
+
+class TestLatestAutoMergeDecision:
+    def test_no_events_is_no_decision(self) -> None:
+        assert mod.latest_auto_merge_decision([]) is None
+
+    @pytest.mark.parametrize("typename", list(mod.ENABLE_EVENT_TYPES))
+    def test_every_enable_variant_is_recognised(self, typename: str) -> None:
+        """An explicit-method arm emits AutoSquashEnabledEvent, not AutoMerge*.
+
+        A detector matching only ``AutoMergeEnabledEvent`` reads an empty
+        enable history for every squash-armed PR in this org.
+        """
+        timeline = [_event(typename, "2026-09-10T17:15:29Z")]
+        assert mod.latest_auto_merge_decision(timeline) == "enable"
+
+    def test_disable_after_enable_is_disable(self) -> None:
+        assert mod.latest_auto_merge_decision(_PR_1310_TIMELINE) == "disable"
+
+    def test_enable_after_disable_is_enable(self) -> None:
+        """Re-arming by hand resumes automation with no special case."""
+        timeline = [
+            *_PR_1310_TIMELINE,
+            _event("AutoSquashEnabledEvent", "2026-09-10T19:00:00Z"),
+        ]
+        assert mod.latest_auto_merge_decision(timeline) == "enable"
+
+    def test_order_comes_from_created_at_not_list_position(self) -> None:
+        timeline = [
+            _event("AutoMergeDisabledEvent", "2026-09-10T18:50:55Z"),
+            _event("AutoSquashEnabledEvent", "2026-09-10T17:15:29Z"),
+        ]
+        assert mod.latest_auto_merge_decision(timeline) == "disable"
+
+    def test_undetermined_timeline_raises(self) -> None:
+        with pytest.raises(ValueError, match="undetermined"):
+            mod.latest_auto_merge_decision(None)
+
+    def test_unknown_event_type_raises(self) -> None:
+        timeline = [_event("AutoTeleportEnabledEvent", "2026-09-10T17:15:29Z")]
+        with pytest.raises(ValueError, match="unknown auto-merge timeline event"):
+            mod.latest_auto_merge_decision(timeline)
+
+    @pytest.mark.parametrize("created_at", [None, "", "   "])
+    def test_unorderable_event_raises(self, created_at: object) -> None:
+        timeline = [{"__typename": "AutoSquashEnabledEvent", "createdAt": created_at}]
+        with pytest.raises(ValueError, match="no usable createdAt"):
+            mod.latest_auto_merge_decision(timeline)
+
+
+class TestShouldHold:
+    def test_pr_1310_shape_holds(self) -> None:
+        """The prod scale-down PR: disabled by a human, must not re-arm."""
+        assert mod.should_hold(_PR_1310_TIMELINE, []) is True
+
+    def test_pr_1678_shape_arms_without_a_label(self) -> None:
+        """Armed on open and never disabled: nothing here says to hold.
+
+        This is the honest limit of the timeline rule, and the reason the
+        pre-emptive label exists.
+        """
+        assert mod.should_hold(_PR_1678_TIMELINE, []) is False
+
+    def test_pr_1678_shape_holds_with_the_label(self) -> None:
+        assert mod.should_hold(_PR_1678_TIMELINE, list(mod.HOLD_LABELS)) is True
+
+    def test_never_armed_pr_arms(self) -> None:
+        assert mod.should_hold([], []) is False
+
+    def test_label_holds_even_with_a_clean_timeline(self) -> None:
+        assert mod.should_hold([], ["hold:auto-merge"]) is True
+
+    def test_label_match_is_case_insensitive_and_trimmed(self) -> None:
+        assert mod.should_hold([], ["  Hold:Auto-Merge "]) is True
+
+    def test_unrelated_labels_do_not_hold(self) -> None:
+        assert mod.should_hold([], ["infra", "needs-review"]) is False
+
+    @pytest.mark.parametrize(
+        ("timeline", "labels"),
+        [
+            (None, []),
+            ([], None),
+            (None, None),
+        ],
+    )
+    def test_undetermined_inputs_fail_closed(
+        self, timeline: object, labels: object
+    ) -> None:
+        assert mod.should_hold(timeline, labels) is True
+
+    def test_unknown_event_type_fails_closed(self) -> None:
+        timeline = [_event("AutoTeleportEnabledEvent", "2026-09-10T17:15:29Z")]
+        assert mod.should_hold(timeline, []) is True
+
+    def test_a_disable_is_honoured_whatever_its_reason(self) -> None:
+        timeline = [
+            _event("AutoSquashEnabledEvent", "2026-09-10T17:15:29Z"),
+            {
+                "__typename": "AutoMergeDisabledEvent",
+                "createdAt": "2026-09-10T18:50:55Z",
+                "reason": "Base branch was changed",
+            },
+        ]
+        assert mod.should_hold(timeline, []) is True
+
+
+class TestCli:
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(_SCRIPT), "hold", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_arm_verdict(self) -> None:
+        result = self._run(
+            "--timeline-json",
+            json.dumps(_PR_1678_TIMELINE),
+            "--labels-json",
+            "[]",
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == "arm"
+
+    def test_hold_verdict(self) -> None:
+        result = self._run(
+            "--timeline-json",
+            json.dumps(_PR_1310_TIMELINE),
+            "--labels-json",
+            "[]",
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == "hold"
+
+    def test_a_hold_verdict_exits_zero(self) -> None:
+        """The verdict rides on stdout, never on the exit status.
+
+        Under the workflow's `set -euo pipefail` a non-zero exit would red
+        the whole job rather than skip one step.
+        """
+        result = self._run("--timeline-json", "null", "--labels-json", "[]")
+        assert result.returncode == 0
+        assert result.stdout.strip() == "hold"
+
+    def test_malformed_json_holds_without_crashing(self) -> None:
+        result = self._run("--timeline-json", "{not json", "--labels-json", "[]")
+        assert result.returncode == 0
+        assert result.stdout.strip() == "hold"
+
+    def test_omitted_flags_hold(self) -> None:
+        result = self._run()
+        assert result.returncode == 0
+        assert result.stdout.strip() == "hold"
+
+    def test_non_array_json_holds(self) -> None:
+        result = self._run("--timeline-json", '{"a":1}', "--labels-json", "[]")
+        assert result.returncode == 0
+        assert result.stdout.strip() == "hold"
+
+
+class TestWorkflowWiring:
+    """The gate is only as good as its wiring into auto-merge.yml."""
+
+    def test_workflow_queries_exactly_the_event_types_the_module_knows(self) -> None:
+        """A type in the query but not the module fails closed, and a type in
+        the module but not the query is simply never delivered -- silently,
+        which is the failure this gate exists to prevent."""
+        workflow = _WORKFLOW.read_text(encoding="utf-8")
+        for typename in (*mod.ENABLE_EVENT_TYPES, *mod.DISABLE_EVENT_TYPES):
+            # GraphQL itemTypes takes the SCREAMING_SNAKE enum spelling.
+            enum_name = "".join(
+                f"_{ch}" if ch.isupper() and i else ch.upper()
+                for i, ch in enumerate(typename)
+            ).upper()
+            assert enum_name in workflow, (
+                f"{typename} ({enum_name}) is missing from the auto-merge.yml "
+                "GraphQL itemTypes filter"
+            )
+
+    def test_the_graphql_query_never_reads_total_count(self) -> None:
+        """`timelineItems.totalCount` ignores the itemTypes filter.
+
+        Measured 2026-09-11: the query that returned 2 filtered nodes for
+        omninode_infra#1310 reported totalCount 7, and 2 nodes / totalCount
+        13 for #1313 -- the unfiltered timeline length both times.
+
+        Scoped to the query lines, not the whole file: the surrounding
+        comments have to be able to name the field in order to explain why
+        it must not be read.
+        """
+        query_lines = [
+            line
+            for line in _WORKFLOW.read_text(encoding="utf-8").splitlines()
+            if "timelineItems(" in line
+        ]
+        assert query_lines, "no GraphQL timelineItems query found in auto-merge.yml"
+        for line in query_lines:
+            assert "totalCount" not in line, line
+
+    def test_every_arming_step_is_gated_on_the_hold_check(self) -> None:
+        """Every step that arms or enqueues must carry the condition.
+
+        Gating only the arm step would still hand a held PR to a merge
+        queue, so this walks the parsed job rather than counting strings.
+        """
+        import yaml
+
+        workflow_text = _WORKFLOW.read_text(encoding="utf-8")
+        assert "check_auto_merge_hold.py" in workflow_text
+
+        # `on:` parses as the boolean True in YAML 1.1; irrelevant here, we
+        # only read `jobs`.
+        parsed = yaml.safe_load(workflow_text)
+        arming_steps = [
+            step
+            for job in parsed["jobs"].values()
+            for step in job.get("steps", [])
+            if str(step.get("name", "")).startswith(
+                ("Enable auto-merge", "Enqueue armed PR")
+            )
+        ]
+        assert arming_steps, "no arming step found in auto-merge.yml"
+        for step in arming_steps:
+            condition = str(step.get("if", ""))
+            assert "steps.hold_gate.outputs.hold != 'true'" in condition, (
+                f"step {step.get('name')!r} arms auto-merge without the "
+                f"OMN-18179 hold gate; its condition is {condition!r}"
+            )


### PR DESCRIPTION
OMN-18179

## What

The Enable Auto-Merge job armed GitHub native auto-merge with no check for whether anyone had already turned it off. This repo re-triggers on check suite completion — 57 of its last 100 auto-merge runs came from that event — so an explicit `gh pr merge --disable-auto` could be undone within minutes and the PR would land as soon as its checks went green. Converting the PR to draft was the only durable pause.

omnibase_core#1678 was armed on open at 2026-09-11T10:40:33Z, before the authorization ruling for that change reached the lane, and merged at 11:17:57Z. Two sibling PRs took the same shape in the preceding 24 hours: omninode_infra#1310, a prod scale-down taking 13 Deployments to zero replicas, armed 17:15:29Z and disabled 18:50:55Z, and omninode_infra#1313, armed 22:48:54Z and disabled 22:50:41Z. Both timelines were read back live.

## The fix

A new `scripts/ci/check_auto_merge_hold.py` decision module, pure and unit-tested and byte-identical to the omnibase_infra and omninode_infra copies, plus a gate step that reads the PR auto-merge timeline and labels and feeds them in. The rule is small: the most recent human decision wins. If the latest auto-merge state-change event is a disable, do not arm. Re-arming by hand writes a fresh enable event after that disable, so automation resumes with no special case. A PR can also be paused pre-emptively with the label named in `HOLD_LABELS`, which is the only thing that covers the never-yet-armed case — the shape #1678 actually had.

Both the arm step and the enqueue step are conditioned on it. The new step is read-only and stays on `GITHUB_TOKEN`, so the OMN-17875 arming-identity split is unchanged and `tests/unit/validation/test_auto_merge_workflow_shape.py` still passes.

## Two measured API details this depends on

Arming with an explicit method emits `AutoSquashEnabledEvent`, **not** `AutoMergeEnabledEvent`. A detector matching only the latter reads an empty enable history for every PR this workflow has ever armed, and never errors. All three enable variants are in the filter, and a test asserts the workflow query and the module tuples stay in lockstep.

`timelineItems.totalCount` ignores the `itemTypes` filter and returns the unfiltered timeline length: 2 filtered nodes against `totalCount` 7 for omninode_infra#1310, and 2 against 13 for #1313. Only `nodes` is read.

Every undetermined input resolves to skipping the arm rather than arming.

The fetch-and-classify path was run end to end against four live PRs before commit. Both disabled PRs classified as a skip; omnibase_core#1678 and omnibase_infra#3427, both armed and never disabled, classified as arm.

```
uv run pytest tests/unit/scripts/ci/test_auto_merge_hold_omn18179.py tests/unit/validation/test_auto_merge_workflow_shape.py -q
50 passed
```

Governed pre-push passed on this branch.

## Related

Companion PRs land the same module in omnibase_infra and omninode_infra. omninode_infra additionally excludes deploy-surface diffs from arming. Follow-up coverage for omnimarket, omniclaude, onex_change_control, omnimemory and omnidash is listed on the ticket.

Evidence-Ticket: OMN-18179
Evidence-Source: OCC#9062
