### PR TITLE
fix(OMN-18075): validate structural OCC self-bind receipts

### DIFF
--- a/src/omnibase_core/validation/validator_occ_merge_eligibility.py
+++ b/src/omnibase_core/validation/validator_occ_merge_eligibility.py
@@ -51,6 +51,8 @@ TICKET_TOKEN_PATTERN = re.compile(r"(?<![A-Z0-9])OMN-(\d+)(?![A-Z0-9])", re.IGNO
 _OCC_REPO_NAME = "onex_change_control"
 _OCC_REPO_ORG = "OmniNode-ai"
 _OCC_REPO_QUALIFIED = f"{_OCC_REPO_ORG}/{_OCC_REPO_NAME}"
+_STRUCTURAL_BINDINGS_RELATIVE_DIR = Path("drift/occ_bindings")
+_STRUCTURAL_SELF_BIND_CHECK_TYPE = "command"
 
 # OMN-16859: check types a PRODUCT-REPO CI runner executes and supersedes.
 #
@@ -97,31 +99,18 @@ def _self_bind_remediation(ticket_id: str, pr_number: int) -> str:
     path so the convention is taught at the moment of failure instead of
     costing a full CI round-trip of re-diagnosis.
     """
-    entry_id = f"occ-self-bind-pr-{pr_number}"
+    evidence_id = f"occ-self-bind-pr-{pr_number}"
     return (
         f"OCC evidence for {ticket_id} verifies (receipts PASS, hashes bound), "
-        f"but no receipt binds to this OCC PR (#{pr_number}). "
-        f"Add a self-bind entry to contracts/{ticket_id}.yaml:\n"
-        "\n"
-        f'  - id: "{entry_id}"\n'
-        "    description: >-\n"
-        f"      OCC self-binding receipt for PR #{pr_number}, the in-repo evidence PR\n"
-        f"      carrying this contract. Binds {ticket_id} to the OCC PR by pr_number\n"
-        "      so eligibility can resolve a PASS receipt for the evidence PR itself.\n"
-        '    source: "manual"\n'
-        '    status: "verified"\n'
-        "    checks:\n"
-        '      - check_type: "command"\n'
-        "        check_value: >-\n"
-        f"          gh pr view {pr_number} --repo {_OCC_REPO_QUALIFIED} "
-        "--json number,state,headRefName\n"
-        "\n"
-        "then write a PASS receipt at "
-        f"drift/dod_receipts/{ticket_id}/{entry_id}/command.yaml with "
-        f"pr_number: {pr_number}. Recompute contract_sha256 on the EXISTING "
-        f"receipts for {ticket_id} — the whole-file hash moves when the contract "
-        "gains an entry; per-entry contract_entry_sha256 values do not "
-        "(OMN-13888)."
+        f"but no structural receipt binds to this OCC PR (#{pr_number}). "
+        "Mint a PASS structural binding receipt at "
+        f"drift/occ_bindings/{ticket_id}/{evidence_id}/command.yaml with "
+        f"ticket_id: {ticket_id}, evidence_item_id: {evidence_id}, "
+        f"check_type: {_STRUCTURAL_SELF_BIND_CHECK_TYPE}, pr_number: {pr_number}, "
+        "and contract_sha256 equal to the current ticket contract hash. "
+        "Do not declare this structural receipt in dod_evidence, do not add "
+        "binds_ac, and do not mint contract_entry_sha256 for an undeclared item "
+        "(OMN-18075)."
     )
 
 
@@ -198,6 +187,7 @@ def validate_occ_merge_eligibility(
             )
 
     contract_hashes: dict[str, str] = {}
+    contract_data_by_ticket: dict[str, object] = {}
     receipt_ids: list[str] = []
     missing_contracts: list[str] = []
     missing_receipts: list[str] = []
@@ -263,6 +253,7 @@ def validate_occ_merge_eligibility(
                 detail=f"contract {contract_path} is unreadable: {exc}",
             )
         contract_hashes[ticket_id] = contract_hash
+        contract_data_by_ticket[ticket_id] = contract_data
         triples = _iter_dod_evidence(contract_data)
         if not triples:
             missing_receipts.append(f"{ticket_id}:*:*")
@@ -484,6 +475,142 @@ def validate_occ_merge_eligibility(
             ),
             detail="one or more receipts are missing or non-PASS",
         )
+
+    # OMN-18075: an OCC companion's receipt-to-current-PR binding is structural
+    # provenance, not product DoD evidence. New companions therefore keep the
+    # deterministic ``occ-self-bind-pr-<N>`` receipt but no longer declare that
+    # id in ``dod_evidence`` (where it polluted the closer's probative ratio).
+    # Resolve that one receipt directly, only for the canonical OCC repo and
+    # only when declared evidence has not already bound the ticket. The latter
+    # preserves every historical companion whose self-bind remains declared.
+    if _is_occ_repo(snapshot.repo):
+        for ticket_id in ticket_ids:
+            if ticket_id in tickets_with_pr_bound_receipt:
+                continue
+
+            evidence_item_id = f"occ-self-bind-pr-{snapshot.pr_number}"
+            receipt_key = (
+                f"{ticket_id}:{evidence_item_id}:{_STRUCTURAL_SELF_BIND_CHECK_TYPE}"
+            )
+            receipt_path = (
+                snapshot.contracts_dir.parent
+                / _STRUCTURAL_BINDINGS_RELATIVE_DIR
+                / ticket_id
+                / evidence_item_id
+                / f"{_STRUCTURAL_SELF_BIND_CHECK_TYPE}.yaml"
+            )
+            if not receipt_path.is_file():
+                continue
+
+            try:
+                receipt_raw = _load_yaml(receipt_path)
+                receipt = ModelDodReceipt.model_validate(receipt_raw)
+            except (OSError, yaml.YAMLError, ValidationError) as exc:
+                return ModelOccEligibilityResult(
+                    eligible=False,
+                    reason=EnumOccEligibilityReason.NONPASS_RECEIPT,
+                    ticket_ids=ticket_ids,
+                    occ_commit_sha=snapshot.occ_commit_sha,
+                    contract_hashes=contract_hashes,
+                    receipt_ids=tuple(sorted(receipt_ids)),
+                    missing_or_nonpass_receipts=(receipt_key,),
+                    detail=f"structural self-bind receipt {receipt_path} is invalid: {exc}",
+                )
+
+            expected_key = (
+                ticket_id,
+                evidence_item_id,
+                _STRUCTURAL_SELF_BIND_CHECK_TYPE,
+            )
+            actual_key = (
+                receipt.ticket_id,
+                receipt.evidence_item_id,
+                receipt.check_type,
+            )
+            if actual_key != expected_key:
+                return ModelOccEligibilityResult(
+                    eligible=False,
+                    reason=EnumOccEligibilityReason.PR_TICKET_MISMATCH,
+                    ticket_ids=ticket_ids,
+                    occ_commit_sha=snapshot.occ_commit_sha,
+                    contract_hashes=contract_hashes,
+                    receipt_ids=tuple(sorted(receipt_ids)),
+                    detail=(
+                        f"structural self-bind receipt {receipt_path} declares key "
+                        f"{actual_key!r}, expected {expected_key!r}"
+                    ),
+                )
+
+            is_bound = _receipt_bound_to_pr(receipt, snapshot)
+            if receipt.contract_entry_sha256 is not None:
+                return ModelOccEligibilityResult(
+                    eligible=False,
+                    reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,
+                    ticket_ids=ticket_ids,
+                    occ_commit_sha=snapshot.occ_commit_sha,
+                    contract_hashes=contract_hashes,
+                    receipt_ids=tuple(sorted(receipt_ids)),
+                    stale_receipt_bindings=(receipt_key,),
+                    detail=(
+                        f"structural self-bind receipt {receipt_path} must not "
+                        "declare contract_entry_sha256 because its evidence id "
+                        "is intentionally absent from dod_evidence (OMN-18075)"
+                    ),
+                )
+            if (
+                receipt.contract_sha256 is None
+                and receipt.contract_entry_sha256 is None
+            ):
+                return ModelOccEligibilityResult(
+                    eligible=False,
+                    reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,
+                    ticket_ids=ticket_ids,
+                    occ_commit_sha=snapshot.occ_commit_sha,
+                    contract_hashes=contract_hashes,
+                    receipt_ids=tuple(sorted(receipt_ids)),
+                    stale_receipt_bindings=(receipt_key,),
+                    detail=(
+                        f"structural self-bind receipt {receipt_path} is missing "
+                        "both contract_sha256 and contract_entry_sha256"
+                    ),
+                )
+            binding_error = check_receipt_contract_binding(
+                receipt=receipt,
+                contract_data=contract_data_by_ticket[ticket_id],
+                evidence_item_id=evidence_item_id,
+                whole_file_hash=contract_hashes[ticket_id],
+                is_bound_to_this_pr=is_bound,
+            )
+            if binding_error is not None:
+                return ModelOccEligibilityResult(
+                    eligible=False,
+                    reason=EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH,
+                    ticket_ids=ticket_ids,
+                    occ_commit_sha=snapshot.occ_commit_sha,
+                    contract_hashes=contract_hashes,
+                    receipt_ids=tuple(sorted(receipt_ids)),
+                    stale_receipt_bindings=(receipt_key,),
+                    detail=f"structural self-bind receipt {receipt_path}: {binding_error}",
+                )
+            if receipt.status is not EnumReceiptStatus.PASS:
+                return ModelOccEligibilityResult(
+                    eligible=False,
+                    reason=EnumOccEligibilityReason.NONPASS_RECEIPT,
+                    ticket_ids=ticket_ids,
+                    occ_commit_sha=snapshot.occ_commit_sha,
+                    contract_hashes=contract_hashes,
+                    receipt_ids=tuple(sorted(receipt_ids)),
+                    missing_or_nonpass_receipts=(receipt_key,),
+                    detail=(
+                        f"structural self-bind receipt {receipt_path} has "
+                        f"non-PASS status {receipt.status.value}"
+                    ),
+                )
+
+            receipt_ids.append(receipt_key)
+            if is_bound:
+                tickets_with_pr_bound_receipt.add(ticket_id)
+
     unbound_tickets = tuple(
         ticket_id
         for ticket_id in ticket_ids

--- a/tests/unit/validation/test_occ_merge_eligibility.py
+++ b/tests/unit/validation/test_occ_merge_eligibility.py
@@ -64,6 +64,8 @@ def _write_receipt(
     pr_number: int | None = 123,
     commit_sha: str = PR_SHA,
     contract_sha256: str | None,
+    contract_entry_sha256: str | None = None,
+    receipts_dir: Path | None = None,
 ) -> None:
     receipt = {
         "schema_version": "1.0.0",
@@ -83,7 +85,10 @@ def _write_receipt(
     }
     if contract_sha256 is not None:
         receipt["contract_sha256"] = contract_sha256
-    path = root / "receipts" / ticket_id / evidence_item_id / "command.yaml"
+    if contract_entry_sha256 is not None:
+        receipt["contract_entry_sha256"] = contract_entry_sha256
+    receipt_root = receipts_dir if receipts_dir is not None else root / "receipts"
+    path = receipt_root / ticket_id / evidence_item_id / "command.yaml"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         yaml.safe_dump(receipt, sort_keys=True),
@@ -811,18 +816,134 @@ def test_missing_self_bind_only_emits_actionable_reason_on_occ_repo(
     assert result.receipt_ids == (f"{TICKET}:dod-001:command",)
     assert result.missing_or_nonpass_receipts == ()
     assert result.stale_receipt_bindings == ()
-    # remediation payload: exact entry id, contract file, receipt path,
-    # pr_number, and the OMN-13888 hash-recompute reminder
+    # Remediation names the deterministic structural path and explicitly keeps
+    # it outside DoD/AC coverage.
     assert "occ-self-bind-pr-123" in result.detail
-    assert f"contracts/{TICKET}.yaml" in result.detail
     assert (
-        f"drift/dod_receipts/{TICKET}/occ-self-bind-pr-123/command.yaml"
+        f"drift/occ_bindings/{TICKET}/occ-self-bind-pr-123/command.yaml"
         in result.detail
     )
     assert "pr_number: 123" in result.detail
     assert "contract_sha256" in result.detail
     assert "contract_entry_sha256" in result.detail
-    assert "OMN-13888" in result.detail
+    assert "Do not declare" in result.detail
+    assert "binds_ac" in result.detail
+    assert "OMN-18075" in result.detail
+
+
+@pytest.mark.unit
+def test_undeclared_structural_self_bind_receipt_is_eligible(
+    tmp_path: Path,
+) -> None:
+    """OMN-18075: structural binding is resolved outside ``dod_evidence``."""
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path,
+        pr_number=999,
+        commit_sha="c" * 40,
+        contract_sha256=contract_hash,
+    )
+    structural_id = "occ-self-bind-pr-123"
+    _write_receipt(
+        tmp_path,
+        evidence_item_id=structural_id,
+        pr_number=123,
+        contract_sha256=contract_hash,
+        receipts_dir=tmp_path / "drift" / "occ_bindings",
+    )
+
+    contract_data = yaml.safe_load(
+        (tmp_path / "contracts" / f"{TICKET}.yaml").read_text(encoding="utf-8")
+    )
+    assert structural_id not in {item["id"] for item in contract_data["dod_evidence"]}
+
+    result = validate_occ_merge_eligibility(_occ_snapshot(tmp_path))
+
+    assert result.eligible is True, result.detail
+    assert result.reason is EnumOccEligibilityReason.ELIGIBLE
+    assert f"{TICKET}:{structural_id}:command" in result.receipt_ids
+
+
+@pytest.mark.unit
+def test_undeclared_structural_self_bind_rejects_stale_contract_hash(
+    tmp_path: Path,
+) -> None:
+    """An undeclared binding stays structural, but never escapes integrity."""
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path,
+        pr_number=999,
+        commit_sha="c" * 40,
+        contract_sha256=contract_hash,
+    )
+    _write_receipt(
+        tmp_path,
+        evidence_item_id="occ-self-bind-pr-123",
+        pr_number=123,
+        contract_sha256=STALE_HASH,
+        receipts_dir=tmp_path / "drift" / "occ_bindings",
+    )
+
+    result = validate_occ_merge_eligibility(_occ_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH
+    assert "occ-self-bind-pr-123" in result.detail
+
+
+@pytest.mark.unit
+def test_undeclared_structural_self_bind_rejects_per_entry_hash(
+    tmp_path: Path,
+) -> None:
+    """Structural provenance cannot claim a hash for a nonexistent DoD row."""
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path,
+        pr_number=999,
+        commit_sha="c" * 40,
+        contract_sha256=contract_hash,
+    )
+    _write_receipt(
+        tmp_path,
+        evidence_item_id="occ-self-bind-pr-123",
+        pr_number=123,
+        contract_sha256=contract_hash,
+        contract_entry_sha256=f"sha256:{'a' * 64}",
+        receipts_dir=tmp_path / "drift" / "occ_bindings",
+    )
+
+    result = validate_occ_merge_eligibility(_occ_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.CONTRACT_HASH_MISMATCH
+    assert "must not declare contract_entry_sha256" in result.detail
+    assert "OMN-18075" in result.detail
+
+
+@pytest.mark.unit
+def test_product_repo_does_not_consume_structural_self_bind_receipt(
+    tmp_path: Path,
+) -> None:
+    """The new structural lookup is confined to the canonical OCC repo."""
+    contract_hash = _write_contract(tmp_path)
+    _write_receipt(
+        tmp_path,
+        pr_number=999,
+        commit_sha="c" * 40,
+        contract_sha256=contract_hash,
+    )
+    _write_receipt(
+        tmp_path,
+        evidence_item_id="occ-self-bind-pr-123",
+        pr_number=123,
+        contract_sha256=contract_hash,
+        receipts_dir=tmp_path / "drift" / "occ_bindings",
+    )
+
+    result = validate_occ_merge_eligibility(_snapshot(tmp_path))
+
+    assert result.eligible is False
+    assert result.reason is EnumOccEligibilityReason.PR_TICKET_MISMATCH
 
 
 @pytest.mark.unit
@@ -1010,9 +1131,8 @@ def test_missing_self_bind_names_every_unbound_ticket(tmp_path: Path) -> None:
 
     assert result.eligible is False
     assert result.reason is EnumOccEligibilityReason.MISSING_OCC_SELF_BIND
-    assert f"contracts/{TICKET}.yaml" in result.detail
-    assert f"contracts/{second_ticket}.yaml" in result.detail
-    assert f"drift/dod_receipts/{second_ticket}/occ-self-bind-pr-123" in result.detail
+    assert f"drift/occ_bindings/{TICKET}/occ-self-bind-pr-123" in result.detail
+    assert f"drift/occ_bindings/{second_ticket}/occ-self-bind-pr-123" in result.detail
 
 
 @pytest.mark.unit
@@ -1050,8 +1170,8 @@ def test_missing_self_bind_only_names_the_unbound_ticket(tmp_path: Path) -> None
 
     assert result.eligible is False
     assert result.reason is EnumOccEligibilityReason.MISSING_OCC_SELF_BIND
-    assert f"drift/dod_receipts/{second_ticket}/occ-self-bind-pr-123" in result.detail
-    assert f"drift/dod_receipts/{TICKET}/" not in result.detail
+    assert f"drift/occ_bindings/{second_ticket}/occ-self-bind-pr-123" in result.detail
+    assert f"drift/occ_bindings/{TICKET}/" not in result.detail
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Implements the core half of the owner-approved OMN-18075 evidence shape.

The OCC self-bind remains a deterministic receipt, but it is structural PR provenance rather than product DoD evidence. The validator now derives drift/occ_bindings from the supplied contracts directory and resolves occ-self-bind-pr-N directly only for the canonical OCC repository.

Safety properties:
- historical declared self-bind receipts remain accepted unchanged
- product repositories cannot consume the structural path
- ticket, evidence id, check type, PR number, PASS status, commit binding, and current whole-contract hash are validated fail-closed
- contract_entry_sha256 is rejected because the structural id is intentionally absent from dod_evidence
- remediation names the exact deterministic path and forbids binds_ac or a fabricated per-entry hash

Verification:
- focused validator suite: 44 passed twice
- Ruff and mypy passed
- complete repository pre-commit suite passed
- push-time mypy, pyright, evidence-shape, naming, UUID, enum, and purity gates passed

This PR must merge and release before the coordinated omnimarket producer change can use the new validator in CI.

Ticket: OMN-18075

Evidence-Ticket: OMN-18075
Evidence-Source: OCC#9094
