### PR TITLE
feat(OMN-18196): stamp which credential served a delegation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.10"
+version = "0.47.11"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/enums/enum_credential_source.py
+++ b/src/omnibase_core/enums/enum_credential_source.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""Which credential actually served a delegation call (OMN-18196)."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class EnumCredentialSource(StrEnum):
+    """The credential the effect boundary resolved for a provider call.
+
+    Axiom 9 forbids a customer route binding a house credential. A model name
+    cannot witness that prohibition, because the same model id is reachable on
+    a customer's own key and on a house credential alike. This enum is the
+    fact itself, and it is only ever produced by the boundary that resolved
+    the credential for the call — never inferred downstream from a model, a
+    route, a tier name, or a tenant's configuration read after the fact.
+
+    ``NONE`` is a real outcome, not an absence: the call reached the provider
+    with no credential attached. It is distinct from the field being unset on
+    a terminal emitted before this field existed, which stays ``None``.
+
+    A tenant whose registered credential was withdrawn keeps its routing
+    overlay row with a blanked ``secret_ref`` (OMN-18191), so the binding it
+    resolves to carries no reference. That case classifies as ``NONE``. It
+    must never read as ``CUSTOMER_KEY``: the row still names the customer, but
+    no customer credential answered.
+    """
+
+    CUSTOMER_KEY = "customer_key"
+    HOUSE = "house"
+    NONE = "none"
+
+
+__all__ = ["EnumCredentialSource"]

--- a/src/omnibase_core/models/delegation/wire/__init__.py
+++ b/src/omnibase_core/models/delegation/wire/__init__.py
@@ -27,6 +27,7 @@ from omnibase_core.models.delegation.wire.model_delegation_provenance import (
     ModelDelegationProvenance,
 )
 from omnibase_core.models.delegation.wire.model_delegation_result import (
+    EnumCredentialSource,
     EnumDelegationTerminalFailureCause,
     EnumQualityScoreComparison,
     ModelDelegationResult,
@@ -86,6 +87,7 @@ __all__: list[str] = [
     "SUPPORTED_ACCEPTANCE_CRITERIA",
     "TASK_DELEGATED_TOPIC_V1",
     "EnumBudgetAction",
+    "EnumCredentialSource",
     "EnumDelegationTerminalFailureCause",
     "EnumDelegationTrafficClass",
     "EnumDelegationRoutingDisposition",

--- a/src/omnibase_core/models/delegation/wire/model_delegation_result.py
+++ b/src/omnibase_core/models/delegation/wire/model_delegation_result.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from omnibase_core.enums.enum_credential_source import EnumCredentialSource
 from omnibase_core.enums.enum_delegation_terminal_failure_cause import (
     EnumDelegationTerminalFailureCause,
 )
@@ -52,6 +53,20 @@ class ModelDelegationResult(BaseModel):
         description=(
             "Declared provider identity for the selected route. Never inferred "
             "from a post-terminal tenant overlay."
+        ),
+    )
+    # OMN-18196: the credential class that served the call, copied verbatim
+    # from the inference response that the effect boundary stamped. Axiom 9
+    # forbids a customer route binding a house credential; before this field
+    # nothing durable recorded which one answered, so the prohibition was
+    # unfalsifiable after the fact. Unpaired from route/provider on purpose: a
+    # refused call has a credential source (``NONE``) and no route at all.
+    credential_source: EnumCredentialSource | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Credential class that served this terminal, as resolved at the "
+            "effect boundary. Absent is explicit legacy provenance."
         ),
     )
     provenance: ModelDelegationProvenance | None = Field(
@@ -295,6 +310,7 @@ class ModelDelegationResult(BaseModel):
 
 
 __all__: list[str] = [
+    "EnumCredentialSource",
     "EnumDelegationTerminalFailureCause",
     "EnumQualityScoreComparison",
     "ModelDelegationResult",

--- a/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
+++ b/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from omnibase_core.enums.enum_budget_action import EnumBudgetAction
+from omnibase_core.enums.enum_credential_source import EnumCredentialSource
 from omnibase_core.models.delegation.wire.model_delegation_wire_request import (
     ModelDelegationRequest,
     validate_response_format,
@@ -253,6 +254,22 @@ class ModelInferenceResponseData(BaseModel):
         description=(
             "Declared provider for the route that produced this response. Never "
             "reconstructed from tenant configuration after execution."
+        ),
+    )
+    # OMN-18196: which credential actually served this call, stamped by the
+    # effect boundary from the binding it resolved. This is the ONLY place the
+    # fact exists first-hand; every downstream carrier copies it. A consumer
+    # must never re-derive it from ``model_used``, ``route``, ``provider`` or a
+    # tier name -- the same model is reachable on a customer key and on a house
+    # credential, which is exactly why the field exists. ``None`` is a response
+    # emitted before this field existed, NOT a call that ran without a
+    # credential; that case is ``EnumCredentialSource.NONE``.
+    credential_source: EnumCredentialSource | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Credential class the effect boundary resolved for this call. "
+            "Absent is explicit legacy provenance, not an absent credential."
         ),
     )
     # string-id-ok: tenant identity is a named slug (e.g. "omninode"), not a UUID.

--- a/tests/unit/models/delegation/wire/test_omn18196_credential_source.py
+++ b/tests/unit/models/delegation/wire/test_omn18196_credential_source.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+"""The wire contract for which credential served a delegation (OMN-18196).
+
+Axiom 9 forbids a customer route binding a house credential. A model name
+cannot witness that -- the same model id is reachable on a customer's own key
+and on the platform's -- so the fact needs a field of its own, produced by the
+boundary that resolved the credential and copied unchanged by everything
+downstream.
+
+These tests pin the CONTRACT: the three values, the defaulting that lets an
+older producer's terminal still parse, and the deliberate decision NOT to pair
+this field with route/provider.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from omnibase_core.enums.enum_credential_source import EnumCredentialSource
+from omnibase_core.models.delegation.wire import (
+    ModelDelegationResult,
+)
+from omnibase_core.models.delegation.wire.model_orchestrator_intents import (
+    ModelInferenceResponseData,
+)
+
+
+def _result(**kwargs: object) -> ModelDelegationResult:
+    defaults: dict[str, object] = {
+        "correlation_id": uuid4(),
+        "task_type": "test",
+        "model_used": "nvidia/nemotron-3-ultra-550b-a55b:free",
+        "endpoint_url": "https://openrouter.ai/api/v1/chat/completions",
+        "content": "ok",
+        "quality_passed": True,
+        "quality_score": 1.0,
+        "latency_ms": 12,
+        "fallback_to_claude": False,
+    }
+    defaults.update(kwargs)
+    return ModelDelegationResult(**defaults)  # type: ignore[arg-type]
+
+
+def _response(**kwargs: object) -> ModelInferenceResponseData:
+    defaults: dict[str, object] = {
+        "correlation_id": uuid4(),
+        "content": "ok",
+        "model_used": "nvidia/nemotron-3-ultra-550b-a55b:free",
+    }
+    defaults.update(kwargs)
+    return ModelInferenceResponseData(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestTheEnum:
+    def test_it_names_exactly_the_three_outcomes_a_call_can_have(self) -> None:
+        assert {member.value for member in EnumCredentialSource} == {
+            "customer_key",
+            "house",
+            "none",
+        }
+
+    def test_the_values_are_the_wire_strings(self) -> None:
+        """Serialised terminals carry these strings; the gateway matches on them."""
+        assert EnumCredentialSource.CUSTOMER_KEY == "customer_key"
+        assert EnumCredentialSource.HOUSE == "house"
+        assert EnumCredentialSource.NONE == "none"
+
+
+@pytest.mark.unit
+class TestTheTerminalCarriesIt:
+    @pytest.mark.parametrize("source", list(EnumCredentialSource))
+    def test_every_value_round_trips_on_the_wire(
+        self, source: EnumCredentialSource
+    ) -> None:
+        dumped = _result(credential_source=source).model_dump(mode="json")
+        assert dumped["credential_source"] == source.value
+        assert ModelDelegationResult.model_validate(dumped).credential_source is source
+
+    def test_a_terminal_from_a_producer_that_predates_the_field_still_parses(
+        self,
+    ) -> None:
+        """A consumer must not turn a missing explanation into no terminal."""
+        assert _result().credential_source is None
+
+    def test_absent_is_omitted_rather_than_serialised_as_null(self) -> None:
+        """Absent means the producer made no claim, and says so by saying nothing."""
+        assert "credential_source" not in _result().model_dump(mode="json")
+
+    def test_an_unrecognised_credential_class_is_refused(self) -> None:
+        with pytest.raises(ValidationError):
+            _result(credential_source="borrowed")
+
+    def test_it_is_not_paired_with_route_and_provider(self) -> None:
+        """A refused call has a credential source and no route at all.
+
+        ``route``/``provider`` validate as a pair, and it would be easy to
+        assume this field joins them. It must not: the case this field exists
+        to record most sharply -- a call that reached no provider because no
+        credential was available -- has a credential source of ``none`` and
+        nothing to say about a route.
+        """
+        result = _result(credential_source=EnumCredentialSource.NONE)
+        assert result.credential_source is EnumCredentialSource.NONE
+        assert result.route is None
+        assert result.provider is None
+
+
+@pytest.mark.unit
+class TestTheInferenceResponseCarriesIt:
+    """The response is where the fact enters the system, first-hand."""
+
+    @pytest.mark.parametrize("source", list(EnumCredentialSource))
+    def test_every_value_round_trips(self, source: EnumCredentialSource) -> None:
+        dumped = _response(credential_source=source).model_dump(mode="json")
+        assert dumped["credential_source"] == source.value
+        assert (
+            ModelInferenceResponseData.model_validate(dumped).credential_source
+            is source
+        )
+
+    def test_a_response_from_an_older_effect_still_parses(self) -> None:
+        assert _response().credential_source is None
+
+    def test_an_unrecognised_credential_class_is_refused(self) -> None:
+        with pytest.raises(ValidationError):
+            _response(credential_source="borrowed")

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.10"
+version = "0.47.11"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## OMN-18196 — the wire contract for which credential served a delegation

Axiom 9 forbids a customer route binding a house credential. Read live on 2026-09-11, nothing durable recorded which one answered a given run, so the prohibition was unfalsifiable after the fact: there was no artifact anyone could audit to find a violation.

`terminal_model_used` cannot stand in for the fact. The same model id is reachable on a customer's own OpenRouter key and on the platform's, so a model-derived answer is a guess wearing evidence's clothes. This PR adds the field the fact actually lives in.

### What changed

- New `EnumCredentialSource` — `customer_key` | `house` | `none`.
- `ModelInferenceResponseData` gains `credential_source`. This is where the fact enters the system first-hand: the effect boundary produces it from the resolution that selected the credential for the call.
- `ModelDelegationResult` gains `credential_source`, copied unchanged onto the terminal.
- Version 0.47.10 to 0.47.11. omnimarket needs the field released before its effect boundary can stamp it, so this is the release that unblocks the producer half.

### Two design decisions worth reviewing

**Absent is not a value.** Both fields default to `None` and are omitted from the serialised payload rather than written as null. A producer that predates the field made no claim, and a terminal from one must still parse. `none` is a positive claim that a call ran with no credential attached, which is a different thing from a producer that never spoke.

**Deliberately NOT paired with route/provider.** Those two validate as a pair, and it would be natural to assume this field joins them. It must not. The case this field records most sharply, a call refused for want of a credential, has a credential source of `none` and nothing whatever to say about a route. `tests/unit/models/delegation/wire/test_omn18196_credential_source.py::TestTheTerminalCarriesIt::test_it_is_not_paired_with_route_and_provider` pins that so a later tidy-up does not fold it in.

### dod_evidence

Local, this branch at d4765ecd:

- `uv run pytest tests/unit/models/delegation/wire/test_omn18196_credential_source.py tests/unit/models/delegation/wire/test_delegation_wire_models.py -q` → **164 passed in 6.17s**. The new file covers all three values round-tripping on both models, the legacy-absent parse, absent-is-omitted, an unrecognised value being refused, and the non-pairing above.
- `uv run mypy --strict` on the three touched source modules → **Success: no issues found in 3 source files**.
- `ruff format` and `ruff check` clean on everything touched.
- Full pre-commit ran on the commit: **100 hooks passed, zero failures**, including the release-identity gate that required this version bump.

### Lab readback

There is no lab surface for this PR. It adds an enum and two optional model fields and changes no runtime behaviour on its own; nothing is dispatched, published or persisted differently by this change alone. The lab proof belongs to the producer half in omnimarket, which is where a call actually resolves a credential, and it is cited there rather than asserted here. Claiming a lab pass for a contract-only change would be borrowing evidence.

### Sequencing

This is the first of the chain for OMN-18196. The omnimarket producer and the gateway persistence both depend on this release. Companion PRs are linked from the ticket.

Evidence-Ticket: OMN-18196
Evidence-Source: OCC#9126
