### PR TITLE
fix(OMN-18219): allow larger dod evidence ledgers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnibase_core"
-version = "0.47.12"
+version = "0.47.13"
 description = "ONEX Core Framework - Base classes and essential implementations"
 authors = [
     {name = "OmniNode.ai", email = "contact@omninode.ai"}

--- a/src/omnibase_core/models/ticket/model_ticket_contract.py
+++ b/src/omnibase_core/models/ticket/model_ticket_contract.py
@@ -80,6 +80,7 @@ _SEMVER_PATTERN: re.Pattern[str] = re.compile(
 # Security constraints (matching OCC values to prevent DoS)
 _MAX_STRING_LENGTH = 10000
 _MAX_LIST_ITEMS = 1000
+_MAX_DOD_EVIDENCE_ITEMS = 10000
 
 
 @allow_string_id(reason="External Linear ticket identifier (e.g., OMN-1807)")
@@ -182,7 +183,7 @@ class ModelTicketContract(BaseModel):
             "Definition of Done evidence items. Maps Linear DoD bullets "
             "to executable checks for automated verification."
         ),
-        max_length=_MAX_LIST_ITEMS,
+        max_length=_MAX_DOD_EVIDENCE_ITEMS,
     )
 
     # Contract completeness level (drives tooling decisions)

--- a/tests/unit/models/ticket/test_model_ticket_contract.py
+++ b/tests/unit/models/ticket/test_model_ticket_contract.py
@@ -45,7 +45,10 @@ from omnibase_core.models.ticket import (
     VerificationKind,
     VerificationStep,
 )
-from omnibase_core.models.ticket.model_ticket_contract import _MAX_LIST_ITEMS
+from omnibase_core.models.ticket.model_ticket_contract import (
+    _MAX_DOD_EVIDENCE_ITEMS,
+    _MAX_LIST_ITEMS,
+)
 
 # =============================================================================
 # Fixtures
@@ -1298,7 +1301,6 @@ class TestListLengthCaps:
         capped_siblings = (
             "interfaces_touched",
             "evidence_requirements",
-            "dod_evidence",
             "requirements",
             "questions",
             "verification_steps",
@@ -1318,6 +1320,16 @@ class TestListLengthCaps:
             for name in capped_siblings
         }
         assert all(v == _MAX_LIST_ITEMS for v in max_lengths.values()), max_lengths
+
+        dod_evidence_max_length = next(
+            (
+                m.max_length
+                for m in contract_fields["dod_evidence"].metadata
+                if hasattr(m, "max_length")
+            ),
+            None,
+        )
+        assert dod_evidence_max_length == _MAX_DOD_EVIDENCE_ITEMS
 
 
 # =============================================================================

--- a/tests/unit/models/ticket/test_model_ticket_contract_merged.py
+++ b/tests/unit/models/ticket/test_model_ticket_contract_merged.py
@@ -327,6 +327,35 @@ def test_yaml_round_trip_preserves_merged_fields() -> None:
     assert restored.title == "Round-trip test"
 
 
+@pytest.mark.unit
+def test_dod_evidence_ledger_accepts_live_occ_observation_volume() -> None:
+    """The OCC observation ledger can exceed the generic operational list cap."""
+
+    evidence_items = [
+        {
+            "id": f"occ-observation-run{i}-1",
+            "description": f"OCC observation append {i}",
+            "source": "generated",
+            "checks": [
+                {
+                    "check_type": "command",
+                    "check_value": f"gh api repos/OmniNode-ai/onex_change_control/commits/{i:040x} --jq .sha",
+                }
+            ],
+        }
+        for i in range(1003)
+    ]
+
+    contract = ModelTicketContract(
+        ticket_id="OMN-14888",
+        title="OCC observation evidence ledger",
+        dod_evidence=evidence_items,
+    )
+
+    assert len(contract.dod_evidence) == 1003
+    assert contract.dod_evidence[-1].id == "occ-observation-run1002-1"
+
+
 # ============================================================================
 # T6 — On-disk YAML sample (OMN-6238.yaml fields) loads without error
 # ============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "omnibase-core"
-version = "0.47.12"
+version = "0.47.13"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

- raise only ModelTicketContract.dod_evidence capacity from 1000 to 10000 entries
- keep the generic operational list cap at 1000 for other ticket-contract fields
- bump omnibase_core to 0.47.13 so release identity does not alias new code onto the published 0.47.12 wheel

## Verification

- uv run ruff format --check src/omnibase_core/models/ticket/model_ticket_contract.py tests/unit/models/ticket/test_model_ticket_contract_merged.py
- uv run ruff check src/omnibase_core/models/ticket/model_ticket_contract.py tests/unit/models/ticket/test_model_ticket_contract_merged.py
- uv run pytest tests/unit/models/ticket/test_model_ticket_contract_merged.py -v
- git commit hooks: passed
- git push hooks: passed

## Merge-sweep context

OCC observation PR onex_change_control#9221 is failing Validate Contract YAML because contracts/OMN-14888.yaml has reached the existing 1000-entry dod_evidence cap and the live generated observation append needs 1003 real entries. This fixes the shared typed model instead of dropping or fabricating receipt data.

Linear: OMN-18219
Blocks: onex_change_control#9221

Evidence-Ticket: OMN-18219
Evidence-Source: OCC#9237
