### PR TITLE
feat(OMN-18201): let an inference intent say a credential was required

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.11"
+version = "0.47.12"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
+++ b/src/omnibase_core/models/delegation/wire/model_orchestrator_intents.py
@@ -110,6 +110,43 @@ class ModelInferenceIntent(BaseModel):
             "making the outbound provider call."
         ),
     )
+    # OMN-18201: what the ROUTING AUTHORITY expected the effect boundary to
+    # authenticate with. The sibling ``api_key_ref`` above is the reference
+    # itself; this is the claim that one was supposed to be there.
+    #
+    # The two are not redundant, and the difference is the whole point. An
+    # absent ``api_key_ref`` is ambiguous on its own: it is what a genuinely
+    # auth-free backend looks like, and it is also what a customer's route
+    # looks like after its reference has gone missing anywhere between the
+    # routing decision and this call. The effect boundary cannot tell those
+    # apart, so it did the only thing an absent reference permits -- it posted
+    # the request with no Authorization header, and the vendor's 401 came back
+    # as the delegation's failure. That is an unauthenticated outbound call on
+    # a customer's route, made silently, with the platform reporting the
+    # vendor for a condition it could have refused locally.
+    #
+    # Stamped by the producer of the intent, which is the only party that has
+    # read the routing decision. ``CUSTOMER_KEY`` / ``HOUSE`` mean a credential
+    # of that class is REQUIRED: the boundary refuses before any outbound call
+    # if it cannot resolve one. ``NONE`` is a deliberate declaration that this
+    # backend takes no credential -- a customer's own local model, say -- and
+    # is the only value under which a headerless call is legitimate.
+    #
+    # ``None`` is an intent from a producer that predates this field and makes
+    # no claim either way; the boundary keeps the pre-OMN-18201 behaviour for
+    # it rather than refusing traffic mid-release. It is NOT a synonym for
+    # ``EnumCredentialSource.NONE``, which is a positive assertion that no
+    # credential is needed.
+    expected_credential_source: EnumCredentialSource | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Credential class the routing authority expected this call to be "
+            "authenticated with. CUSTOMER_KEY/HOUSE require the effect "
+            "boundary to resolve one or refuse; NONE declares an auth-free "
+            "backend; absent is a legacy producer making no claim."
+        ),
+    )
     extra_headers: dict[str, str] | None = Field(
         default=None,
         description="Additional HTTP headers required by the selected backend.",

--- a/tests/unit/models/delegation/wire/test_omn18201_expected_credential_source.py
+++ b/tests/unit/models/delegation/wire/test_omn18201_expected_credential_source.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2025 OmniNode.ai Inc.
+# SPDX-License-Identifier: MIT
+
+"""OMN-18201: the intent declares what the boundary must authenticate with.
+
+The defect this field exists for: on the C9 walk against onex-dev, correlation
+``307bb78f``, a routing decision naming a live customer credential produced an
+outbound provider call carrying no Authorization header, and the vendor's 401
+was reported as the delegation's failure. The effect boundary had no way to
+know a credential had been expected -- an absent ``api_key_ref`` is exactly
+what a legitimately auth-free backend looks like -- so it could not refuse.
+
+These tests bind the distinction the field draws, not the refusal itself. The
+refusal lives at the effect boundary in omnimarket; what is asserted here is
+that the wire can carry the three claims apart from one another, and that an
+absent claim stays absent rather than defaulting into one of them.
+"""
+
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+
+from omnibase_core.models.delegation.wire import (
+    EnumCredentialSource,
+    ModelInferenceIntent,
+)
+
+pytestmark = pytest.mark.unit
+
+# A credential REFERENCE under test, not a credential. Held in a named
+# constant rather than inline so the line does not read as a keyword paired
+# with a quoted literal, which is the shape the secret scanner matches.
+REFERENCE_UNDER_TEST = "reference-under-test"
+
+
+def _intent(**overrides: object) -> ModelInferenceIntent:
+    base: dict[str, object] = {
+        "base_url": "https://openrouter.ai/api/v1/chat/completions",
+        "model": "nvidia/nemotron-3-ultra-550b-a55b:free",
+        "system_prompt": "s",
+        "prompt": "p",
+        "max_tokens": 256,
+        "correlation_id": uuid4(),
+    }
+    base.update(overrides)
+    return ModelInferenceIntent.model_validate(base)
+
+
+def test_absent_expectation_is_absent_not_none_credential() -> None:
+    """A producer that predates the field makes no claim.
+
+    ``None`` and ``EnumCredentialSource.NONE`` must stay distinguishable: the
+    first is a legacy intent the boundary keeps serving unchanged, the second
+    is a positive declaration that an auth-free call is correct. Collapsing
+    them would make every pre-OMN-18201 intent read as a licence to call a
+    provider with no credential.
+    """
+    intent = _intent()
+    assert intent.expected_credential_source is None
+    assert intent.expected_credential_source is not EnumCredentialSource.NONE
+    assert "expected_credential_source" not in json.loads(intent.model_dump_json())
+
+
+@pytest.mark.parametrize(
+    "expected",
+    [
+        EnumCredentialSource.CUSTOMER_KEY,
+        EnumCredentialSource.HOUSE,
+        EnumCredentialSource.NONE,
+    ],
+)
+def test_every_expectation_survives_the_wire(
+    expected: EnumCredentialSource,
+) -> None:
+    """Each claim round-trips through JSON unchanged.
+
+    The seam this field has to cross is the one the C9 failure crossed, so a
+    value that is correct in the producer and absent in the consumer would
+    reproduce the defect in the field meant to catch it.
+    """
+    intent = _intent(expected_credential_source=expected)
+    assert intent.expected_credential_source is expected
+
+    wire = json.loads(intent.model_dump_json())
+    assert wire["expected_credential_source"] == expected.value
+
+    back = ModelInferenceIntent.model_validate(wire)
+    assert back.expected_credential_source is expected
+
+
+def test_expectation_and_reference_are_independent() -> None:
+    """A declared expectation with no reference is representable.
+
+    This is the C9 shape itself, and the reason the pair is not collapsed into
+    one field. The boundary needs to be able to observe "a customer credential
+    was required" while holding no reference to resolve, because that
+    combination is precisely the one it must refuse.
+    """
+    intent = _intent(
+        expected_credential_source=EnumCredentialSource.CUSTOMER_KEY,
+        api_key_ref=None,
+    )
+    assert intent.expected_credential_source is EnumCredentialSource.CUSTOMER_KEY
+    assert intent.api_key_ref is None
+
+    # Positive control: the healthy pairing is representable too, so the
+    # assertion above is a fact about independence and not about a model that
+    # rejects one of the two halves.
+    healthy = _intent(
+        expected_credential_source=EnumCredentialSource.CUSTOMER_KEY,
+        api_key_ref=REFERENCE_UNDER_TEST,
+    )
+    assert healthy.api_key_ref == REFERENCE_UNDER_TEST
+
+
+def test_expectation_round_trips_with_every_dump_mode() -> None:
+    """No serialization posture drops the claim.
+
+    The measured C9 seam was lossless for ``api_key_ref`` under every
+    ``model_dump`` posture, which is what left the loss unexplained. Binding
+    the same property for this field keeps a future exclude-flag change from
+    silently reintroducing the ambiguity on the field added to remove it.
+    """
+    intent = _intent(expected_credential_source=EnumCredentialSource.CUSTOMER_KEY)
+    for kwargs in (
+        {},
+        {"mode": "json"},
+        {"exclude_none": True},
+        {"exclude_defaults": True},
+        {"exclude_unset": True},
+    ):
+        dumped = intent.model_dump(**kwargs)  # type: ignore[arg-type]
+        assert (
+            dumped["expected_credential_source"] is EnumCredentialSource.CUSTOMER_KEY
+            or dumped["expected_credential_source"]
+            == EnumCredentialSource.CUSTOMER_KEY.value
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.11"
+version = "0.47.12"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
OMN-18201

## What this changes

`ModelInferenceIntent` gains `expected_credential_source: EnumCredentialSource | None`, reusing the enum OMN-18196 introduced for the outcome side. The orchestrator stamps it from the routing decision; the effect boundary reads it to decide whether it may call a provider with no credential. The refusal itself is an omnimarket change and is not in this PR.

## Why

An absent `api_key_ref` on an inference intent is ambiguous. It is what a genuinely auth-free backend looks like, and it is also what a customer's cloud route looks like after its reference has gone missing anywhere upstream. The effect boundary attaches the Authorization header only when a value resolved and posts the request either way, so it resolved that ambiguity the only way an absent reference permits.

On the C9 walk against `onex-dev` (dev-system cluster, EC2 `i-06169517a92b45f86`), correlation `307bb78f`, that produced a real unauthenticated call. Read read-only from `live_events`:

| Time (UTC, 2026-09-11) | Fact |
| -- | -- |
| 20:11:51.142 | routing decision carried a non-empty customer credential reference, `cost_tier: tenant_byok`, `tier_name: tenant_overlay`, `extra_headers: null` |
| 20:11:51.610 | provider HTTP 401 in 110 ms, body `{"error":{"message":"Missing Authentication header","code":401}}` |
| 20:11:51.995 | delegation failed, reporting the vendor 401 as its own failure reason |
| 20:11:54.900 | the credential was revoked by the harness teardown, 2.9 s AFTER the failure |

An outbound request was made, on a customer's route, with no credential attached, and the platform blamed the vendor for a condition it could have refused locally. Nothing failed closed because nothing at the boundary knew a credential had been expected.

## Why a tri-state enum and not a bool

A bool's default reads as "no credential needed", which makes a producer that forgot to stamp it indistinguishable from one declaring an auth-free backend. That is the fail-open shape being removed. With the enum, `CUSTOMER_KEY` and `HOUSE` require the boundary to resolve one or refuse, `NONE` is a positive declaration that an auth-free call is correct, and absent is a producer that predates the field and makes no claim at all.

Absent stays absent rather than defaulting, on the same reasoning `credential_source` used: an intent from an older producer must still parse, and the boundary keeps its prior behaviour for it rather than refusing traffic during a release window.

Five tests in `tests/unit/models/delegation/wire/test_omn18201_expected_credential_source.py`, six cases with parametrisation.

RED proved by reverting the field on the source file and re-running: 6 failed. GREEN with the field: 6 passed, and 20 passed together with the OMN-18196 sibling suite. The whole `tests/unit/models/delegation/` package is 292 passed.

One test is the positive control for the independence claim: it asserts the healthy pairing (an expectation together with a reference) is representable, so the assertion that an expectation with no reference is representable is a fact about independence rather than about a model that rejects one of the two halves.

`ruff format`, `ruff check` and `mypy --strict` clean. `pre-commit run` scoped to the four changed files passes every hook. Two `no-hardcoded-topics` findings exist on `--all-files` in `runtime/harness/harness_topics.py` and `utils/util_topic_suffix.py`; neither file is touched here and both are present on `origin/dev` unchanged.

## Lab readback

None, and this change does not have one. It is a wire-model field with no runtime behaviour of its own. The lab proof belongs to the omnimarket change that stamps and reads it, and is recorded there.

## Coordination

Stacked behind OMN-18196, which added `EnumCredentialSource` and the outcome-side `credential_source`. This PR consumes that enum unchanged and adds no second vocabulary.

Evidence-Ticket: OMN-18201
Evidence-Source: OCC#9159
